### PR TITLE
YTI-2421 Class note and editorial note

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
@@ -14,6 +14,7 @@ public class ClassDTO {
     private Set<String> subClassOf = Set.of();
     private String subject;
     private String identifier;
+    private Map<String, String> note = Map.of();
 
     public Map<String, String> getLabel() {
         return label;
@@ -69,6 +70,14 @@ public class ClassDTO {
 
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
+    }
+
+    public Map<String, String> getNote() {
+        return note;
+    }
+
+    public void setNote(Map<String, String> note) {
+        this.note = note;
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.ClassDTO;
 import fi.vm.yti.datamodel.api.v2.dto.Iow;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
@@ -26,8 +27,11 @@ public class ClassMapper {
 
     private final JenaService jenaService;
 
-    public ClassMapper(JenaService jenaService) {
+    private final AuthorizationManager authorizationManager;
+
+    public ClassMapper(JenaService jenaService, AuthorizationManager authorizationManager) {
         this.jenaService = jenaService;
+        this.authorizationManager = authorizationManager;
     }
 
     public String createClassAndMapToModel(String prefix, Model model, ClassDTO dto){
@@ -50,8 +54,10 @@ public class ClassMapper {
         var modelResource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
         var langs = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
         MapperUtils.addLocalizedProperty(langs, dto.getLabel(), classResource, RDFS.label, model);
-        //Comment
-        classResource.addProperty(SKOS.note, dto.getComment());
+        //Comment (not visible for unauthenticated users)
+        classResource.addProperty(SKOS.editorialNote, dto.getComment());
+        //Note
+        MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SKOS.note, model);
         //Status
         classResource.addProperty(OWL.versionInfo, dto.getStatus().name());
         //Equivalent class
@@ -73,9 +79,10 @@ public class ClassMapper {
 
     /**
      * Map model with given prefix and class identifier
-     * @param modelPrefix Model prefix
+     *
+     * @param modelPrefix     Model prefix
      * @param classIdentifier class identifier
-     * @param model Model
+     * @param model           Model
      * @return Class DTO
      */
     public ClassDTO mapToClassDTO(String modelPrefix, String classIdentifier, Model model){
@@ -92,7 +99,10 @@ public class ClassMapper {
         classDTO.setEquivalentClass(MapperUtils.arrayPropertyToSet(classResource, OWL.equivalentClass));
         classDTO.setSubject(MapperUtils.propertyToString(classResource, DCTerms.subject));
         classDTO.setIdentifier(classResource.getLocalName());
-        classDTO.setComment(MapperUtils.propertyToString(classResource, SKOS.note));
+        classDTO.setNote(MapperUtils.localizedPropertyToMap(classResource, SKOS.note));
+        if (authorizationManager.hasRightToModel(modelPrefix, model)) {
+            classDTO.setComment(MapperUtils.propertyToString(classResource, SKOS.editorialNote));
+        }
         return classDTO;
     }
 
@@ -104,7 +114,7 @@ public class ClassMapper {
         var classResource = model.getResource(classUri);
         indexClass.setId(classUri);
         indexClass.setLabel(MapperUtils.localizedPropertyToMap(classResource, RDFS.label));
-        indexClass.setComment(MapperUtils.propertyToString(classResource, SKOS.note));
+        indexClass.setNote(MapperUtils.localizedPropertyToMap(classResource, SKOS.note));
         indexClass.setStatus(MapperUtils.propertyToString(classResource, OWL.versionInfo));
         indexClass.setIsDefinedBy(MapperUtils.propertyToString(classResource, RDFS.isDefinedBy));
         indexClass.setIdentifier(classResource.getLocalName());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -98,8 +98,11 @@ public class MapperUtils {
     public static Set<String> arrayPropertyToSet(Resource resource, Property property){
         var list = new HashSet<String>();
         try{
-            resource.getProperty(property)
-                    .getList()
+            var statement = resource.getProperty(property);
+            if (statement == null) {
+                return list;
+            }
+            statement.getList()
                     .asJavaList()
                     .forEach(node -> list.add(node.toString()));
         }catch(JenaException ex){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexClass.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexClass.java
@@ -1,9 +1,11 @@
 package fi.vm.yti.datamodel.api.v2.opensearch.index;
 
+import java.util.Map;
+
 public class IndexClass extends IndexBase {
     private String isDefinedBy;
     private String contentModified;
-    private String comment;
+    private Map<String, String> note;
     private String identifier;
     private String namespace;
 
@@ -23,12 +25,12 @@ public class IndexClass extends IndexBase {
         this.contentModified = contentModified;
     }
 
-    public String getComment() {
-        return comment;
+    public Map<String, String> getNote() {
+        return note;
     }
 
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void setNote(Map<String, String> note) {
+        this.note = note;
     }
 
     public String getIdentifier() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
@@ -178,7 +178,7 @@ public class OpenSearchIndexer {
         addProperty(constructBuilder, DCTerms.created, "?created");
         addOptional(constructBuilder, Iow.contentModified, "?contentModified");
         addProperty(constructBuilder, RDFS.isDefinedBy, "?isDefinedBy");
-        addOptional(constructBuilder, SKOS.note, "?comment");
+        addOptional(constructBuilder, SKOS.note, "?note");
         addOptional(constructBuilder, RDFS.subClassOf, "?subClassOf");
         addOptional(constructBuilder, OWL.equivalentClass, "?equivalentClass");
         var indexClasses = jenaService.constructWithQuery(constructBuilder.build());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.mapper;
 
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
@@ -20,7 +21,9 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 
@@ -32,6 +35,8 @@ class ClassMapperTest {
 
     @MockBean
     JenaService jenaService;
+    @MockBean
+    AuthorizationManager authorizationManager;
     @Autowired
     ClassMapper mapper;
 
@@ -50,6 +55,7 @@ class ClassMapperTest {
         dto.setComment("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
+        dto.setNote(Map.of("fi", "test note"));
 
         mapper.createClassAndMapToModel("test", m, dto);
 
@@ -73,7 +79,8 @@ class ClassMapperTest {
         assertEquals(XSDDatatype.XSDNCName, classResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
         assertEquals("TestClass", classResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
-        assertEquals("comment", classResource.getProperty(SKOS.note).getObject().toString());
+        assertEquals("comment", classResource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals("test note", classResource.getProperty(SKOS.note).getLiteral().getString());
 
         assertEquals(1, classResource.listProperties(RDFS.subClassOf).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
@@ -91,7 +98,8 @@ class ClassMapperTest {
 
         var dto = mapper.mapToClassDTO("test", "TestClass", m);
 
-        assertEquals("test comment", dto.getComment());
+        // not authenticated
+        assertNull(dto.getComment());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals("TestClass", dto.getIdentifier());
         assertEquals(1, dto.getEquivalentClass().size());
@@ -101,6 +109,23 @@ class ClassMapperTest {
         assertEquals(1, dto.getLabel().size());
         assertEquals("test label", dto.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject());
+        assertEquals(2, dto.getNote().size());
+        assertEquals("test note fi", dto.getNote().get("fi"));
+        assertEquals("test note en", dto.getNote().get("en"));
+    }
+
+    @Test
+    void testMapToClassDTOAuthenticatedUser() {
+        when(jenaService.doesClassExistInGraph(anyString(), anyString())).thenReturn(true);
+        when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        var dto = mapper.mapToClassDTO("test", "TestClass", m);
+
+        assertEquals("comment visible for admin", dto.getComment());
     }
 
     @Test
@@ -114,7 +139,7 @@ class ClassMapperTest {
         var indexClass = mapper.mapToIndexClass(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
 
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
-        assertEquals("test comment", indexClass.getComment());
+        assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals("VALID", indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -150,6 +150,7 @@ class ClassControllerTest {
         dto.setLabel(Map.of("fi", "test label"));
         dto.setEquivalentClass(Set.of("tietomallit.suomi.fi/ns/notrealns/FakeClass"));
         dto.setSubClassOf(Set.of("tietomallit.suomi.fi/ns/notrealns/FakeClass"));
+        dto.setNote(Map.of("fi", "test note"));
         return dto;
     }
 

--- a/src/test/resources/test_datamodel_with_class.ttl
+++ b/src/test/resources/test_datamodel_with_class.ttl
@@ -43,4 +43,5 @@ test:TestClass  rdf:type     owl:Class ;
         dcterms:subject      "http://uri.suomi.fi/terminology/test/test1" ;
         owl:equivalentClass  "http://uri.suomi.fi/datamodel/ns/test#EqClass" ;
         owl:versionInfo      "VALID" ;
-        skos:note            "test comment" .
+        skos:editorialNote   "comment visible for admin" ;
+        skos:note         "test note fi"@fi, "test note en"@en .


### PR DESCRIPTION
- Add new property note for class. For now, stored in SKOS:note but it might change in the future
- Comment is stored to SKOS:editorialNote and it's not visible for unauthenticated users and not indexed in Opensearch either
- Add null check for getting list of properties as some of them might not exist, e.g. equivalentClass