### PR TITLE
YTI-2376 Add missing features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.security:spring-security-config"
     implementation "org.springframework.security:spring-security-web"
+    implementation "org.springframework.boot:spring-boot-starter-webflux"
 
     implementation "fi.vm.yti:yti-spring-security:0.4.0"
     implementation "fi.vm.yti:yti-spring-migration:0.2.0"

--- a/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
@@ -13,11 +13,14 @@ import org.apache.hc.core5.ssl.TrustStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
@@ -86,5 +89,14 @@ public class RestConfig {
         }
 
         return restTemplate;
+    }
+
+    @Bean
+    WebClient.Builder defaultWebClient() {
+
+        var httpHeaders = new HttpHeaders();
+        httpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        return WebClient.builder().defaultHeaders(headers -> headers.addAll(httpHeaders));
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/BaseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/BaseDTO.java
@@ -1,5 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Map;
 
 public abstract class BaseDTO {
@@ -17,5 +19,10 @@ public abstract class BaseDTO {
 
     public Map<String, String> getLabel() {
         return label;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/GroupManagementOrganizationDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/GroupManagementOrganizationDTO.java
@@ -1,0 +1,60 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GroupManagementOrganizationDTO {
+    private String uuid;
+    private Map<String,String> prefLabel;
+    private Map<String,String> description;
+    private String url;
+
+    private String parentId;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public Map<String, String> getPrefLabel() {
+        return prefLabel;
+    }
+
+    public void setPrefLabel(Map<String, String> prefLabel) {
+        this.prefLabel = prefLabel;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    public Map<String, String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Map<String, String> description) {
+        this.description = description;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/GroupManagementUserDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/GroupManagementUserDTO.java
@@ -1,0 +1,43 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.beans.ConstructorProperties;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class GroupManagementUserDTO {
+
+    private final UUID id;
+    private final String email;
+    private final String firstName;
+    private final String lastName;
+    private final LocalDateTime removedDateTime;
+
+    @ConstructorProperties({"id", "email", "firstName", "lastName", "removedDateTime"})
+    public GroupManagementUserDTO(UUID id, String email, String firstName, String lastName, LocalDateTime removedDateTime) {
+        this.id = id;
+        this.email = email;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.removedDateTime = removedDateTime;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public LocalDateTime getRemovedDateTime() {
+        return removedDateTime;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
+import java.util.List;
 import java.util.Map;
 
 public class ModelConstants {
@@ -11,7 +12,9 @@ public class ModelConstants {
     public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
     public static final String URN_UUID = "urn:uuid:";
     public static final String DEFAULT_LANGUAGE = "fi";
-
+    public static final List<String> USED_LANGUAGES = List.of("fi", "sv", "en");
+    public static final String ORGANIZATION_GRAPH = "urn:yti:organizations";
+    public static final String SERVICE_CATEGORY_GRAPH = "urn:yti:servicecategories";
     public static final Map<String, String> PREFIXES = Map.of(
             "rdfs", "http://www.w3.org/2000/01/rdf-schema#",
             "rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#", //TODO this can be removed once migration for old rdf lists are done

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/IndexModelDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/IndexModelDTO.java
@@ -1,0 +1,91 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.dto;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+
+import java.util.List;
+import java.util.Map;
+
+public class IndexModelDTO {
+    private String id;
+    private Status status;
+    private ModelType type;
+    private String prefix;
+    private Map<String, String> label;
+    private Map<String, String> comment;
+    private List<String> contributor;
+    private List<String> isPartOf;
+    private List<String> language;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public ModelType getType() {
+        return type;
+    }
+
+    public void setType(ModelType type) {
+        this.type = type;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public Map<String, String> getComment() {
+        return comment;
+    }
+
+    public void setComment(Map<String, String> comment) {
+        this.comment = comment;
+    }
+
+    public List<String> getContributor() {
+        return contributor;
+    }
+
+    public void setContributor(List<String> contributor) {
+        this.contributor = contributor;
+    }
+
+    public List<String> getIsPartOf() {
+        return isPartOf;
+    }
+
+    public void setIsPartOf(List<String> isPartOf) {
+        this.isPartOf = isPartOf;
+    }
+
+    public List<String> getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(List<String> language) {
+        this.language = language;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/ModelSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/ModelSearchRequest.java
@@ -1,0 +1,106 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.dto;
+
+import java.util.Set;
+
+public class ModelSearchRequest {
+
+    private String query;
+
+    private String language;
+
+    private String sortLang;
+
+    private Set<String> status;
+
+    private Set<String> type;
+
+    private Integer pageSize;
+
+    private Integer pageFrom;
+
+    private Set<String> includeIncompleteFrom;
+
+    private Set<String> organizations;
+
+    private Set<String> groups;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getSortLang() {
+        return sortLang;
+    }
+
+    public void setSortLang(String sortLang) {
+        this.sortLang = sortLang;
+    }
+
+    public Set<String> getStatus() {
+        return status;
+    }
+
+    public void setStatus(Set<String> status) {
+        this.status = status;
+    }
+
+    public Set<String> getType() {
+        return type;
+    }
+
+    public void setType(Set<String> type) {
+        this.type = type;
+    }
+
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public Integer getPageFrom() {
+        return pageFrom;
+    }
+
+    public void setPageFrom(Integer pageFrom) {
+        this.pageFrom = pageFrom;
+    }
+
+    public Set<String> getIncludeIncompleteFrom() {
+        return includeIncompleteFrom;
+    }
+
+    public void setIncludeIncompleteFrom(Set<String> includeIncompleteFrom) {
+        this.includeIncompleteFrom = includeIncompleteFrom;
+    }
+
+    public Set<String> getOrganizations() {
+        return organizations;
+    }
+
+    public void setOrganizations(Set<String> organizations) {
+        this.organizations = organizations;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/ModelSearchResponse.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/elasticsearch/dto/ModelSearchResponse.java
@@ -1,0 +1,42 @@
+package fi.vm.yti.datamodel.api.v2.elasticsearch.dto;
+
+import java.util.List;
+
+public class ModelSearchResponse {
+    private long totalHitCount;
+    private Integer pageSize;
+    private Integer pageFrom;
+    private List<IndexModelDTO> models;
+
+    public long getTotalHitCount() {
+        return totalHitCount;
+    }
+
+    public void setTotalHitCount(long totalHitCount) {
+        this.totalHitCount = totalHitCount;
+    }
+
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public Integer getPageFrom() {
+        return pageFrom;
+    }
+
+    public void setPageFrom(Integer pageFrom) {
+        this.pageFrom = pageFrom;
+    }
+
+    public List<IndexModelDTO> getModels() {
+        return models;
+    }
+
+    public void setModels(List<IndexModelDTO> models) {
+        this.models = models;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -8,6 +8,7 @@ import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidDatamodel;
+import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,7 +36,10 @@ public class Datamodel {
 
     private final ModelMapper mapper;
 
-    public Datamodel(JenaService jenaService, AuthorizationManager authorizationManager, ElasticIndexer elasticIndexer, ModelMapper modelMapper) {
+    public Datamodel(JenaService jenaService,
+                     AuthorizationManager authorizationManager,
+                     ElasticIndexer elasticIndexer,
+                     ModelMapper modelMapper) {
         this.authorizationManager = authorizationManager;
         this.mapper = modelMapper;
         this.elasticIndexer = elasticIndexer;
@@ -58,7 +62,7 @@ public class Datamodel {
         elasticIndexer.createModelToIndex(indexModel);
     }
 
-    @Operation(summary = "Create a new model")
+    @Operation(summary = "Modify model")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
     @PostMapping(path = "/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
@@ -88,6 +92,16 @@ public class Datamodel {
     public DataModelDTO getModel(@PathVariable String prefix){
         var model = jenaService.getDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
         return mapper.mapToDataModelDTO(prefix, model);
+    }
+
+    @Operation(summary = "Check if prefix already exists")
+    @ApiResponse(responseCode = "200", description = "Boolean value indicating whether prefix")
+    @GetMapping(value = "/freePrefix/{prefix}", produces = APPLICATION_JSON_VALUE)
+    public Boolean freePrefix(@PathVariable String prefix) {
+        if (ValidationConstants.RESERVED_WORDS.contains(prefix)) {
+            return false;
+        }
+        return !jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FakeableUserController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FakeableUserController.java
@@ -1,0 +1,34 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.dto.GroupManagementUserDTO;
+import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("v2/fakeableUsers")
+@Tag(name = "Admin")
+public class FakeableUserController {
+    private final GroupManagementService groupManagementService;
+
+    FakeableUserController(GroupManagementService groupManagementService) {
+        this.groupManagementService = groupManagementService;
+    }
+
+    @GetMapping
+    @Operation(description = "Get fakeable users")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of user objects")
+    })
+    public List<GroupManagementUserDTO> getFakeableUsers() {
+        return groupManagementService.getFakeableUsers();
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -2,11 +2,15 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
 import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.ModelSearchRequest;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.ModelSearchResponse;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
+import fi.vm.yti.security.AuthenticatedUserProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,12 +18,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
 @RequestMapping("v2/frontend")
@@ -30,14 +33,17 @@ public class FrontendController {
     private final SearchIndexService searchIndexService;
     private final ObjectMapper objectMapper;
     private final FrontendService frontendService;
+    private final AuthenticatedUserProvider userProvider;
 
     @Autowired
     public FrontendController(SearchIndexService searchIndexService,
                               ObjectMapper objectMapper,
-                              FrontendService frontendService) {
+                              FrontendService frontendService,
+                              AuthenticatedUserProvider userProvider) {
         this.searchIndexService = searchIndexService;
         this.objectMapper = objectMapper;
         this.frontendService = frontendService;
+        this.userProvider = userProvider;
     }
 
     @Operation(summary = "Get counts", description = "List counts of data model grouped by different search results")
@@ -53,7 +59,7 @@ public class FrontendController {
     @ApiResponse(responseCode = "200", description = "Organization list as JSON")
     @GetMapping(path = "/organizations", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<OrganizationDTO> getOrganizations(
-            @RequestParam("sortLang") String sortLang,
+            @RequestParam(value = "sortLang", required = false) String sortLang,
             @RequestParam(value = "includeChildOrganizations", required = false) boolean includeChildOrganizations) {
         logger.info("GET /organizations requested");
         return frontendService.getOrganizations(sortLang, includeChildOrganizations);
@@ -62,8 +68,15 @@ public class FrontendController {
     @Operation(summary = "Get service categories", description = "List of service categories sorted by name")
     @ApiResponse(responseCode = "200", description = "Service categories as JSON")
     @GetMapping(path = "/serviceCategories", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<ServiceCategoryDTO> getServiceCategories(@RequestParam("sortLang") String sortLang) {
+    public List<ServiceCategoryDTO> getServiceCategories(@RequestParam(value = "sortLang", required = false) String sortLang) {
         logger.info("GET /serviceCategories requested");
-        return frontendService.getServiceCategories(sortLang);
+        return frontendService.getServiceCategories(sortLang == null ? ModelConstants.DEFAULT_LANGUAGE : sortLang);
+    }
+
+    @Operation(summary = "Search models")
+    @ApiResponse(responseCode = "200", description = "List of data model objects")
+    @PostMapping(value = "/searchModels", produces = APPLICATION_JSON_VALUE)
+    public ModelSearchResponse getModels(@RequestBody ModelSearchRequest request) {
+        return searchIndexService.searchModels(request, userProvider.getUser());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -1,0 +1,41 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MapperUtils {
+
+    /**
+     * Get UUID from urn
+     * Will return null if urn cannot be parsed
+     * @param urn URN string formatted as urn:uuid:{uuid}
+     * @return UUID
+     */
+    public static UUID getUUID(String urn) {
+        try {
+            return UUID.fromString(urn.replace("urn:uuid:", ""));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Localized property to Map of (language, value)
+     * @param resource Resource to get property from
+     * @param property Property type
+     * @return Map of (language, value)
+     */
+    public static Map<String, String> localizedPropertyToMap(Resource resource, Property property){
+        var map = new HashMap<String, String>();
+        resource.listProperties(property).forEach(prop -> {
+            var lang = prop.getLanguage();
+            var value = prop.getString();
+            map.put(lang, value);
+        });
+        return map;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/OrganizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/OrganizationMapper.java
@@ -1,0 +1,74 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.GroupManagementOrganizationDTO;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+
+import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.*;
+import static fi.vm.yti.datamodel.api.v2.mapper.MapperUtils.getUUID;
+import static fi.vm.yti.datamodel.api.v2.mapper.MapperUtils.localizedPropertyToMap;
+
+public class OrganizationMapper {
+
+    public static Model mapGroupManagementOrganizationToModel(List<GroupManagementOrganizationDTO> organizations) {
+        var orgModel = ModelFactory.createDefaultModel();
+
+        for (var organization : organizations) {
+            var resource = orgModel.createResource(URN_UUID + organization.getUuid());
+            resource.addProperty(RDF.type, FOAF.Organization);
+
+            USED_LANGUAGES.forEach(lang -> {
+                var label = organization.getPrefLabel().get(lang);
+                var description = organization.getDescription().get(lang);
+
+                if (StringUtils.isNotBlank(label)) {
+                    resource.addLiteral(SKOS.prefLabel, ResourceFactory.createLangLiteral(label, lang));
+                }
+                if (StringUtils.isNotBlank(description)) {
+                    resource.addLiteral(DCTerms.description, ResourceFactory.createLangLiteral(description, lang));
+                }
+            });
+
+            if (StringUtils.isNotBlank(organization.getParentId())) {
+                resource.addProperty(Iow.parentOrganization, URN_UUID + organization.getParentId());
+            }
+            if (StringUtils.isNotBlank(organization.getUrl())) {
+                resource.addLiteral(FOAF.homepage, organization.getUrl());
+            }
+        }
+        return orgModel;
+    }
+
+    public static List<OrganizationDTO> mapToListOrganizationDTO(Model organizationModel) {
+        var iterator = organizationModel.listResourcesWithProperty(RDF.type, FOAF.Organization);
+        List<OrganizationDTO> result = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            var resource = iterator.next().asResource();
+
+            var labels = localizedPropertyToMap(resource, SKOS.prefLabel);
+            var id = getUUID(resource.getURI());
+
+            Statement stmt = resource.getProperty(Iow.parentOrganization);
+            UUID parentId = stmt != null ? getUUID(stmt.getObject().toString()) : null;
+
+            result.add(new OrganizationDTO(id.toString(), labels, parentId));
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
@@ -2,20 +2,14 @@ package fi.vm.yti.datamodel.api.v2.service;
 
 import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.*;
 
-import fi.vm.yti.datamodel.api.index.ElasticConnector;
 import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
-import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
-import fi.vm.yti.datamodel.api.v2.elasticsearch.queries.CountQueryFactory;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.RequestOptions;
+import fi.vm.yti.datamodel.api.v2.mapper.OrganizationMapper;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +27,7 @@ public class FrontendService {
 
     public List<OrganizationDTO> getOrganizations(@NotNull String sortLanguage, boolean includeChildOrganizations) {
         var organizations = jenaService.getOrganizations();
-        var dtos = modelMapper.mapToListOrganizationDTO(organizations);
+        var dtos = OrganizationMapper.mapToListOrganizationDTO(organizations);
 
         sortByLabel(sortLanguage, dtos);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
@@ -1,15 +1,86 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import fi.vm.yti.datamodel.api.v2.dto.GroupManagementOrganizationDTO;
+import fi.vm.yti.datamodel.api.v2.dto.GroupManagementUserDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static fi.vm.yti.datamodel.api.v2.mapper.OrganizationMapper.mapGroupManagementOrganizationToModel;
 
 @Service
 public class GroupManagementService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(GroupManagementService.class);
+    private final JenaService jenaService;
+
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${defaultGroupManagementAPI}")
+    private String defaultGroupManagementUrl;
+
+    @Value("${fake.login.allowed:false}")
+    private boolean fakeLoginAllowed;
+
+    public GroupManagementService(WebClient.Builder webClientBuilder,
+                                  JenaService jenaService) {
+        this.jenaService = jenaService;
+        this.webClientBuilder = webClientBuilder;
+    }
+
     public void initOrganizations() {
-        // TODO: fetch organizations and save to Fuseki
+        var webClient = webClientBuilder.baseUrl(defaultGroupManagementUrl).build();
+
+        try {
+            var organizations = webClient.get().uri(builder -> builder
+                            .path("/organizations")
+                            .queryParam("onlyValid", "true")
+                            .build())
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<List<GroupManagementOrganizationDTO>>() {
+                    })
+                    .block();
+
+            var model = mapGroupManagementOrganizationToModel(organizations);
+            jenaService.saveOrganizations(model);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
     }
 
     public void updateUsers() {
         // TODO:
+    }
+
+    public List<String> getChildOrganizations(String orgId) {
+        return List.of();
+    }
+
+    public List<GroupManagementUserDTO> getFakeableUsers() {
+
+        if (fakeLoginAllowed) {
+
+            // String url = properties.getDefaultGroupManagementAPI() + "users";
+
+            var webClient = webClientBuilder.baseUrl(defaultGroupManagementUrl).build();
+
+            try {
+                return webClient.get().uri(builder -> builder
+                                .path("/users")
+                                .build())
+                        .retrieve()
+                        .bodyToMono(new ParameterizedTypeReference<List<GroupManagementUserDTO>>() {
+                        }).block();
+
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        return List.of();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -54,7 +54,11 @@ public class JenaService {
 
     public void initServiceCategories() {
         Model model = RDFDataMgr.loadModel("ptvl-skos.rdf");
-        coreWrite.put("urn:yti:servicecategories", model);
+        coreWrite.put(ModelConstants.SERVICE_CATEGORY_GRAPH, model);
+    }
+
+    public void saveOrganizations(Model model) {
+        coreWrite.put(ModelConstants.ORGANIZATION_GRAPH, model);
     }
 
     public Model getDataModel(String graph) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
@@ -1,25 +1,44 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.datamodel.api.index.ElasticConnector;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.IndexModelDTO;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.CountSearchResponse;
+import fi.vm.yti.datamodel.api.v2.elasticsearch.dto.ModelSearchResponse;
 import fi.vm.yti.datamodel.api.v2.elasticsearch.queries.CountQueryFactory;
+import fi.vm.yti.security.Role;
+import fi.vm.yti.security.YtiUser;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class SearchIndexService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SearchIndexService.class);
     private final CountQueryFactory countQueryFactory;
     private final RestHighLevelClient client;
+    private final GroupManagementService groupManagementService;
+    private final ObjectMapper objectMapper;
 
-    public SearchIndexService(ElasticConnector elasticConnector, CountQueryFactory countQueryFactory) {
+    public SearchIndexService(ElasticConnector elasticConnector,
+                              CountQueryFactory countQueryFactory,
+                              GroupManagementService groupManagementService,
+                              ObjectMapper objectMapper) {
         this.countQueryFactory = countQueryFactory;
         this.client = elasticConnector.getEsClient();
+        this.groupManagementService = groupManagementService;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -32,6 +51,55 @@ public class SearchIndexService {
             SearchResponse response = client.search(query, RequestOptions.DEFAULT);
             return countQueryFactory.parseResponse(response);
         } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public ModelSearchResponse searchModels(ModelSearchRequest request,
+                                            YtiUser user) {
+        if (!user.isSuperuser()) {
+            final Map<UUID, Set<Role>> rolesInOrganizations = user.getRolesInOrganizations();
+
+            var orgIds = rolesInOrganizations.keySet()
+                    .stream()
+                    .map(UUID::toString)
+                    .collect(Collectors.toSet());
+
+            // show child organization's incomplete content for main organization users
+            var childOrganizationIds = orgIds.stream()
+                    .map(groupManagementService::getChildOrganizations)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+
+            orgIds.addAll(childOrganizationIds);
+            request.setIncludeIncompleteFrom(orgIds);
+        }
+        return searchModels(request);
+    }
+
+    private ModelSearchResponse searchModels(ModelSearchRequest request) {
+        try {
+            // TODO: implement search
+            var response = client.search(new SearchRequest("models_v2"), RequestOptions.DEFAULT);
+            var models = Arrays.stream(response.getHits().getHits())
+                    .map(hit -> {
+                        try {
+                            return objectMapper.readValue(hit.getSourceAsString(), IndexModelDTO.class);
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .collect(Collectors.toList());
+
+            var modelSearchResponse = new ModelSearchResponse();
+            modelSearchResponse.setModels(models);
+            modelSearchResponse.setTotalHitCount(response.getHits().getTotalHits());
+            modelSearchResponse.setPageFrom(request.getPageFrom());
+            modelSearchResponse.setPageSize(request.getPageSize());
+
+            return modelSearchResponse;
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 })
 class ModelMapperTest {
 
-
     @MockBean
     JenaService jenaService;
     @Autowired
@@ -256,8 +255,8 @@ class ModelMapperTest {
 
         assertEquals("test", result.getPrefix());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test", result.getId());
-        assertEquals("profile", result.getType());
-        assertEquals("VALID", result.getStatus());
+        assertEquals(ModelType.PROFILE.name(), result.getType());
+        assertEquals(Status.VALID.name(), result.getStatus());
         assertEquals("2023-01-03T12:44:45.799Z", result.getModified());
         assertEquals("2023-01-03T12:44:45.799Z", result.getCreated());
         assertEquals("2023-01-03T12:44:45.799Z", result.getContentModified());
@@ -294,8 +293,8 @@ class ModelMapperTest {
 
         assertEquals("testaa", resultOld.getPrefix());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "testaa", resultOld.getId());
-        assertEquals("library", resultOld.getType());
-        assertEquals("DRAFT", resultOld.getStatus());
+        assertEquals(ModelType.LIBRARY.name(), resultOld.getType());
+        assertEquals(Status.DRAFT.name(), resultOld.getStatus());
         assertEquals("2018-03-20T16:21:07.067Z", resultOld.getModified());
         assertEquals("2018-03-20T17:59:44", resultOld.getCreated());
 
@@ -320,32 +319,7 @@ class ModelMapperTest {
         assertTrue(resultOld.getIsPartOf().contains("P11"));
     }
 
-    @Test
-    void testMapOrganizationsToDTO() {
-        var model = ModelFactory.createDefaultModel();
-        var stream = getClass().getResourceAsStream("/organizations.ttl");
-        assertNotNull(stream);
-        RDFDataMgr.read(model, stream, Lang.TURTLE);
 
-        var organizations = mapper.mapToListOrganizationDTO(model);
-
-        assertEquals(3, organizations.size());
-
-        var org = organizations.stream()
-                .filter(o -> o.getId().equals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"))
-                .findFirst()
-                .orElseThrow();
-        var child = organizations.stream()
-                .filter(o -> o.getId().equals("8fab2816-03c5-48cd-9d48-b61048f435da"))
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("Yhteentoimivuusalustan yllapito", org.getLabel().get("fi"));
-        assertEquals("Utvecklare av interoperabilitetsplattform", org.getLabel().get("sv"));
-        assertEquals("Interoperability platform developers", org.getLabel().get("en"));
-
-        assertEquals(UUID.fromString("74776e94-7f51-48dc-aeec-c084c4defa09"), child.getParentOrganization());
-    }
 
     @Test
     void testMapServiceCategoriesToDTO() {

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/OrganizationMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/OrganizationMapperTest.java
@@ -1,0 +1,79 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.GroupManagementOrganizationDTO;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.mapper.OrganizationMapper;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.URN_UUID;
+
+public class OrganizationMapperTest {
+
+    @Test
+    void testMapOrganizationsToDTO() {
+        var model = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/organizations.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(model, stream, Lang.TURTLE);
+
+        var organizations = OrganizationMapper.mapToListOrganizationDTO(model);
+
+        assertEquals(3, organizations.size());
+
+        var org = organizations.stream()
+                .filter(o -> o.getId().equals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"))
+                .findFirst()
+                .orElseThrow();
+        var child = organizations.stream()
+                .filter(o -> o.getId().equals("8fab2816-03c5-48cd-9d48-b61048f435da"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("Yhteentoimivuusalustan yllapito", org.getLabel().get("fi"));
+        assertEquals("Utvecklare av interoperabilitetsplattform", org.getLabel().get("sv"));
+        assertEquals("Interoperability platform developers", org.getLabel().get("en"));
+
+        assertEquals(UUID.fromString("74776e94-7f51-48dc-aeec-c084c4defa09"), child.getParentOrganization());
+    }
+
+    @Test
+    void testMapGroupManagementOrganizationToModel() {
+        var dto = new GroupManagementOrganizationDTO();
+        var uuid = UUID.randomUUID().toString();
+        var parentId = UUID.randomUUID().toString();
+
+        dto.setUuid(uuid);
+        dto.setPrefLabel(Map.of(
+                "fi", "Organisaatio",
+                "en", "Organization")
+        );
+        dto.setDescription(Map.of("en", "Test"));
+        dto.setUrl("https://dvv.fi");
+        dto.setParentId(parentId);
+
+        var model = OrganizationMapper.mapGroupManagementOrganizationToModel(List.of(dto));
+        var resource = model.getResource(URN_UUID + uuid);
+        var label = MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel);
+        var description = MapperUtils.localizedPropertyToMap(resource, DCTerms.description);
+
+        assertEquals(FOAF.Organization, resource.getProperty(RDF.type).getObject().asResource());
+        assertEquals("Organisaatio", label.get("fi"));
+        assertEquals("Organization", label.get("en"));
+        assertEquals("Test", description.get("en"));
+        assertEquals("https://dvv.fi", resource.getProperty(FOAF.homepage).getObject().toString());
+        assertEquals(URN_UUID + parentId, resource.getProperty(Iow.parentOrganization).getObject().toString());
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -238,6 +239,29 @@ class DatamodelTest {
                         .contentType("application/json")
                         .content(convertObjectToJsonString(dataModelDTO)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"http","test"})
+    void shouldCheckFreePrefixWhenExists(String prefix) throws Exception {
+        when(jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + "test")).thenReturn(true);
+
+        this.mvc
+                .perform(get("/v2/model/freePrefix/" + prefix)
+                    .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("false")));
+    }
+
+    @Test
+    void shouldCheckFreePrefixWhenNotExist() throws Exception {
+        when(jenaService.doesDataModelExist(anyString())).thenReturn(false);
+
+        this.mvc
+                .perform(get("/v2/model/freePrefix/xyz")
+                        .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("true")));
     }
 
     private String convertObjectToJsonString(DataModelDTO datamodel) throws JsonProcessingException {


### PR DESCRIPTION
Add missing features from legacy:
- freePrefix, users and fakeableUsers endpoints
- dto classes for Elastisearch response

Added simplified implementation for model search. Final implementation after Elasticsearch upgrade

Refactor (partly) model mapping. Moved some common methods to MapperUtils class. Add separate mapper class for Organizations.
