### PR TITLE
YTI-2361: FIX check datamodel for orgs instead of datamodeldto

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/security/AuthorizationManager.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/security/AuthorizationManager.java
@@ -8,6 +8,7 @@ import org.apache.jena.iri.IRI;
 import fi.vm.yti.datamodel.api.model.AbstractClass;
 import fi.vm.yti.datamodel.api.model.AbstractModel;
 import fi.vm.yti.datamodel.api.model.AbstractPredicate;
+import org.apache.jena.rdf.model.Model;
 
 public interface AuthorizationManager {
 
@@ -20,6 +21,8 @@ public interface AuthorizationManager {
     boolean hasRightToCreateNewVersion(AbstractModel model);
 
     boolean hasRightToAnyOrganization(Collection<UUID> organizations);
+
+    boolean hasRightToModel(String prefix, Model model);
 
     boolean isAdminOfAnyOrganization(Collection<UUID> organizations);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/security/AuthorizationManagerImpl.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/security/AuthorizationManagerImpl.java
@@ -3,16 +3,20 @@ package fi.vm.yti.datamodel.api.security;
 import fi.vm.yti.datamodel.api.model.AbstractClass;
 import fi.vm.yti.datamodel.api.model.AbstractModel;
 import fi.vm.yti.datamodel.api.model.AbstractPredicate;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.YtiUser;
 
 import org.apache.jena.iri.IRI;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.DCTerms;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static fi.vm.yti.security.Role.ADMIN;
 import static fi.vm.yti.security.Role.DATA_MODEL_EDITOR;
@@ -47,6 +51,17 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
     public boolean hasRightToAnyOrganization(Collection<UUID> organizations) {
         YtiUser user = getUser();
         return user.isSuperuser() || user.isInAnyRole(EnumSet.of(ADMIN, DATA_MODEL_EDITOR), organizations);
+    }
+
+    public boolean hasRightToModel(String prefix, Model model){
+        var oldRes = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
+        var organizations = oldRes.listProperties(DCTerms.contributor).toList().stream().map(prop -> {
+            var orgUri = prop.getObject().toString();
+            return UUID.fromString(
+                    orgUri.substring(
+                            orgUri.lastIndexOf(":")+ 1));
+        }).collect(Collectors.toSet());
+        return hasRightToAnyOrganization(organizations);
     }
 
     public boolean isAdminOfAnyOrganization(Collection<UUID> organizations) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/ElasticIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/index/ElasticIndexer.java
@@ -126,6 +126,7 @@ public class ElasticIndexer {
             var indexModel = modelMapper.mapToIndexModel(resource.getLocalName(), newModel);
             list.add(indexModel);
         }
+        //TODO check why http://uri.suomi/fi/datamodel/ns/aaa is not indexes
         var values = objectMapper.valueToTree(list);
         bulkInsert(ELASTIC_INDEX_MODEL, values);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -65,11 +65,15 @@ public class Datamodel {
     public void updateModel(@ValidDatamodel(updateModel = true) @RequestBody DataModelDTO modelDTO,
                             @PathVariable String prefix) {
         logger.info("Updating model {}", modelDTO);
-        check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
 
-        var jenaModel = mapper.mapToUpdateJenaModel(prefix, modelDTO);
+        var oldModel = jenaService.getDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
 
-        jenaService.createDataModel(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);
+        check(authorizationManager.hasRightToModel(prefix, oldModel));
+
+        var jenaModel = mapper.mapToUpdateJenaModel(prefix, modelDTO, oldModel);
+
+        jenaService.createDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix, jenaModel);
+
 
         var indexModel = mapper.mapToIndexModel(prefix, jenaModel);
         elasticIndexer.updateModelToIndex(indexModel);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -85,11 +85,9 @@ public class ModelMapper {
     }
 
 
-    public Model mapToUpdateJenaModel(String prefix, DataModelDTO dataModelDTO){
+    public Model mapToUpdateJenaModel(String prefix, DataModelDTO dataModelDTO, Model model){
         var updateDate = new XSDDateTime(Calendar.getInstance());
         var hasUpdated = false;
-
-        var model = jenaService.getDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
 
         var modelResource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -116,7 +116,7 @@ class ModelMapperTest {
 
         assertEquals(Status.VALID, Status.valueOf(modelResource.getProperty(OWL.versionInfo).getString()));
 
-        Model model = mapper.mapToUpdateJenaModel("test", dto);
+        Model model = mapper.mapToUpdateJenaModel("test", dto, m);
 
         //changed values
         modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");

--- a/src/test/java/fi/vm/yti/datamodel/api/service/TestAuthorizationManagerImpl.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/service/TestAuthorizationManagerImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 import org.apache.jena.iri.IRI;
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -42,6 +43,11 @@ public class TestAuthorizationManagerImpl implements AuthorizationManager {
 
     @Override
     public boolean hasRightToAnyOrganization(final Collection<UUID> organizations) {
+        return true;
+    }
+
+    @Override
+    public boolean hasRightToModel(final String prefix, final Model model) {
         return true;
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -80,6 +80,7 @@ class DatamodelTest {
                 .build();
 
         when(authorizationManager.hasRightToAnyOrganization(anyCollection())).thenReturn(true);
+        when(authorizationManager.hasRightToModel(any(), any())).thenReturn(true);
     }
 
     @Test
@@ -129,7 +130,8 @@ class DatamodelTest {
         //Mock mapping
         var model = mock(Model.class);
         var indexmodel = mock(IndexModel.class);
-        when(modelMapper.mapToUpdateJenaModel(anyString(), any(DataModelDTO.class))).thenReturn(model);
+        when(jenaService.getDataModel(anyString())).thenReturn(mock(Model.class));
+        when(modelMapper.mapToUpdateJenaModel(anyString(), any(DataModelDTO.class), any(Model.class))).thenReturn(model);
         when(modelMapper.mapToIndexModel("test", model)).thenReturn(indexmodel);
 
         this.mvc
@@ -140,7 +142,7 @@ class DatamodelTest {
 
         //Check that functions are called
         verify(this.modelMapper)
-                .mapToUpdateJenaModel(anyString(), any(DataModelDTO.class));
+                .mapToUpdateJenaModel(anyString(), any(DataModelDTO.class), any(Model.class));
         verify(this.modelMapper)
                 .mapToIndexModel(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.modelMapper);


### PR DESCRIPTION
Changelog: 
- Add hasRightToModel to auth manager
- Use to check datamodel instead of datamodelDTO
- Fix tests to reflect this change (mainly just mocking the auth manager check)