### PR TITLE
YTI-2309: Added counts for data models.

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/CountDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/CountDTO.java
@@ -1,0 +1,66 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.dto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CountDTO {
+
+    private Map<String, Long> statuses;
+    private Map<String, Long> languages;
+
+    private Map<String, Long> groups;
+
+    private Map<String, Long> types;
+
+    public CountDTO() {
+        this.statuses = Collections.emptyMap();
+        this.languages = Collections.emptyMap();
+        this.types = Collections.emptyMap();
+        this.groups = Collections.emptyMap();
+    }
+
+    public CountDTO(
+            final Map<String, Long> statuses,
+            final Map<String, Long> languages,
+            final Map<String, Long> types,
+            final Map<String, Long> groups) {
+        this.statuses = statuses;
+        this.languages = languages;
+        this.types = types;
+        this.groups = groups;
+    }
+
+
+
+    public Map<String, Long> getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(Map<String, Long> statuses) {
+        this.statuses = statuses;
+    }
+
+    public Map<String, Long> getLanguages() {
+        return languages;
+    }
+
+    public void setLanguages(Map<String, Long> languages) {
+        this.languages = languages;
+    }
+
+    public Map<String, Long> getTypes() {
+        return types;
+    }
+
+    public void setTypes(Map<String, Long> types){
+        this.types = types;
+    }
+
+    public Map<String, Long> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Map<String, Long> groups) {
+        this.groups = groups;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/CountSearchResponse.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/CountSearchResponse.java
@@ -1,0 +1,29 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.dto;
+
+public class CountSearchResponse {
+
+    private long totalHitCount;
+    private CountDTO counts;
+
+    public CountSearchResponse() {
+        this.totalHitCount = 0;
+        this.counts = new CountDTO();
+    }
+
+    public long getTotalHitCount() {
+        return totalHitCount;
+    }
+
+    public void setTotalHitCount(long totalHitCount) {
+        this.totalHitCount = totalHitCount;
+    }
+
+    public CountDTO getCounts() {
+        return counts;
+    }
+
+    public void setCounts(CountDTO counts) {
+        this.counts = counts;
+    }
+}
+

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/queries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/queries/CountQueryFactory.java
@@ -1,0 +1,164 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.queries;
+
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountDTO;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Singleton
+@Service
+public class CountQueryFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(CountQueryFactory.class);
+
+    public SearchRequest createModelQuery() {
+        QueryBuilder withIncompleteHandling = QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("status", "INCOMPLETE"));
+
+        SearchRequest sr = new SearchRequest("dm_models")
+                .source(new SearchSourceBuilder()
+                        .size(0)
+                        .query(withIncompleteHandling)
+                        .aggregation(createStatusAggregation())
+                        .aggregation(createTypeAggregation())
+                        .aggregation(createLanguageAggregation())
+                        .aggregation(createInformationDomainAggregation())
+                        );
+
+        log.debug("Count request: {}", sr);
+        return sr;
+    }
+
+    private TermsAggregationBuilder createStatusAggregation() {
+        var scriptSource = "doc.containsKey('status') ? doc.status : params._source.properties.status[0].value";
+        Map<String, Object> params = new HashMap<>(16);
+        var script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                Script.DEFAULT_SCRIPT_LANG,
+                scriptSource,
+                params);
+
+        return AggregationBuilders
+                .terms("statusagg")
+                .size(300)
+                .script(script);
+    }
+
+
+    private TermsAggregationBuilder createTypeAggregation() {
+        var scriptSource = "doc.containsKey('type') ? doc.type : params._source.properties.type[0].value";
+        Map<String, Object> params = new HashMap<>(16);
+        var script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                Script.DEFAULT_SCRIPT_LANG,
+                scriptSource,
+                params);
+
+        return AggregationBuilders
+                .terms("typeagg")
+                .size(300)
+                .script(script);
+    }
+
+    private TermsAggregationBuilder createLanguageAggregation() {
+        String scriptSource = "params._source.language" +
+                ".stream()" +
+                ".collect(Collectors.toList())";
+
+        var script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                Script.DEFAULT_SCRIPT_LANG,
+                scriptSource,
+                new HashMap<>(16));
+
+        return AggregationBuilders
+                .terms("langagg")
+                .order(BucketOrder.count(false))
+                .size(300)
+                .script(script);
+    }
+
+    private TermsAggregationBuilder createInformationDomainAggregation() {
+        var scriptSource = "params._source.isPartOf";
+
+        Map<String, Object> params = new HashMap<>(16);
+        var script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                Script.DEFAULT_SCRIPT_LANG,
+                scriptSource,
+                params);
+
+        return AggregationBuilders
+                .terms("infodomainagg")
+                .size(300)
+                .script(script);
+    }
+
+    public CountSearchResponse parseResponse(SearchResponse response) {
+        var ret = new CountSearchResponse();
+        ret.setTotalHitCount(response.getHits().getTotalHits());
+
+
+        Terms statusAgg = response.getAggregations().get("statusagg");
+        var statuses = statusAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        Terms typeAgg = response.getAggregations().get("typeagg");
+        var types = typeAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        Terms infodomainAgg = response.getAggregations().get("infodomainagg");
+        var infoDomains = infodomainAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        Map<String, Long> languages = new HashMap<>();
+        Terms langagg = response.getAggregations().get("langagg");
+        if (langagg != null) {
+            languages = langagg
+                    .getBuckets()
+                    .stream()
+                    .collect(
+                            LinkedHashMap::new,
+                            (map, item) -> map.put(
+                                    item.getKeyAsString(),
+                                    item.getDocCount()
+                            ),
+                            Map::putAll
+                    );
+        }
+
+        ret.setCounts(new CountDTO(statuses, languages, types, infoDomains));
+
+        return ret;
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -1,0 +1,51 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.index.SearchIndexManager;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
+import fi.vm.yti.datamodel.api.service.JerseyResponseManager;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Component
+@Path("v2/frontend")
+@Tag(name = "Frontend")
+public class FrontendController {
+
+    private static final Logger logger = LoggerFactory.getLogger(FrontendController.class);
+    private final SearchIndexManager searchIndexManager;
+    private final JerseyResponseManager jerseyResponseManager;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public FrontendController(SearchIndexManager searchIndexManager,
+                       JerseyResponseManager jerseyResponseManager,
+                       ObjectMapper objectMapper) {
+        this.searchIndexManager = searchIndexManager;
+        this.jerseyResponseManager = jerseyResponseManager;
+        this.objectMapper = objectMapper;
+    }
+
+
+    @GET
+    @Operation(summary = "Get counts", description = "List counts of data model grouped by different search results")
+    @Path("/counts")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Counts response container object as JSON")
+    public Response getCounts() {
+        logger.info("GET /counts requested");
+        CountSearchResponse response = searchIndexManager.getCounts();
+        return jerseyResponseManager.ok(objectMapper.valueToTree(response));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/elasticsearch/CountQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/elasticsearch/CountQueryFactoryTest.java
@@ -1,0 +1,49 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch;
+
+import fi.vm.yti.datamodel.api.index.EsUtils;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.queries.CountQueryFactory;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CountQueryFactoryTest {
+
+    CountQueryFactory factory = new CountQueryFactory();
+
+    @Test
+    void testModelCounts() throws Exception {
+        String expected = EsUtils.getJsonString("/es/models_count_request.json");
+
+        SearchRequest request = factory.createModelQuery();
+
+        JSONAssert.assertEquals(expected, request.source().toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    void testParseModelCountResponse() throws Exception {
+        SearchResponse response = EsUtils.getMockResponse("/es/models_count_response.json");
+
+        CountSearchResponse countSearchResponse = factory.parseResponse(response);
+
+        assertEquals(8, countSearchResponse.getTotalHitCount());
+        Map<String, Long> groups = countSearchResponse.getCounts().getGroups();
+        Map<String, Long> statuses = countSearchResponse.getCounts().getStatuses();
+
+        assertEquals(3, groups.keySet().size());
+        assertEquals(2L, groups.get("P13"));
+        assertEquals(1L, groups.get("P11"));
+        assertEquals(1L, groups.get("P21"));
+
+        assertEquals(2, statuses.keySet().size());
+        assertEquals(7, statuses.get("DRAFT"));
+        assertEquals(1, statuses.get("VALID"));
+    }
+}

--- a/src/test/resources/es/models_count_request.json
+++ b/src/test/resources/es/models_count_request.json
@@ -1,0 +1,50 @@
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "term": {
+            "status": {
+              "value": "INCOMPLETE"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "aggregations": {
+    "sterms#statusagg": {
+      "terms": {
+        "script": {
+          "source": "doc.containsKey('status') ? doc.status : params._source.properties.status[0].value",
+          "lang": "painless"
+        }
+      }
+    },
+    "infodomainagg": {
+      "terms": {
+        "script": {
+          "source": "params._source.isPartOf",
+          "lang": "painless"
+        }
+      }
+    },
+    "typeagg": {
+      "terms": {
+        "script": {
+          "source": "doc.containsKey('type') ? doc.type : params._source.properties.type[0].value",
+          "lang": "painless"
+        }
+      }
+    },
+    "langagg": {
+      "terms": {
+        "script": {
+          "source": "params._source.language.stream().collect(Collectors.toList())",
+          "lang": "painless"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/es/models_count_response.json
+++ b/src/test/resources/es/models_count_response.json
@@ -1,0 +1,57 @@
+{
+  "took": 103,
+  "timed_out": false,
+  "_shards": { "total": 10, "successful": 10, "skipped": 0, "failed": 0 },
+  "hits": { "total": 8, "max_score": 0.0, "hits": [] },
+  "aggregations": {
+    "sterms#statusagg": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        { "key": "DRAFT", "doc_count": 7 },
+        { "key": "VALID", "doc_count": 1 }
+      ]
+    },
+    "sterms#typeagg": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "library",
+          "doc_count": 3
+        },
+        {
+          "key": "profile",
+          "doc_count": 1
+        }
+      ]
+    },
+    "sterms#infodomainagg": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "P13",
+          "doc_count": 2
+        },
+        {
+          "key": "P11",
+          "doc_count": 1
+        },
+        {
+          "key": "P21",
+          "doc_count": 1
+        }
+      ]
+    },
+    "sterms#langagg": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        { "key": "fi", "doc_count": 13 },
+        { "key": "sv", "doc_count": 10 },
+        { "key": "en", "doc_count": 8 }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Changelog:
- Added endpoint for counts in `v2/frontend/counts`
  - Slight note on the group count is that elastic search in terminology-api could return more information, but the datamodel-api elastic search only returns the identifier
- unit tests
- cleaned SearchIndexManager a bit

Example:
`http://localhost:9004/datamodel-api/api/v2/frontend/counts`

```json
{
 "totalHitCount": 4,
  "counts": {
   "statuses": {
	"DRAFT": 4
   },
   "languages": {
	"en": 3,
	"fi": 3,
	"sv": 2
  },
   "groups": {
	"P11": 1,
	"P13": 2,
	"P21": 1
  },
   "types": {
	"library": 3,
	"profile": 1
  }
 }
}
```
