### PR TITLE
YTI-2361: datamodel update endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id "org.springframework.boot" version "2.5.12"
     id "org.sonarqube" version "3.3"
     id "jacoco"
-    id "org.owasp.dependencycheck" version "6.1.6"
+    id "org.owasp.dependencycheck" version "7.4.4"
     id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
     id "com.gorylenko.gradle-git-properties" version "2.3.1"
     id "com.github.ben-manes.versions" version "0.39.0"

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -7,4 +7,5 @@ public class ModelConstants {
     }
 
     public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
+    public static final String URN_UUID = "urn:uuid:";
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -58,6 +58,23 @@ public class Datamodel {
         elasticIndexer.createModelToIndex(indexModel);
     }
 
+    @Operation(summary = "Create a new model")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
+    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @PostMapping(path = "/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public void updateModel(@ValidDatamodel(updateModel = true) @RequestBody DataModelDTO modelDTO,
+                            @PathVariable String prefix) {
+        logger.info("Updating model {}", modelDTO);
+        check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
+
+        var jenaModel = mapper.mapToUpdateJenaModel(prefix, modelDTO);
+
+        jenaService.createDataModel(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);
+
+        var indexModel = mapper.mapToIndexModel(prefix, jenaModel);
+        elasticIndexer.updateModelToIndex(indexModel);
+    }
+
     @Operation(summary = "Get a model from fuseki")
     @ApiResponse(responseCode = "200", description = "Datamodel object for the found model")
     @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidDatamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidDatamodel.java
@@ -22,5 +22,6 @@ public @interface ValidDatamodel {
 
     Class<?>[] groups() default {};
 
+    boolean updateModel() default false;
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -1,5 +1,5 @@
 server.port=9004
-server.servlet.context-path=/datamodel-api/api
+server.servlet.context-path=/datamodel-api
 
 spring.application.name=yti-datamodel-api
 defaultNamespace=http://uri.suomi.fi/datamodel/ns/


### PR DESCRIPTION
Changelog: 
- changed endpoint back to original as it caused v1 endpoints to not work correctly. 
  - v1 = `datamodel-api/api/v1/<endpoint>`
  - v2 = `datamodel-api/v2/<endpoint>`
- modelMapper for updating model.
  - Same DataModelDTO but validation does not allow prefix and modeltype to be set
- end point for updating model.
- testing