### PR TITLE
YTI-2408: Namespace resolution

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveController.java
@@ -1,0 +1,36 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResolvingException;
+import fi.vm.yti.datamodel.api.v2.service.NamespaceResolver;
+import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("v2/namespace")
+@Tag(name = "Namespace" )
+public class NamespaceResolveController {
+
+
+    private final NamespaceResolver namespaceResolver;
+
+    public NamespaceResolveController(NamespaceResolver namespaceResolver) {
+        this.namespaceResolver = namespaceResolver;
+    }
+
+    @PutMapping
+    public boolean resolveNamespace(@RequestParam String namespace, @RequestParam(required = false, defaultValue = "false") boolean force){
+        if(!force && namespaceResolver.namespaceAlreadyResolved(namespace)){
+            throw new ResolvingException("Already resolved", "Use force parameter to force resolving");
+        }
+        if(ValidationConstants.RESERVED_NAMESPACES.containsValue(namespace)){
+            throw new ResolvingException("Reserved namespace", "This namespace is reserved and cannot be resolved");
+        }
+        return namespaceResolver.resolveNamespace(namespace);
+    }
+
+    @GetMapping("/resolved")
+    public boolean isNamespaceAlreadyResolved(@RequestParam String namespace){
+        return namespaceResolver.namespaceAlreadyResolved(namespace);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveController.java
@@ -3,23 +3,30 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResolvingException;
 import fi.vm.yti.datamodel.api.v2.service.NamespaceResolver;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.Role;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
+
+import static fi.vm.yti.security.AuthorizationException.check;
 
 @RestController
 @RequestMapping("v2/namespace")
 @Tag(name = "Namespace" )
 public class NamespaceResolveController {
 
-
     private final NamespaceResolver namespaceResolver;
 
-    public NamespaceResolveController(NamespaceResolver namespaceResolver) {
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+
+    public NamespaceResolveController(NamespaceResolver namespaceResolver, AuthenticatedUserProvider authenticatedUserProvider) {
         this.namespaceResolver = namespaceResolver;
+        this.authenticatedUserProvider = authenticatedUserProvider;
     }
 
     @PutMapping
     public boolean resolveNamespace(@RequestParam String namespace, @RequestParam(required = false, defaultValue = "false") boolean force){
+        check(!authenticatedUserProvider.getUser().getOrganizations(Role.DATA_MODEL_EDITOR, Role.ADMIN).isEmpty());
         if(!force && namespaceResolver.namespaceAlreadyResolved(namespace)){
             throw new ResolvingException("Already resolved", "Use force parameter to force resolving");
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/ApiGenericError.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/ApiGenericError.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.datamodel.api.v2.endpoint.error;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiGenericError extends ApiError {
+
+    private String message;
+
+    private String details;
+
+    public ApiGenericError(HttpStatus status) {
+        super(status);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+}
+

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/ResolvingException.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/ResolvingException.java
@@ -1,0 +1,14 @@
+package fi.vm.yti.datamodel.api.v2.endpoint.error;
+
+public class ResolvingException extends RuntimeException {
+
+    private final String details;
+    public ResolvingException(String message, String details) {
+        super("Error during resolution: " + message);
+        this.details = details;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -10,6 +10,7 @@ import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.*;
@@ -54,12 +55,30 @@ public class ClassMapper {
         classResource.addProperty(SKOS.note, dto.getComment());
         //Status
         classResource.addProperty(OWL.versionInfo, dto.getStatus().name());
+
+        //namespaces so we don't add any that aren't in model.
+        //user will have to add namespaces to model before adding class with these.
+        var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
+        var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
         //Equivalent class
-        //Checking of resolvability should be done in validator
-        dto.getEquivalentClass().forEach(eq -> classResource.addProperty(OWL.equivalentClass, eq));
+        dto.getEquivalentClass().forEach(eq -> {
+            var namespace = NodeFactory.createURI(eq).getNameSpace().replace("#", "");
+            if(!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
+                throw new MappingError("Equivalent class namespace not in owl:imports or dcterms:requires");
+            }
+            classResource.addProperty(OWL.equivalentClass, eq);
+        });
         //Sub Class
-        //Checking of resolvability should be done in validator
-        dto.getSubClassOf().forEach(sub -> classResource.addProperty(RDFS.subClassOf, sub));
+        if(dto.getSubClassOf() == null || dto.getSubClassOf().isEmpty()){
+            classResource.addProperty(RDFS.subClassOf, OWL.Thing);
+        }
+        dto.getSubClassOf().forEach(sub -> {
+            var namespace = NodeFactory.createURI(sub).getNameSpace().replace("#", "");
+            if(!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
+                throw new MappingError("Sub class namespace not in owl:imports or dcterms:requires");
+            }
+            classResource.addProperty(RDFS.subClassOf, sub);
+        });
         //Subject
         //TODO are all subjects resolved before hand or do we resolve on the fly?
         //This can be expanded when adding terminology functionality

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -76,6 +76,10 @@ public class MapperUtils {
      */
     public static List<String> arrayPropertyToList(Resource resource, Property property){
         var list = new ArrayList<String>();
+        //return empty list if property is not found
+        if(!resource.hasProperty(property)){
+            return list;
+        }
         try{
             resource.getProperty(property)
                     .getList()
@@ -93,10 +97,14 @@ public class MapperUtils {
      * Convert array property to set of strings
      * @param resource Resource to get property from
      * @param property Property type
-     * @return Set of property values
+     * @return Set of property values, empty if property is not found
      */
     public static Set<String> arrayPropertyToSet(Resource resource, Property property){
         var list = new HashSet<String>();
+        //return empty list if property is not found
+        if(!resource.hasProperty(property)){
+            return list;
+        }
         try{
             resource.getProperty(property)
                     .getList()

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -81,8 +81,11 @@ public class MapperUtils {
             return list;
         }
         try{
-            resource.getProperty(property)
-                    .getList()
+            var statement = resource.getProperty(property);
+            if (statement == null) {
+                return list;
+            }
+            statement.getList()
                     .asJavaList()
                     .forEach(node -> list.add(node.toString()));
         }catch(JenaException ex){
@@ -101,10 +104,6 @@ public class MapperUtils {
      */
     public static Set<String> arrayPropertyToSet(Resource resource, Property property){
         var list = new HashSet<String>();
-        //return empty list if property is not found
-        if(!resource.hasProperty(property)){
-            return list;
-        }
         try{
             var statement = resource.getProperty(property);
             if (statement == null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -71,11 +71,7 @@ public class ModelMapper {
         addOrgsToModel(modelDTO, modelResource);
 
         addInternalNamespaceToDatamodel(modelDTO, modelResource, model);
-        //As this could not be reasonably checked using the constraint validator we do not add external namespaces to core vocabularies
-        if(!modelDTO.getType().equals(ModelType.LIBRARY)){
-            addExternalNamespaceToDatamodel(modelDTO, model, modelResource);
-        }
-
+        addExternalNamespaceToDatamodel(modelDTO, model, modelResource);
 
         model.setNsPrefix(modelDTO.getPrefix(), modelUri + "#");
 
@@ -133,7 +129,7 @@ public class ModelMapper {
         }
 
         //TODO remove namespace and remove linked resource to namepsace
-
+        //TODO possible to simplify this code (extract the removal to its own function and use for both external and internal namespaces)
         if(dataModelDTO.getInternalNamespaces() != null){
             var reqIterator = modelResource.listProperties(DCTerms.requires);
             while(reqIterator.hasNext()){
@@ -153,9 +149,7 @@ public class ModelMapper {
             hasUpdated = true;
         }
 
-
-        //As this could not be reasonably checked using the constraint validator we do not add external namespaces to core vocabularies(Ontologies)
-        if(dataModelDTO.getExternalNamespaces() != null && !modelResource.getProperty(RDF.type).getResource().equals(OWL.Ontology)){
+        if(dataModelDTO.getExternalNamespaces() != null){
             var reqIterator = modelResource.listProperties(DCTerms.requires);
             while(reqIterator.hasNext()){
                 var next = reqIterator.next();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RiotException;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ public class NamespaceResolver {
                 jenaService.putNamespaceToImports(namespace, model);
                 return true;
             }
-        } catch (RiotException exception){
+        } catch (RiotException | HttpException ex){
             //if namespace resolution fails for any reason we send false back
             //example: url not real, url can't find anything, url does not contain valid syntax
             return false;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -3,10 +3,14 @@ package fi.vm.yti.datamodel.api.v2.service;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RiotException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class NamespaceResolver {
+
+    private final Logger logger = LoggerFactory.getLogger(NamespaceResolver.class);
 
     private final JenaService jenaService;
 
@@ -28,9 +32,11 @@ public class NamespaceResolver {
                 jenaService.putNamespaceToImports(namespace, model);
                 return true;
             }
-        } catch (RiotException | HttpException ex){
-            //if namespace resolution fails for any reason we send false back
-            //example: url not real, url can't find anything, url does not contain valid syntax
+        } catch (RiotException ex){
+            logger.warn("Namespace not resolvable: {}", ex.getMessage());
+            return false;
+        } catch (HttpException ex){
+            logger.warn("Namespace not resolvable due to HTTP error, Status code: {}", ex.getStatusCode());
             return false;
         }
         return false;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -1,0 +1,41 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RiotException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NamespaceResolver {
+
+    private final JenaService jenaService;
+
+    public NamespaceResolver(JenaService jenaService) {
+        this.jenaService = jenaService;
+    }
+
+    /**
+     * Resolved namespace
+     * @param namespace Namespace uri
+     * @return true if resolved
+     */
+    public boolean resolveNamespace(String namespace){
+        var model = ModelFactory.createDefaultModel();
+        try{
+            model.read(namespace);
+            //if namespace contained any triplets we can put the statements into fuseki
+            if(model.size() > 0){
+                jenaService.putNamespaceToImports(namespace, model);
+                return true;
+            }
+        } catch (RiotException exception){
+            //if namespace resolution fails for any reason we send false back
+            //example: url not real, url can't find anything, url does not contain valid syntax
+            return false;
+        }
+        return false;
+    }
+
+    public boolean namespaceAlreadyResolved(String namespace){
+        return jenaService.doesResolvedNamespaceExist(namespace);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -10,14 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import static fi.vm.yti.datamodel.api.v2.validator.ValidationConstants.PREFIX_MAX_LENGTH;
-import static fi.vm.yti.datamodel.api.v2.validator.ValidationConstants.PREFIX_REGEX;
-
 public class DataModelValidator extends BaseValidator implements
         ConstraintValidator<ValidDatamodel, DataModelDTO> {
-
-    private static final String MSG_VALUE_MISSING = "should-have-value";
-    private static final String MSG_NOT_ALLOWED_UPDATE = "not-allowed-update";
 
     @Autowired
     private JenaService jenaService;
@@ -56,11 +50,11 @@ public class DataModelValidator extends BaseValidator implements
         var prefix = dataModel.getPrefix();
         if(updateModel){
             if(prefix != null){
-                addConstraintViolation(context, MSG_NOT_ALLOWED_UPDATE, prefixPropertyLabel);
+                addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, prefixPropertyLabel);
             }
             return;
         }else if(prefix == null){
-            addConstraintViolation(context, MSG_VALUE_MISSING, prefixPropertyLabel);
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, prefixPropertyLabel);
             return;
         }
         //Check prefix text content
@@ -80,9 +74,9 @@ public class DataModelValidator extends BaseValidator implements
     private void checkModelType(ConstraintValidatorContext context, DataModelDTO dataModel) {
         var modelType = dataModel.getType();
         if(updateModel && modelType != null){
-            addConstraintViolation(context, MSG_NOT_ALLOWED_UPDATE, "type");
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "type");
         }else if(!updateModel && modelType == null){
-            addConstraintViolation(context, MSG_VALUE_MISSING, "type");
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "type");
         }
     }
 
@@ -153,7 +147,7 @@ public class DataModelValidator extends BaseValidator implements
         var organizations = dataModel.getOrganizations();
         var existingOrgs = jenaService.getOrganizations();
         if(organizations == null || organizations.isEmpty()){
-            addConstraintViolation(context, MSG_VALUE_MISSING, "organization");
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "organization");
             return;
         }
         organizations.forEach(org -> {
@@ -173,7 +167,7 @@ public class DataModelValidator extends BaseValidator implements
         var groups = dataModel.getGroups();
         var existingGroups = jenaService.getServiceCategories();
         if(groups == null || groups.isEmpty()){
-            addConstraintViolation(context, MSG_VALUE_MISSING, "groups");
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "groups");
             return;
         }
         groups.forEach(group -> {
@@ -204,7 +198,6 @@ public class DataModelValidator extends BaseValidator implements
      * @param dataModel Data model
      */
     private void checkExternalNamespaces(ConstraintValidatorContext context, DataModelDTO dataModel){
-        //TODO: do we need to add checking if the string is a valid URI?
         var namespaces = dataModel.getExternalNamespaces();
         var externalNamespace = "externalNamespaces";
         if(namespaces != null){
@@ -233,10 +226,10 @@ public class DataModelValidator extends BaseValidator implements
             addConstraintViolation(context, "prefix-is-reserved", property);
         }
 
-        if(prefix.length() < 3 || prefix.length() > PREFIX_MAX_LENGTH){
+        if(prefix.length() < 3 || prefix.length() > ValidationConstants.PREFIX_MAX_LENGTH){
             addConstraintViolation(context, "prefix-character-count-mismatch", property);
         }
-        if(!prefix.matches(PREFIX_REGEX)){
+        if(!prefix.matches(ValidationConstants.PREFIX_REGEX)){
             addConstraintViolation(context, "prefix-not-matching-pattern", property);
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
@@ -61,7 +61,17 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(MappingError.class)
     protected  ResponseEntity<Object> handleMappingError(MappingError error){
-        return new ResponseEntity<>(error.getMessage(), BAD_REQUEST);
+        var apiError = new ApiError(BAD_REQUEST);
+        apiError.setMessage(error.getMessage());
+        return ResponseEntity.badRequest().body(apiError);
+    }
+
+    @ExceptionHandler(ResolvingException.class)
+    protected  ResponseEntity<Object> handleMappingError(ResolvingException error){
+        var apiError = new ApiGenericError(BAD_REQUEST);
+        apiError.setMessage(error.getMessage());
+        apiError.setDetails(error.getDetails());
+        return ResponseEntity.badRequest().body(apiError);
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -9,6 +9,9 @@ public class ValidationConstants {
         //Utility class
     }
 
+    public static final String MSG_VALUE_MISSING = "should-have-value";
+    public static final String MSG_NOT_ALLOWED_UPDATE =  "not-allowed-update";
+
     public static final int TEXT_FIELD_MAX_LENGTH = 150;
     public static final int TEXT_AREA_MAX_LENGTH = 5000;
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -45,8 +45,8 @@ class ClassMapperTest {
         ClassDTO dto = new ClassDTO();
         dto.setIdentifier("TestClass");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/test#EqClass"));
-        dto.setSubClassOf(Set.of("http://uri.suomi.fi/datamodel/ns/test#SubClass"));
+        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqClass"));
+        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext#SubClass"));
         dto.setComment("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
@@ -76,9 +76,9 @@ class ClassMapperTest {
         assertEquals("comment", classResource.getProperty(SKOS.note).getObject().toString());
 
         assertEquals(1, classResource.listProperties(RDFS.subClassOf).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext#SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(1, classResource.listProperties(OWL.equivalentClass).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", classResource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqClass", classResource.getProperty(OWL.equivalentClass).getObject().toString());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveControllerTest.java
@@ -1,0 +1,91 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.service.NamespaceResolver;
+import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
+import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = NamespaceResolveController.class)
+@ActiveProfiles("junit")
+class NamespaceResolveControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private NamespaceResolver namespaceResolver;
+
+    @Autowired
+    private NamespaceResolveController namespaceResolveController;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.namespaceResolveController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void shouldTryToResolve() throws Exception {
+        this.mvc
+                .perform(put("/v2/namespace")
+                        .param("namespace", "notrealaddress"))
+                .andExpect(status().isOk());
+        verify(namespaceResolver).resolveNamespace(anyString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("reservedNamespaceProvider")
+    void shouldFailToResolveReserved(String namespace) throws Exception {
+        this.mvc
+                .perform(put("/v2/namespace")
+                        .param("namespace", namespace))
+                .andExpect(result -> assertTrue(Objects.requireNonNull(result.getResolvedException()).getMessage().contains("Reserved namespace")))
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<Arguments> reservedNamespaceProvider(){
+        return ValidationConstants.RESERVED_NAMESPACES.values().stream().map(Arguments::of);
+    }
+
+    @Test
+    void testForceResolution() throws Exception {
+        when(namespaceResolver.namespaceAlreadyResolved(anyString())).thenReturn(true);
+
+        this.mvc
+                .perform(put("/v2/namespace")
+                        .param("namespace", "notrealaddress"))
+                .andExpect(status().isBadRequest());
+
+        this.mvc
+                .perform(put("/v2/namespace")
+                        .param("namespace", "notrealaddress")
+                        .param("force", "true"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/NamespaceResolveControllerTest.java
@@ -3,6 +3,9 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 import fi.vm.yti.datamodel.api.v2.service.NamespaceResolver;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.Role;
+import fi.vm.yti.security.YtiUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,13 +19,13 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.Objects;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -39,8 +42,23 @@ class NamespaceResolveControllerTest {
     @MockBean
     private NamespaceResolver namespaceResolver;
 
+    @MockBean
+    private AuthenticatedUserProvider authenticatedUserProvider;
+
     @Autowired
     private NamespaceResolveController namespaceResolveController;
+
+    private final YtiUser mockUser = new YtiUser("test@localhost",
+            "test",
+            "tester",
+            UUID.randomUUID(),
+            true,
+            false,
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            new HashMap<>(Map.of(UUID.randomUUID(), Set.of(Role.ADMIN))),
+            "",
+            "");
 
     @BeforeEach
     public void setup() {
@@ -48,6 +66,8 @@ class NamespaceResolveControllerTest {
                 .standaloneSetup(this.namespaceResolveController)
                 .setControllerAdvice(new ExceptionHandlerAdvice())
                 .build();
+
+        when(authenticatedUserProvider.getUser()).thenReturn(mockUser);
     }
 
     @Test


### PR DESCRIPTION
Changelog:
- New Namespace Resolution controller
  - unit tests
- New namespace resolving service
- Remove checking for core vocabulary for external namespaces (no ticket seperately for this)
- Add owl:Thing to subClassOf by default (YTI-2428)
- Better error messages for some exceptions
- Move some validation messages to ValidationConstants
- Fix ClassMapper unit tests

