### PR TITLE
YTI-2114: catch 404s and return null instead of throwing error

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/endpoint/model/Models.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/endpoint/model/Models.java
@@ -155,8 +155,10 @@ public class Models {
             String graphService = endpointServices.getCoreReadWriteAddress();
 
             /* TODO: Create Namespace service? */
-            RDFConnection connection = RDFConnection.connect(graphService);
-            Model model = connection.fetch(id);
+            Model model;
+            try(RDFConnection connection = RDFConnection.connect(graphService)){
+                model = connection.fetch(id);
+            }
 
             if (model == null) {
                 return jerseyResponseManager.notFound();

--- a/src/main/java/fi/vm/yti/datamodel/api/service/ImportManager.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/service/ImportManager.java
@@ -272,8 +272,9 @@ public class ImportManager {
 
             Model results = qexec.execConstruct();
 
-            RDFConnection connection = RDFConnection.connect(endpointServices.getCoreReadWriteAddress());
-            connection.load(resource, results);
+            try(RDFConnection connection = RDFConnection.connect(endpointServices.getCoreReadWriteAddress())){
+                connection.load(resource, results);
+            }
         }
 
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/service/TerminologyManager.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/service/TerminologyManager.java
@@ -139,13 +139,15 @@ public final class TerminologyManager {
                                                          String modelUri,
                                                          Query query) {
 
-        logger.info("Constructing resource with concept: " + conceptUri);
-        RDFConnection connection = RDFConnection.connect(endpointServices.getCoreReadAddress());
+        logger.info("Constructing resource with concept: {}", conceptUri);
+
 
         Model conceptModel = searchConceptFromTerminologyIntegrationAPIAsModel(null, null, conceptUri);
 
         assert conceptModel != null;
-        conceptModel.add(connection.fetch(modelUri));
+        try(RDFConnection connection = RDFConnection.connect(endpointServices.getCoreReadAddress())){
+            conceptModel.add(connection.fetch(modelUri));
+        }
 
         try (QueryExecution qexec = QueryExecutionFactory.create(query, conceptModel)) {
             return qexec.execConstruct();


### PR DESCRIPTION
Changelog:
- Catch HTTP 404 exception and return null if it happens
  - Why does it return 404 instead of null in the newer version anyways? Its hard to figure things out due to Jena having very little documentation
- Use try with resources for most connections to try and reduce more errors from happening
- Cleaned some logger commands as well