### PR TITLE
YTI-1675 Force update codes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/endpoint/codes/Codes.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/endpoint/codes/Codes.java
@@ -53,10 +53,12 @@ public class Codes {
     })
     public Response getCodes(
         @Parameter(description = "uri", required = true)
-        @QueryParam("uri") String uri) {
+        @QueryParam("uri") String uri,
+        @Parameter(description = "forced update")
+        @QueryParam("force") boolean force) {
         if (uri.startsWith("http://uri.suomi.fi")) {
             SuomiCodeServer codeServer = new SuomiCodeServer("https://koodistot.suomi.fi", applicationProperties.getDefaultSuomiCodeServerAPI(), endpointServices, codeSchemeManager);
-            codeServer.updateCodes(uri);
+            codeServer.updateCodes(uri, force);
         } else if (uri.startsWith("https://virkailija.opintopolku.fi")) {
             OPHCodeServer codeServer = new OPHCodeServer("https://virkailija.opintopolku.fi/koodisto-service/rest/json/", endpointServices);
             if (!codeServer.containsCodeList(uri)) {

--- a/src/main/java/fi/vm/yti/datamodel/api/model/SuomiCodeServer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/model/SuomiCodeServer.java
@@ -269,7 +269,7 @@ public class SuomiCodeServer {
         }
     }
 
-    public void updateCodes(String containerUri) {
+    public void updateCodes(String containerUri, boolean force) {
 
         LocalDateTime codeSchemeModified = null;
         Model model = null;
@@ -301,8 +301,8 @@ public class SuomiCodeServer {
                     model = createModelFromCodeList(containerUri, schemeModifiedString);
                 } else {
                     Date lastModifiedDateTime = codeSchemeManager.lastModified(containerUri);
-                    if (lastModifiedDateTime == null) {
-                        logger.info("No modified found. Updating scheme: " + containerUri);
+                    if (lastModifiedDateTime == null || force) {
+                        logger.info("No modified found or forced update. Updating scheme: " + containerUri);
                         model = createModelFromCodeList(containerUri, schemeModifiedString);
                     } else {
                         LocalDateTime lastModifiedLocalDateTime = lastModifiedDateTime.toInstant()


### PR DESCRIPTION
Sometimes there are problems displaying codes in datamodel application if the indexing of codes has failed. If force parameter is provided, the timestamp check is ignored.