### PR TITLE
YTI-2373 fix languages getmodel

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -5,6 +5,7 @@ import fi.vm.yti.datamodel.api.v2.elasticsearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.rdf.model.*;
+import org.apache.jena.shared.JenaException;
 import org.apache.jena.vocabulary.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -259,7 +260,16 @@ public class ModelMapper {
      */
     private List<String> arrayPropertyToList(Resource resource, Property property){
         var list = new ArrayList<String>();
-        resource.listProperties(property).forEach(val -> list.add(val.getObject().toString()));
+        try{
+            resource.getProperty(property)
+                    .getList()
+                    .asJavaList()
+                    .forEach(node -> list.add(node.toString()));
+        }catch(JenaException ex){
+            //if item could not be gotten as list it means it is multiple statements of the property
+            resource.listProperties(property)
+                    .forEach(val -> list.add(val.getObject().toString()));
+        }
         return list;
     }
 
@@ -271,7 +281,16 @@ public class ModelMapper {
      */
     private Set<String> arrayPropertyToSet(Resource resource, Property property){
         var list = new HashSet<String>();
-        resource.listProperties(property).forEach(val -> list.add(val.getObject().toString()));
+        try{
+            resource.getProperty(property)
+                    .getList()
+                    .asJavaList()
+                    .forEach(node -> list.add(node.toString()));
+        }catch(JenaException ex){
+            //if item could not be gotten as list it means it is multiple statements of the property
+            resource.listProperties(property)
+                    .forEach(val -> list.add(val.getObject().toString()));
+        }
         return list;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -24,10 +24,11 @@ public class JenaService {
 
     private final Cache<String, Model> modelCache;
 
-    public JenaService(@Value("${termed.cache.expiration:1800}") Long cacheExpireTime) {
-        this.coreWrite = RDFConnection.connect("http://localhost:3030/core/data");
-        this.coreRead = RDFConnection.connect("http://localhost:3030/core/get");
-        this.coreSparql = RDFConnection.connect("http://localhost:3030/core/sparql");
+    public JenaService(@Value("${model.cache.expiration:1800}") Long cacheExpireTime,
+                       @Value(("${endpoint}")) String endpoint) {
+        this.coreWrite = RDFConnection.connect(endpoint + "/core/data");
+        this.coreRead = RDFConnection.connect(endpoint + "/core/get");
+        this.coreSparql = RDFConnection.connect( endpoint + "/core/sparql");
         this.modelCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTime, TimeUnit.SECONDS)
                 .maximumSize(1000)

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -166,7 +166,38 @@ class ModelMapperTest {
 
         assertEquals(1, result.getGroups().size());
         assertTrue(result.getGroups().contains("P11"));
-        System.out.println(m);
+    }
+
+    @Test
+    void testMapToDatamodelDtoOld(){
+        Model mOld = ModelFactory.createDefaultModel();
+        var streamOld = getClass().getResourceAsStream("/test_datamodel_v1.ttl");
+        assertNotNull(streamOld);
+        RDFDataMgr.read(mOld, streamOld, RDFLanguages.TURTLE);
+        var resultOld = mapper.mapToDataModelDTO("testaa", mOld);
+
+        assertEquals("testaa", resultOld.getPrefix());
+        assertEquals(ModelType.LIBRARY, resultOld.getType());
+        assertEquals(Status.DRAFT, resultOld.getStatus());
+
+        assertEquals(1, resultOld.getLabel().size());
+        assertTrue(resultOld.getLabel().containsValue("Testaa"));
+        assertTrue(resultOld.getLabel().containsKey("fi"));
+
+
+        assertEquals(1, resultOld.getDescription().size());
+        assertTrue(resultOld.getDescription().containsValue("Testaa desc"));
+        assertTrue(resultOld.getDescription().containsKey("fi"));
+
+        assertEquals(2, resultOld.getLanguages().size());
+        assertTrue(resultOld.getLanguages().contains("fi"));
+        assertTrue(resultOld.getLanguages().contains("en"));
+
+        assertEquals(1, resultOld.getOrganizations().size());
+        assertTrue(resultOld.getOrganizations().contains(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
+
+        assertEquals(1, resultOld.getGroups().size());
+        assertTrue(resultOld.getGroups().contains("P11"));
     }
 
     @Test
@@ -205,6 +236,43 @@ class ModelMapperTest {
 
         assertEquals(1, result.getIsPartOf().size());
         assertTrue(result.getIsPartOf().contains("P11"));
-        System.out.println(m);
+    }
+
+    @Test
+    void testMapToIndexModelOld(){
+        Model mOld = ModelFactory.createDefaultModel();
+
+        var streamOld = getClass().getResourceAsStream("/test_datamodel_v1.ttl");
+        assertNotNull(streamOld);
+        RDFDataMgr.read(mOld, streamOld, RDFLanguages.TURTLE);
+
+        var resultOld = mapper.mapToIndexModel("testaa", mOld);
+
+        assertEquals("testaa", resultOld.getPrefix());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "testaa", resultOld.getId());
+        assertEquals("library", resultOld.getType());
+        assertEquals("DRAFT", resultOld.getStatus());
+        assertEquals("2018-03-20T16:21:07.067Z", resultOld.getModified());
+        assertEquals("2018-03-20T17:59:44", resultOld.getCreated());
+
+        assertEquals(0, resultOld.getDocumentation().size());
+
+        assertEquals(1, resultOld.getLabel().size());
+        assertTrue(resultOld.getLabel().containsValue("Testaa"));
+        assertTrue(resultOld.getLabel().containsKey("fi"));
+
+        assertEquals(1, resultOld.getComment().size());
+        assertTrue(resultOld.getComment().containsValue("Testaa desc"));
+        assertTrue(resultOld.getComment().containsKey("fi"));
+
+        assertEquals(2, resultOld.getLanguage().size());
+        assertTrue(resultOld.getLanguage().contains("fi"));
+        assertTrue(resultOld.getLanguage().contains("en"));
+
+        assertEquals(1, resultOld.getContributor().size());
+        assertTrue(resultOld.getContributor().contains(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
+
+        assertEquals(1, resultOld.getIsPartOf().size());
+        assertTrue(resultOld.getIsPartOf().contains("P11"));
     }
 }

--- a/src/test/resources/test_datamodel_v1.ttl
+++ b/src/test/resources/test_datamodel_v1.ttl
@@ -59,12 +59,13 @@ testaa:test-property  a     owl:DatatypeProperty ;
 
 <http://uri.suomi.fi/datamodel/ns/testaa>
         a                               owl:Ontology , dcap:DCAP ;
+        rdfs:comment                    "Testaa desc"@fi ;
         rdfs:label                      "Testaa"@fi ;
         dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
         dcterms:created                 "2018-03-20T17:59:44"^^xsd:dateTime ;
         dcterms:hasPart                 testaa:test-property , testaa:Test ;
         dcterms:identifier              "urn:uuid:f15bc8e6-8e6c-46fc-abc7-edcdd728aa94" ;
-        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1001> ;
+        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                ( "fi" "en" ) ;
         dcterms:modified                "2018-03-20T16:21:07.067Z"^^xsd:dateTime ;
         dcterms:references              <http://uri.suomi.fi/terminology/jhs/terminological-vocabulary-1> ;


### PR DESCRIPTION
Changelog:
 - Get languages for old models properly.
   - ModelMapper will first try the statement as a RDF:List and then as separate statements
 - Fix endpoints for JenaService
 - Tests for old models (might be deleted in the future when old models are migrated)