### PR TITLE
YTI-2271: support for language filtering in elasticsearch

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/index/ModelQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/index/ModelQueryFactory.java
@@ -50,16 +50,17 @@ public class ModelQueryFactory {
     }
 
     public SearchRequest createQuery(ModelSearchRequest request) {
-        return createQuery(request.getUri(),request.getQuery(), request.getStatus(), request.getType(), request.getAfter(), request.getBefore(), Collections.EMPTY_SET, request.getPageSize(), request.getPageFrom(), request.getFilter(), request.getIncludeIncomplete(), request.getIncludeIncompleteFrom());
+        return createQuery(request.getUri(),request.getQuery(), request.getLanguage(), request.getStatus(), request.getType(), request.getAfter(), request.getBefore(), Collections.emptySet(), request.getPageSize(), request.getPageFrom(), request.getFilter(), request.getIncludeIncomplete(), request.getIncludeIncompleteFrom());
     }
 
     public SearchRequest createQuery(ModelSearchRequest request,
                                      Collection<String> additionalModelIds) {
-        return createQuery(request.getUri(), request.getQuery(), request.getStatus(), request.getType(), request.getAfter(), request.getBefore(), additionalModelIds, request.getPageSize(), request.getPageFrom(), request.getFilter(), request.getIncludeIncomplete(), request.getIncludeIncompleteFrom());
+        return createQuery(request.getUri(), request.getQuery(), request.getLanguage(), request.getStatus(), request.getType(), request.getAfter(), request.getBefore(), additionalModelIds, request.getPageSize(), request.getPageFrom(), request.getFilter(), request.getIncludeIncomplete(), request.getIncludeIncompleteFrom());
     }
 
     private SearchRequest createQuery(Set<String> uris,
                                       String query,
+                                      String language,
                                       Set<String> status,
                                       String type,
                                       Date after,
@@ -97,6 +98,11 @@ public class ModelQueryFactory {
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
         List<QueryBuilder> mustList = boolQuery.must();
+
+        if (language != null ) {
+            mustList.add(QueryBuilders.termsQuery(
+                    "language", language));
+        }
 
         if(uris!=null) {
             QueryBuilder uriQuery = QueryBuilders.boolQuery()
@@ -151,7 +157,7 @@ public class ModelQueryFactory {
             mustList.add(contentQuery);
         }
 
-        if (mustList.size() > 0) {
+        if (!mustList.isEmpty()) {
             sourceBuilder.query(boolQuery);
         } else {
             sourceBuilder.query(QueryBuilders.matchAllQuery());
@@ -173,7 +179,7 @@ public class ModelQueryFactory {
         SearchRequest sr = new SearchRequest("dm_models")
             .source(sourceBuilder);
 
-        logger.debug(sr.source().toString());
+        logger.debug("Model Query request: {}", sr.source());
 
         return sr;
 

--- a/src/main/java/fi/vm/yti/datamodel/api/index/model/ModelSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/index/model/ModelSearchRequest.java
@@ -9,6 +9,8 @@ public class ModelSearchRequest {
 
     private String query;
 
+    private String language;
+
     private boolean searchResources;
 
     private Date after;
@@ -50,6 +52,7 @@ public class ModelSearchRequest {
     }
 
     public ModelSearchRequest(final String query,
+                              final String language,
                               final boolean searchResources,
                               final Set<String> status,
                               final String type,
@@ -61,6 +64,7 @@ public class ModelSearchRequest {
                               final Boolean includeIncomplete,
                               final Set<String> includeIncompleteFrom) {
         this.query = query;
+        this.language = language;
         this.searchResources = searchResources;
         this.status = status;
         this.type = type;
@@ -74,6 +78,7 @@ public class ModelSearchRequest {
     }
 
     public ModelSearchRequest(final String query,
+                              final String language,
                               final boolean searchResources,
                               final Set<String> status,
                               final String type,
@@ -82,6 +87,7 @@ public class ModelSearchRequest {
                               final Integer pageFrom,
                               final Set<String> filter) {
         this.query = query;
+        this.language = language;
         this.searchResources = searchResources;
         this.status = status;
         this.type = type;
@@ -105,6 +111,14 @@ public class ModelSearchRequest {
 
     public void setQuery(final String query) {
         this.query = query;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
     }
 
     public boolean isSearchResources() {
@@ -199,6 +213,7 @@ public class ModelSearchRequest {
     public String toString() {
         return "ModelSearchRequest{" +
             "query='" + query + '\'' +
+            ", language=" + language +
             ", searchResources=" + searchResources +
             ", after=" + after +
             ", before=" + before +

--- a/src/test/java/fi/vm/yti/datamodel/api/index/EsUtils.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/index/EsUtils.java
@@ -1,0 +1,68 @@
+package fi.vm.yti.datamodel.api.index;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.search.aggregations.metrics.max.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.max.ParsedMax;
+import org.elasticsearch.search.aggregations.metrics.tophits.ParsedTopHits;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsAggregationBuilder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EsUtils {
+
+    public static String getJsonString(String file) throws Exception {
+        return new String(EsUtils.class
+                .getResourceAsStream(file).readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    public static SearchResponse getMockResponse(String path) throws Exception {
+        return getSearchResponseFromJson(getJsonString(path));
+    }
+
+    // for use with getSearchResponseFromJson
+    private static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
+        Map<String, ContextParser<Object, ? extends Aggregation>> map = new HashMap<>();
+        // Elasticsearch needs a hint to know what type of aggregation to
+        // parse this as. The hint is provided by elastic when
+        // adding ?typed_keys to the query.
+        // e.g. "sterms#group_by_terminology"
+        map.put(TopHitsAggregationBuilder.NAME, (p, c) ->
+                ParsedTopHits.fromXContent(p, (String) c));
+        map.put(StringTerms.NAME, (p, c) ->
+                ParsedStringTerms.fromXContent(p, (String) c));
+        map.put(MaxAggregationBuilder.NAME, (p, c) ->
+                ParsedMax.fromXContent(p, (String) c));
+        return map.entrySet().stream()
+                .map(entry -> new NamedXContentRegistry.Entry(
+                        Aggregation.class,
+                        new ParseField(entry.getKey()),
+                        entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    // helper method for generating elasticsearch SearchResponse from JSON
+    private static SearchResponse getSearchResponseFromJson(String jsonResponse) throws IOException {
+        NamedXContentRegistry registry = new NamedXContentRegistry(
+                getDefaultNamedXContents());
+        XContentParser parser = JsonXContent.jsonXContent.createParser(
+                registry,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                jsonResponse);
+        SearchResponse searchResponse = SearchResponse.fromXContent(parser);
+        return searchResponse;
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/index/ModelQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/index/ModelQueryFactoryTest.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.datamodel.api.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.config.ApplicationProperties;
+import fi.vm.yti.datamodel.api.index.model.ModelSearchRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class ModelQueryFactoryTest {
+
+    ModelQueryFactory factory = new ModelQueryFactory(new ObjectMapper(), new LuceneQueryFactory(new ApplicationProperties()));
+
+
+    @Test
+    public void testModelSearchRequest() throws Exception {
+        var expected = EsUtils.getJsonString("/es/modelrequest.json");
+        var request = new ModelSearchRequest();
+        request.setQuery("test");
+        request.setLanguage("fi");
+        request.setStatus(Set.of("VALID", "DRAFT"));
+
+        SearchRequest searchRequest = factory.createQuery(request, Collections.emptySet());
+        JSONAssert.assertEquals(expected, searchRequest.source().toString(), JSONCompareMode.LENIENT);
+    }
+
+}

--- a/src/test/resources/es/modelrequest.json
+++ b/src/test/resources/es/modelrequest.json
@@ -1,0 +1,47 @@
+{
+  "size": 10000,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "language":  ["fi"]
+          }
+        },
+        {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "status": {
+                    "value": "INCOMPLETE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "query_string": {
+            "query": "test test* *test",
+            "fields": ["label.*^1.0"]
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "terms": {
+                  "status": [
+                    "VALID",
+                    "DRAFT"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Changelog:
- Added language filtering option: "language" parameter
- unit tests for ModelQueryFactory
- Cleaned some code smells

Example API request to `datamodel-api/api/v1/searchModels`
```json
{
	"query": "",
	"searchResources": true,
	"sortLang": "fi",
	"pageSize": 1000,
	"pageFrom": 0,
	"language": "fi" #new parameter
}
```