### PR TITLE
YTI-2375: Check prefix when creating

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -4,6 +4,7 @@ import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.elasticsearch.index.ElasticIndexer;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidDatamodel;
@@ -66,6 +67,9 @@ public class Datamodel {
         logger.info("Updating model {}", modelDTO);
 
         var oldModel = jenaService.getDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
+        if(oldModel == null){
+            throw new ResourceNotFoundException(prefix);
+        }
 
         check(authorizationManager.hasRightToModel(prefix, oldModel));
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -4,10 +4,12 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import org.apache.jena.arq.querybuilder.AskBuilder;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.arq.querybuilder.ExprFactory;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdfconnection.RDFConnection;
@@ -74,6 +76,16 @@ public class JenaService {
             return coreSparql.queryConstruct(query);
         }catch(HttpException ex){
             return null;
+        }
+    }
+
+    public boolean doesDataModelExist(String graph){
+        var askBuilder = new AskBuilder()
+                .addGraph(NodeFactory.createURI(graph), "?s", "?p", "?o");
+        try {
+            return coreSparql.queryAsk(askBuilder.build());
+        }catch(HttpException ex){
+            throw new RuntimeException("Error querying graph");
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -12,6 +12,9 @@ public class ValidationConstants {
     public static final int TEXT_FIELD_MAX_LENGTH = 150;
     public static final int TEXT_AREA_MAX_LENGTH = 5000;
 
+    public static final int PREFIX_MAX_LENGTH = 10;
+    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]{2,}";
+
     public static final Map<String, String> RESERVED_NAMESPACES = Map.ofEntries(
             Map.entry("owl", "http://www.w3.org/2002/07/owl#"),
             Map.entry("xsd", "http://www.w3.org/2001/XMLSchema#"),


### PR DESCRIPTION
Changelog:
- New ASK query for checking if graph exists in core
- Prefix validation
  - Added length and pattern matching for external namespace
  - Datamodel checks if current prefix is already in use and checks reserved prefixes
  - Unit test for prefix checking