### PR TITLE
YTI-2363: elasticsearch indexing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,6 @@ dependencies {
     implementation 'org.reflections:reflections:0.10.2'
     implementation 'com.google.guava:guava:31.1-jre'
 
-    testImplementation "junit:junit:4.13.2"
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation 'com.jayway.jsonpath:json-path-assert:2.7.0'
     testImplementation 'org.mockito:mockito-core:4.8.0'
@@ -156,6 +155,9 @@ jacocoTestReport {
     reports {
         xml.enabled true
     }
+}
+test {
+    useJUnitPlatform()
 }
 
 dependencyCheck {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
@@ -1,0 +1,17 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class Iow {
+
+    private Iow(){
+        //property class
+    }
+
+    public static final String URI ="http://uri.suomi.fi/datamodel/ns/iow#";
+
+    public static final Property contentModified = ResourceFactory.createProperty(URI, "contentModified");
+    public static final Property documentation = ResourceFactory.createProperty(URI, "documentation");
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -1,5 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
+import java.util.Map;
+
 public class ModelConstants {
 
     private ModelConstants(){
@@ -8,4 +10,14 @@ public class ModelConstants {
 
     public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
     public static final String URN_UUID = "urn:uuid:";
+
+    public static final Map<String, String> PREFIXES = Map.of(
+            "rdfs", "http://www.w3.org/2000/01/rdf-schema#",
+            "rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#", //TODO this can be removed once migration for old rdf lists are done
+            "dcterms", "http://purl.org/dc/terms/",
+            "owl", "http://www.w3.org/2002/07/owl#",
+            "dcap", "http://purl.org/ws-mmi-dc/terms/",
+            "xsd", "http://www.w3.org/2001/XMLSchema#",
+            "iow", "http://uri.suomi.fi/datamodel/ns/iow#"
+    );
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/ElasticIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/ElasticIndexer.java
@@ -1,28 +1,56 @@
 package fi.vm.yti.datamodel.api.v2.elasticsearch.index;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.datamodel.api.index.ElasticConnector;
-import fi.vm.yti.datamodel.api.index.SearchIndexManager;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import org.apache.jena.arq.querybuilder.ConstructBuilder;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Map;
+
 
 @Service
 public class ElasticIndexer {
 
     private final Logger logger = LoggerFactory.getLogger(ElasticIndexer.class);
     private static final String ELASTIC_INDEX_MODEL = "models_v2";
+    private static final String GRAPH_VARIABLE = "?model";
     private final ElasticConnector elasticConnector;
     private final ObjectMapper objectMapper;
+    private final JenaService jenaService;
+    private final ModelMapper modelMapper;
+    private final RestHighLevelClient esClient;
 
 
     public ElasticIndexer(ElasticConnector elasticConnector,
-                          ObjectMapper objectMapper){
+                          ObjectMapper objectMapper,
+                          JenaService jenaService,
+                          ModelMapper modelMapper,
+                          RestHighLevelClient esClient){
         this.elasticConnector = elasticConnector;
         this.objectMapper = objectMapper;
+        this.jenaService = jenaService;
+        this.modelMapper = modelMapper;
+        this.esClient = esClient;
     }
 
     public void reindex() {
@@ -38,8 +66,7 @@ public class ElasticIndexer {
     }
 
     private String getModelMappings() throws IOException {
-        //TODO create model mappings
-        InputStream is = SearchIndexManager.class.getClassLoader().getResourceAsStream("model_mapping.json");
+        InputStream is = ElasticIndexer.class.getClassLoader().getResourceAsStream("model_v2_mapping.json");
         Object obj = objectMapper.readTree(is);
         return objectMapper.writeValueAsString(obj);
     }
@@ -64,14 +91,66 @@ public class ElasticIndexer {
     /**
      * Init search indexes
      */
-    private void initSearchIndexes() {
+    private void initSearchIndexes() throws IOException {
         initModelIndex();
     }
 
     /**
      * Init model index
      */
-    private void initModelIndex(){
-        //TODO get all models from fuseki
+    public void initModelIndex() throws IOException {
+        var constructBuilder = new ConstructBuilder()
+                .addPrefixes(ModelConstants.PREFIXES);
+        addProperty(constructBuilder, RDFS.label, "?prefLabel");
+        addOptional(constructBuilder, RDFS.comment, "?comment");
+        addProperty(constructBuilder, RDF.type, "?modelType");
+        addProperty(constructBuilder, OWL.versionInfo, "?versionInfo");
+        addProperty(constructBuilder, DCTerms.modified, "?modified");
+        addProperty(constructBuilder, DCTerms.created, "?created");
+        addProperty(constructBuilder, DCTerms.contributor, "?contributor");
+        addProperty(constructBuilder, DCTerms.isPartOf, "?isPartOf");
+        addOptional(constructBuilder, Iow.contentModified, "?contentModified");
+        addOptional(constructBuilder, Iow.documentation, "?documentation");
+        //TODO swap to commented text once older migration is ready
+        //addProperty(constructBuilder, DCTerms.language, "?language");
+        constructBuilder.addConstruct(GRAPH_VARIABLE, DCTerms.language, "?language")
+                .addWhere(GRAPH_VARIABLE, "dcterms:language/rdf:rest*/rdf:first", "?language");
+
+        var indexModels = jenaService.constructWithQuery(constructBuilder.build());
+        var it = indexModels.listSubjects();
+        var list = new ArrayList<IndexModel>();
+        while(it.hasNext()){
+            var resource = it.next();
+            var newModel = ModelFactory.createDefaultModel()
+                    .add(resource.listProperties());
+            var indexModel = modelMapper.mapToIndexModel(resource.getLocalName(), newModel);
+            list.add(indexModel);
+        }
+        var values = objectMapper.valueToTree(list);
+        bulkInsert(ELASTIC_INDEX_MODEL, values);
+    }
+
+    private void addProperty(ConstructBuilder builder, Property property, String propertyName){
+        builder.addConstruct(GRAPH_VARIABLE, property, propertyName)
+                .addWhere(GRAPH_VARIABLE, property, propertyName);
+    }
+
+    private void addOptional(ConstructBuilder builder, Property property, String propertyName){
+        builder.addConstruct(GRAPH_VARIABLE, property, propertyName)
+                .addOptional(GRAPH_VARIABLE, property, propertyName);
+    }
+
+    public void bulkInsert(String indexName, JsonNode indexModels) throws IOException {
+        var bulkrequest = new BulkRequest();
+        indexModels.forEach(indexModel -> {
+            var req = new IndexRequest(indexName, "doc", indexModel.get("id").asText())
+                    .source(objectMapper.convertValue(indexModel, Map.class));
+            bulkrequest.add(req);
+        });
+        if(bulkrequest.numberOfActions() > 0){
+            var res = esClient.bulk(bulkrequest, RequestOptions.DEFAULT);
+            logger.debug("Bulk insert status: {}", res.status().getStatus());
+        }
+
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/IndexModel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/IndexModel.java
@@ -9,7 +9,6 @@ public class IndexModel {
 
     private String id;
     private String status;
-    private String statusModified;
     private String modified;
     private String created;
     private String contentModified;
@@ -41,14 +40,6 @@ public class IndexModel {
 
     public void setStatus(String status) {
         this.status = status;
-    }
-
-    public String getStatusModified() {
-        return statusModified;
-    }
-
-    public void setStatusModified(String statusModified) {
-        this.statusModified = statusModified;
     }
 
     public String getModified() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
@@ -1,0 +1,37 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.index.ElasticIndexer;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static fi.vm.yti.security.AuthorizationException.check;
+
+@RestController
+@RequestMapping("v2/index")
+@Tag(name = "Index" )
+public class IndexController {
+
+
+    private final ElasticIndexer indexer;
+    private final AuthorizationManager authorizationManager;
+
+    public IndexController(ElasticIndexer indexer,
+                           AuthorizationManager authorizationManager) {
+        this.indexer = indexer;
+        this.authorizationManager = authorizationManager;
+    }
+
+
+
+    @Operation(summary = "Reindex all datamodels")
+    @GetMapping(value = "/reindex")
+    public void reIndex() {
+        check(authorizationManager.hasRightToDropDatabase());
+
+        indexer.reindex();
+    }
+}

--- a/src/main/resources/model_v2_mapping.json
+++ b/src/main/resources/model_v2_mapping.json
@@ -1,0 +1,61 @@
+{
+  "mappings": {
+    "doc": {
+      "dynamic_templates": [
+        {
+          "label": {
+            "path_match": "label.*",
+            "mapping": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "comment": {
+            "path_match": "comment.*",
+            "mapping": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "documentation": {
+            "path_match": "documentation.*",
+            "mapping": {
+              "type": "text"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "status": {
+          "type": "keyword"
+        },
+        "contentModified": {
+          "type": "date"
+        },
+        "created": {
+          "type": "date"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "prefix": {
+          "type": "keyword"
+        },
+        "contributor": {
+          "type": "keyword"
+        },
+        "language": {
+          "type": "keyword"
+        },
+        "isPartOf": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/index/ModelQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/index/ModelQueryFactoryTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.datamodel.api.config.ApplicationProperties;
 import fi.vm.yti.datamodel.api.index.model.ModelSearchRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 

--- a/src/test/java/fi/vm/yti/datamodel/api/integration/FusekiTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/integration/FusekiTest.java
@@ -14,18 +14,16 @@ import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.*;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.InputStream;
 import java.util.UUID;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class FusekiTest {
+//FIXME: You can run these locally if you want to, but these cannot be run in jenkins
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@Disabled
+class FusekiTest {
 
     public static final String GRAPH_NAME = "http://uri.suomi.fi/datamodel-v2/ns/test";
 
@@ -36,14 +34,14 @@ public class FusekiTest {
     static final RDFConnection connectionRead = RDFConnection.connect(FUSEKI_URL + "/core/get");
     static final RDFConnection connectionSparql = RDFConnection.connect(FUSEKI_URL + "/core/sparql");
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         // clean resources before test execution
         //connectionWrite.delete(GRAPH_NAME);
         //FIXME: This will fail if graph name doesnt exist, tests are being currently ignored due to no asserts being run
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanResources() {
         // clean resources after test execution
         // connectionWrite.delete(GRAPH_NAME);
@@ -53,7 +51,7 @@ public class FusekiTest {
      * Parses rdf data from file and saves datamodel metadata
      */
     @Test
-    public void t001_SaveDatamodel() {
+    void t001_SaveDatamodel() {
         InputStream data = this.getClass().getResourceAsStream("/create_model.json");
         Model model = ModelFactory.createDefaultModel();
         RDFParser
@@ -65,7 +63,7 @@ public class FusekiTest {
     }
 
     @Test
-    public void testModelCreate() {
+    void testModelCreate() {
         Model model = ModelFactory.createDefaultModel();
         model.setNsPrefix("dcterms", "http://purl.org/dc/terms/");
         model.setNsPrefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
@@ -87,7 +85,7 @@ public class FusekiTest {
      * Add two classes to the model
      */
     @Test
-    public void t002_AddClasses() {
+    void t002_AddClasses() {
 
         Model model = connectionRead.fetch(GRAPH_NAME);
 
@@ -104,7 +102,7 @@ public class FusekiTest {
      * Fetches class from model and adds new property (comment)
      */
     @Test
-    public void t004_ModifyClass() {
+    void t004_ModifyClass() {
         Model model = connectionRead.fetch(GRAPH_NAME);
         Resource resource = model.getResource(GRAPH_NAME + "#TestClass");
         resource.addProperty(RDFS.comment, model.createLiteral("Test description", "fi"));
@@ -115,7 +113,7 @@ public class FusekiTest {
      * Get class information with simple sparql query
      */
     @Test
-    public void t005_GetClass() {
+    void t005_GetClass() {
         String query = "CONSTRUCT WHERE {" +
                 "?class ?p ?o" +
                 "}";
@@ -147,7 +145,7 @@ public class FusekiTest {
      * Creates two attributes and adds them to the class
      */
     @Test
-    public void t006_AddClassProperty() {
+    void t006_AddClassProperty() {
         Model model = connectionRead.fetch(GRAPH_NAME);
         Resource classResource = model.getResource(GRAPH_NAME + "#TestClass");
 
@@ -163,7 +161,7 @@ public class FusekiTest {
     }
 
     @Test
-    public void t998_PrintModel() {
+    void t998_PrintModel() {
         RDFConnection connection = RDFConnection.connect(FUSEKI_URL + "/core/get");
         Model model = connection.fetch(GRAPH_NAME);
         StmtIterator stmtIterator = model.listStatements();

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -183,7 +183,6 @@ class ModelMapperTest {
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test", result.getId());
         assertEquals("library", result.getType());
         assertEquals("VALID", result.getStatus());
-        assertEquals("2023-01-03T12:44:45.799Z", result.getStatusModified());
         assertEquals("2023-01-03T12:44:45.799Z", result.getModified());
         assertEquals("2023-01-03T12:44:45.799Z", result.getCreated());
         assertEquals("2023-01-03T12:44:45.799Z", result.getContentModified());

--- a/src/test/java/fi/vm/yti/datamodel/api/service/EndpointConnectionTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/service/EndpointConnectionTest.java
@@ -1,23 +1,23 @@
 package fi.vm.yti.datamodel.api.service;
 
 import org.apache.jena.query.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.slf4j.Logger;import org.slf4j.LoggerFactory;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import fi.vm.yti.datamodel.api.config.ApplicationProperties;
-import static org.junit.Assert.fail;
 
-@RunWith(SpringRunner.class)
+import static org.junit.jupiter.api.Assertions.fail;
+
 @ActiveProfiles("junit")
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest
-public class EndpointConnectionTest {
+@Disabled
+class EndpointConnectionTest {
 
     @Autowired
     private ApplicationProperties applicationProperties;
@@ -25,7 +25,8 @@ public class EndpointConnectionTest {
     private static final Logger logger = LoggerFactory.getLogger(EndpointConnectionTest.class.getName());
 
     @Test
-    public void testEndpoint() {
+    //FIXME: cannot be run in jenkins, should this test be removed if we have FusekiTest
+    void testEndpoint() {
 
         String queryString = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 1";
 

--- a/src/test/java/fi/vm/yti/datamodel/api/service/ModelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/service/ModelTest.java
@@ -6,12 +6,10 @@ import org.apache.jena.iri.IRI;
 import org.apache.jena.rdf.model.Model;
 import org.glassfish.jersey.client.ClientProperties;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,7 +22,6 @@ import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.test.context.junit4.SpringRunner;
 import fi.vm.yti.datamodel.api.config.ApplicationProperties;
 import fi.vm.yti.datamodel.api.model.DataModel;
 import fi.vm.yti.datamodel.api.model.ReusableClass;
@@ -34,14 +31,17 @@ import fi.vm.yti.datamodel.api.utils.LDHelper;
 import fi.vm.yti.security.YtiUser;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-@RunWith(SpringRunner.class)
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @ActiveProfiles("junit")
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest
-public class ModelTest  {
+@Disabled
+//TODO: this is part of v1 is this in use anymore
+class ModelTest  {
 
     private static final Logger logger = LoggerFactory.getLogger(ModelTest.class.getName());
     private static Client testClient = ClientBuilder.newClient().property(ClientProperties.FOLLOW_REDIRECTS,Boolean.TRUE);
@@ -73,19 +73,17 @@ public class ModelTest  {
     }
 
     @Test
-    @Ignore
-    public void test1_user() {
+    void test1_user() {
 
         String user = target.path("user").request().get().readEntity(String.class);
-        Assert.assertThat(user,JsonPathMatchers.hasJsonPath("$.email",Matchers.notNullValue()));
-        Assert.assertThat(user,JsonPathMatchers.hasJsonPath("$.firstName"));
-        Assert.assertThat(user,JsonPathMatchers.hasJsonPath("$.lastName"));
+        assertThat(user,JsonPathMatchers.hasJsonPath("$.email",Matchers.notNullValue()));
+        assertThat(user,JsonPathMatchers.hasJsonPath("$.firstName"));
+        assertThat(user,JsonPathMatchers.hasJsonPath("$.lastName"));
 
     }
 
     @Test
-    @Ignore
-    public void test2_createNewModel() {
+    void test2_createNewModel() {
 
         testModelId = LDHelper.toIRI(applicationProperties.getDefaultNamespace()+"junit5");
 
@@ -132,8 +130,7 @@ public class ModelTest  {
     }
 
     @Test
-    @Ignore
-    public void test3_createNewClassToModel() {
+    void test3_createNewClassToModel() {
 
         String testClass = target.path("classCreator")
                 .queryParam("modelID",testModelId)
@@ -154,8 +151,7 @@ public class ModelTest  {
     }
 
     @Test
-    @Ignore
-    public void test4_createNewPredicateToModel(){
+    void test4_createNewPredicateToModel(){
 
        String testPredicate = target.path("predicateCreator")
                 .queryParam("modelID",testModelId)
@@ -177,8 +173,7 @@ public class ModelTest  {
     }
 
     @Test
-    @Ignore
-    public void test5_removeModel() {
+    void test5_removeModel() {
 
         graphManager.removeModel(testModelId);
         serviceDescriptionManager.deleteGraphDescription(testModelId.toString());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/elasticsearch/ElasticIndexerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/elasticsearch/ElasticIndexerTest.java
@@ -1,0 +1,63 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.index.ElasticConnector;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.index.ElasticIndexer;
+import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import org.apache.jena.query.Query;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResIterator;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        ElasticIndexer.class
+})
+public class ElasticIndexerTest {
+
+    @MockBean
+    JenaService jenaService;
+
+    @MockBean
+    ElasticConnector elasticConnector;
+
+    @MockBean
+    ObjectMapper objectMapper;
+
+    @MockBean
+    ModelMapper modelMapper;
+
+    @MockBean
+    RestHighLevelClient esClient;
+
+    @Autowired
+    ElasticIndexer elasticIndexer;
+
+
+    @Test
+    void initModelIndexTest() throws IOException {
+        var model = mock(Model.class);
+        var subjects = mock(ResIterator.class);
+        when(jenaService.constructWithQuery(any(Query.class))).thenReturn(model);
+        when(model.listSubjects()).thenReturn(subjects);
+        when(objectMapper.valueToTree(any())).thenReturn(mock(JsonNode.class));
+
+        elasticIndexer.initModelIndex();
+
+        verify(this.jenaService).constructWithQuery(any(Query.class));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
@@ -1,0 +1,61 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.index.ElasticIndexer;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers =IndexController.class)
+@ActiveProfiles("junit")
+class IndexControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AuthorizationManager authorizationManager;
+
+    @MockBean
+    private ElasticIndexer elasticIndexer;
+
+    @Autowired
+    private IndexController indexController;
+
+    @MockBean
+    private JenaService jenaService;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.indexController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+
+        when(authorizationManager.hasRightToDropDatabase()).thenReturn(true);
+    }
+
+    @Test
+    void shouldReIndex() throws Exception {
+        this.mvc
+            .perform(get("/v2/index/reindex"))
+            .andExpect(status().isOk());
+
+        verify(this.elasticIndexer).reindex();
+    }
+}

--- a/src/test/resources/test_datamodel.ttl
+++ b/src/test/resources/test_datamodel.ttl
@@ -20,4 +20,3 @@
                 "test" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         owl:versionInfo                 "VALID" ;
-        <status:modified>               "2023-01-03T12:44:45.799Z"^^xsd:dateTime .


### PR DESCRIPTION
Changelog:
- Add indexing controller with proper authorization requirements
- Create query for getting all datamodel graphs into a single model. 
- unit tests
- move prefixes to ModelConstants
- use Iow class as properties instead of defining every time