### PR TITLE
skip deleting position graph before saving

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/endpoint/model/ModelPositions.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/endpoint/model/ModelPositions.java
@@ -120,9 +120,6 @@ public class ModelPositions {
             return jerseyResponseManager.invalidParameter();
         }
 
-        // TODO: Does this fix the strange duplication bug?
-        jenaClient.deleteModelFromCore(model+"#PositionGraph");
-
         jenaClient.putModelToCore(model + "#PositionGraph", newPositions);
 
         return jerseyResponseManager.okEmptyContent();


### PR DESCRIPTION
Deleting position graph before saving produces an error. Skipping this doesn't cause any duplication issues mentioned in the comment