### PR TITLE
YTI-2417: Added class update

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
@@ -7,14 +7,14 @@ import java.util.Set;
 
 public class ClassDTO {
 
-    private Map<String, String> label = Map.of();
-    private String comment;
+    private Map<String, String> label;
+    private String editorialNote;
     private Status status;
-    private Set<String> equivalentClass = Set.of();
-    private Set<String> subClassOf = Set.of();
+    private Set<String> equivalentClass;
+    private Set<String> subClassOf;
     private String subject;
     private String identifier;
-    private Map<String, String> note = Map.of();
+    private Map<String, String> note;
 
     public Map<String, String> getLabel() {
         return label;
@@ -24,12 +24,12 @@ public class ClassDTO {
         this.label = label;
     }
 
-    public String getComment() {
-        return comment;
+    public String getEditorialNote() {
+        return editorialNote;
     }
 
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void setEditorialNote(String editorialNote) {
+        this.editorialNote = editorialNote;
     }
 
     public Status getStatus() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -59,7 +59,7 @@ public class ClassController {
     @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
     @PutMapping(value = "/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public void updateClass(@PathVariable String prefix, @PathVariable String classIdentifier, @RequestBody @ValidClass(updateClass = true) ClassDTO classDTO){
-        logger.info("Updating model {}", classIdentifier);
+        logger.info("Updating class {}", classIdentifier);
 
         var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var classURI = graph + "#" + classIdentifier;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -11,6 +11,8 @@ import fi.vm.yti.datamodel.api.v2.validator.ValidClass;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +24,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @Tag(name = "Class" )
 @Validated
 public class ClassController {
+
+    private final Logger logger = LoggerFactory.getLogger(ClassController.class);
 
     private final AuthorizationManager authorizationManager;
     private final JenaService jenaService;
@@ -49,6 +53,29 @@ public class ClassController {
         jenaService.createDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix, model);
         var indexClass = classMapper.mapToIndexClass(model, classURi);
         openSearchIndexer.createClassToIndex(indexClass);
+    }
+
+    @Operation(summary = "Update a class in a model")
+    @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
+    @PutMapping(value = "/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    public void updateClass(@PathVariable String prefix, @PathVariable String classIdentifier, @RequestBody @ValidClass(updateClass = true) ClassDTO classDTO){
+        logger.info("Updating model {}", classIdentifier);
+
+        var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var classURI = graph + "#" + classIdentifier;
+        if(!jenaService.doesClassExistInGraph(graph, graph + "#" + classIdentifier)){
+            throw new ResourceNotFoundException(classIdentifier);
+        }
+
+        var model = jenaService.getDataModel(graph);
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        var classResource = model.getResource(classURI);
+
+        classMapper.mapToUpdateClass(model, graph, classResource, classDTO);
+
+        var indexClass = classMapper.mapToIndexClass(model, classURI);
+        openSearchIndexer.updateClassToIndex(indexClass);
     }
 
     @Operation(summary = "Get a class from a data model")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -70,15 +70,15 @@ public class FrontendController {
 
     @Operation(summary = "Search models")
     @ApiResponse(responseCode = "200", description = "List of data model objects")
-    @PostMapping(value = "/searchModels", produces = APPLICATION_JSON_VALUE)
-    public SearchResponseDTO<IndexModel> getModels(@RequestBody ModelSearchRequest request) {
+    @GetMapping(value = "/searchModels", produces = APPLICATION_JSON_VALUE)
+    public SearchResponseDTO<IndexModel> getModels(ModelSearchRequest request) {
         return searchIndexService.searchModels(request, userProvider.getUser());
     }
 
     @Operation(summary = "Search classes", description = "List of classes")
     @ApiResponse(responseCode = "200", description = "List of classes as JSON")
-    @GetMapping(path = "/searchInternalClasses", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public SearchResponseDTO<IndexClass> getClasses(@RequestBody ClassSearchRequest request) throws IOException {
+    @GetMapping(path = "/searchInternalClasses", produces = APPLICATION_JSON_VALUE)
+    public SearchResponseDTO<IndexClass> getClasses(ClassSearchRequest request) throws IOException {
         return searchIndexService.searchInternalClasses(request);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -69,6 +69,25 @@ public class MapperUtils {
     }
 
     /**
+     * Updates localized property
+     * @param languages Languages of the datamodel, localized property has to be in language
+     * @param data Data to add
+     * @param resource Resource
+     * @param property Property
+     * @param model Model
+     */
+    public static void updateLocalizedProperty(Set<String> languages,
+                                               Map<String, String> data,
+                                               Resource resource,
+                                               Property property,
+                                               Model model) {
+        if(data != null && languages != null && !languages.isEmpty()){
+            resource.removeAll(property);
+            addLocalizedProperty(languages, data, resource, property, model);
+        }
+    }
+
+    /**
      * Convert array property to list of strings
      * @param resource Resource to get property from
      * @param property Property type
@@ -131,5 +150,34 @@ public class MapperUtils {
         var object = prop.getObject();
         //null check for object
         return object == null ? null : object.toString();
+    }
+
+    /**
+     * Update string property
+     * If string is empty|blank value is removed
+     * @param resource Resource
+     * @param property Property
+     * @param value Value
+     */
+    public static void updateStringProperty(Resource resource, Property property, String value){
+        if(value != null){
+            resource.removeAll(property);
+            if(!value.isBlank()){
+                resource.addProperty(property, value);
+            }
+        }
+    }
+
+    /**
+     * Adds an optional string property
+     * This has a null check, so it does not need to be separately added
+     * @param resource Resource
+     * @param property Property
+     * @param value Value
+     */
+    public static void addOptionalStringProperty(Resource resource, Property property, String value){
+        if(value != null && !value.isBlank()){
+            resource.addProperty(property, value);
+        }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -39,6 +39,7 @@ public class ModelMapper {
         var model = ModelFactory.createDefaultModel();
         var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix();
         // TODO: type of application profile?
+        model.setNsPrefixes(ModelConstants.PREFIXES);
         Resource type = modelDTO.getType().equals(ModelType.LIBRARY)
                 ? OWL.Ontology
                 : ResourceFactory.createProperty("http://www.w3.org/2002/07/dcap#DCAP");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
@@ -25,7 +25,8 @@ public class ClassValidator extends BaseValidator implements
         setConstraintViolationAdded(false);
 
         checkLabel(context, classDTO);
-        checkComment(context, classDTO);
+        checkEditorialNote(context, classDTO);
+        checkNote(context, classDTO);
         checkStatus(context, classDTO);
         checkEquivalentClass(context, classDTO);
         checkSubClassOf(context, classDTO);
@@ -37,17 +38,32 @@ public class ClassValidator extends BaseValidator implements
 
     private void checkLabel(ConstraintValidatorContext context, ClassDTO classDTO){
         var labels = classDTO.getLabel();
-        labels.forEach((lang, value) -> {
-            if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                addConstraintViolation(context, "value-over-character-limit." + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "label");
-            }
-        });
+        if(!updateClass && (labels == null || labels.isEmpty() || labels.values().stream().allMatch(String::isBlank))){
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "label");
+        }else if(labels != null){
+            labels.forEach((lang, value) -> {
+                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
+                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "label");
+                }
+            });
+        }
     }
 
-    private void checkComment(ConstraintValidatorContext context, ClassDTO classDTO){
-        var comment = classDTO.getComment();
-        if(comment.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
-            addConstraintViolation(context, "value-over-character-limit." + ValidationConstants.TEXT_AREA_MAX_LENGTH, "label");
+    private void checkEditorialNote(ConstraintValidatorContext context, ClassDTO classDTO){
+        var editorialNote = classDTO.getEditorialNote();
+        if(editorialNote != null && editorialNote.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
+            addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_AREA_MAX_LENGTH, "editorialNote");
+        }
+    }
+
+    private void checkNote(ConstraintValidatorContext context, ClassDTO classDTO) {
+        var notes = classDTO.getNote();
+        if(notes != null){
+            notes.forEach((lang, value) -> {
+                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
+                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "note");
+                }
+            });
         }
     }
 
@@ -61,26 +77,30 @@ public class ClassValidator extends BaseValidator implements
 
     private void checkEquivalentClass(ConstraintValidatorContext context, ClassDTO classDTO){
         var equivalentClass = classDTO.getEquivalentClass();
-        equivalentClass.forEach(eqClass -> {
-            var asUri = NodeFactory.createURI(eqClass);
-            //if namespace is resolvable make sure class can be found in resolved namespace
-            if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
-                    && jenaService.doesClassExistInNamespace(asUri.getNameSpace(), asUri.getURI())){
-                addConstraintViolation(context, "class-not-found-in-resolved-namespace", "eqClass");
-            }
-        });
+        if(equivalentClass != null){
+            equivalentClass.forEach(eqClass -> {
+                var asUri = NodeFactory.createURI(eqClass);
+                //if namespace is resolvable make sure class can be found in resolved namespace
+                if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
+                        && jenaService.doesClassExistInNamespace(asUri.getNameSpace(), asUri.getURI())){
+                    addConstraintViolation(context, "class-not-found-in-resolved-namespace", "eqClass");
+                }
+            });
+        }
     }
 
     private void checkSubClassOf(ConstraintValidatorContext context, ClassDTO classDTO){
         var subClassOf = classDTO.getSubClassOf();
-        subClassOf.forEach(subClass -> {
-            var asUri = NodeFactory.createURI(subClass);
-            //if namespace is resolvable make sure class can be found in resolved namespace
-            if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
-            && jenaService.doesClassExistInNamespace(asUri.getNameSpace(), asUri.getURI())){
+        if(subClassOf != null) {
+            subClassOf.forEach(subClass -> {
+                var asUri = NodeFactory.createURI(subClass);
+                //if namespace is resolvable make sure class can be found in resolved namespace
+                if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
+                        && jenaService.doesClassExistInNamespace(asUri.getNameSpace(), asUri.getURI())){
                     addConstraintViolation(context, "class-not-found-in-resolved-namespace", "subClassOf");
-            }
-        });
+                }
+            });
+        }
     }
 
     private void checkSubject(ConstraintValidatorContext context, ClassDTO classDTO){
@@ -90,8 +110,10 @@ public class ClassValidator extends BaseValidator implements
 
     private void checkIdentifier(ConstraintValidatorContext context, ClassDTO classDTO){
         var identifier = classDTO.getIdentifier();
-        if(identifier == null || identifier.isBlank()){
+        if(!updateClass && (identifier == null || identifier.isBlank())){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "identifier");
+        }else if(updateClass && identifier != null){
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -112,7 +112,7 @@ public class DataModelValidator extends BaseValidator implements
                 addConstraintViolation(context, "language-not-in-language-list." + key, labelPropertyLabel);
             }
             if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                addConstraintViolation(context, "value-over-character-limit." + ValidationConstants.TEXT_FIELD_MAX_LENGTH, labelPropertyLabel);
+                addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, labelPropertyLabel);
             }
         });
     }
@@ -133,7 +133,7 @@ public class DataModelValidator extends BaseValidator implements
                 addConstraintViolation(context, "language-not-in-language-list." + key, "description");
             }
             if(value.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
-                addConstraintViolation(context, "value-over-character-limit." + ValidationConstants.TEXT_AREA_MAX_LENGTH, "description");
+                addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_AREA_MAX_LENGTH, "description");
             }
         });
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -11,6 +11,7 @@ public class ValidationConstants {
 
     public static final String MSG_VALUE_MISSING = "should-have-value";
     public static final String MSG_NOT_ALLOWED_UPDATE =  "not-allowed-update";
+    public static final String MSG_OVER_CHARACTER_LIMIT = "value-over-character-limit.";
 
     public static final int TEXT_FIELD_MAX_LENGTH = 150;
     public static final int TEXT_AREA_MAX_LENGTH = 5000;

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -16,12 +16,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -52,7 +51,7 @@ class ClassMapperTest {
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
         dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqClass"));
         dto.setSubClassOf(Set.of("https://www.example.com/ns/ext#SubClass"));
-        dto.setComment("comment");
+        dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
@@ -89,6 +88,30 @@ class ClassMapperTest {
     }
 
     @Test
+    void testCreateClassAndMapToModelOwlThing() {
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        ClassDTO dto = new ClassDTO();
+        dto.setSubClassOf(Collections.emptySet());
+        dto.setStatus(Status.VALID);
+        dto.setIdentifier("Identifier");
+
+        mapper.createClassAndMapToModel("test", m, dto);
+
+        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
+        Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Identifier");
+
+        assertNotNull(modelResource);
+        assertNotNull(classResource);
+
+        assertEquals(1, classResource.listProperties(RDFS.subClassOf).toList().size());
+        assertEquals(OWL.Thing, classResource.getProperty(RDFS.subClassOf).getResource());
+    }
+
+    @Test
     void testMapToClassDTO(){
         when(jenaService.doesClassExistInGraph(anyString(), anyString())).thenReturn(true);
         Model m = ModelFactory.createDefaultModel();
@@ -99,7 +122,7 @@ class ClassMapperTest {
         var dto = mapper.mapToClassDTO("test", "TestClass", m);
 
         // not authenticated
-        assertNull(dto.getComment());
+        assertNull(dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals("TestClass", dto.getIdentifier());
         assertEquals(1, dto.getEquivalentClass().size());
@@ -115,6 +138,28 @@ class ClassMapperTest {
     }
 
     @Test
+    void testMapToClassMinimalDTO(){
+        when(jenaService.doesClassExistInGraph(anyString(), anyString())).thenReturn(true);
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/models/test_datamodel_with_minimal_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        var dto = mapper.mapToClassDTO("test", "TestClass", m);
+
+        // not authenticated
+        assertNull(dto.getEditorialNote());
+        assertEquals(Status.VALID, dto.getStatus());
+        assertEquals("TestClass", dto.getIdentifier());
+        assertTrue(dto.getEquivalentClass().isEmpty());
+        assertTrue(dto.getSubClassOf().isEmpty());
+        assertEquals(1, dto.getLabel().size());
+        assertEquals("test label", dto.getLabel().get("fi"));
+        assertNull(dto.getSubject());
+        assertTrue(dto.getNote().isEmpty());
+    }
+
+    @Test
     void testMapToClassDTOAuthenticatedUser() {
         when(jenaService.doesClassExistInGraph(anyString(), anyString())).thenReturn(true);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
@@ -125,7 +170,7 @@ class ClassMapperTest {
 
         var dto = mapper.mapToClassDTO("test", "TestClass", m);
 
-        assertEquals("comment visible for admin", dto.getComment());
+        assertEquals("comment visible for admin", dto.getEditorialNote());
     }
 
     @Test
@@ -147,4 +192,139 @@ class ClassMapperTest {
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
     }
+
+    @Test
+    void testMapToIndexClassMinimal(){
+        when(jenaService.doesClassExistInGraph(anyString(), anyString())).thenReturn(true);
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/models/test_datamodel_with_minimal_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        var indexClass = mapper.mapToIndexClass(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
+        assertEquals(Status.VALID, indexClass.getStatus());
+        assertEquals("TestClass", indexClass.getIdentifier());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals(1, indexClass.getLabel().size());
+        assertEquals("test label", indexClass.getLabel().get("fi"));
+        assertNull(indexClass.getNote());
+    }
+
+    @Test
+    void testMapToUpdateClass(){
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        var dto = new ClassDTO();
+        dto.setLabel(Map.of("fi", "new label"));
+        dto.setStatus(Status.INVALID);
+        dto.setNote(Map.of("fi", "new note"));
+        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int#NewEq"));
+        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext#NewSub"));
+        dto.setSubject("http://uri.suomi.fi/terminology/qwe");
+        dto.setEditorialNote("new editorial note");
+
+        assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+
+        mapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto);
+
+        assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(1, resource.listProperties(SKOS.note).toList().size());
+        assertEquals("new note", resource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(SKOS.note).getLiteral().getLanguage());
+    }
+
+    @Test
+    void testMapToUpdateClassNullValuesDTO(){
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        var dto = new ClassDTO();
+
+        assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+
+        mapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto);
+
+        assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+    }
+
+    @Test
+    void testMapToUpdateClassEmptyValuesDTO(){
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        var dto = new ClassDTO();
+        dto.setSubject("");
+        dto.setEquivalentClass(Collections.emptySet());
+        dto.setSubClassOf(Collections.emptySet());
+        dto.setEditorialNote("");
+        dto.setNote(Collections.emptyMap());
+
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+
+        mapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto);
+
+        assertNull(resource.getProperty(DCTerms.subject));
+        assertNull(resource.getProperty(OWL.equivalentClass));
+        //OWl thing is default value if all subClassOf is emptied
+        assertEquals(OWL.Thing, resource.getProperty(RDFS.subClassOf).getResource());
+        assertNull(resource.getProperty(SKOS.editorialNote));
+        assertNull(resource.getProperty(SKOS.note));
+    }
+
 }

--- a/src/test/resources/models/test_datamodel_with_minimal_class.ttl
+++ b/src/test/resources/models/test_datamodel_with_minimal_class.ttl
@@ -1,0 +1,42 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
+
+
+<http://uri.suomi.fi/datamodel/ns/test>
+        a                               dcap:DCAP ;
+        rdfs:comment                    "test desc"@fi ;
+        rdfs:label                      "testlabel"@fi ;
+        dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+        dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        dcterms:hasPart                 test:TestClass ;
+        dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
+        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+        dcterms:language                "fi" ;
+        owl:imports                     "http://uri.suomi.fi/datamodel/ns/int" ;
+        dcterms:requires                "https://www.example.com/ns/ext" ;
+        dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespacePrefix
+                "test" ;
+        iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        owl:versionInfo                 "VALID" .
+
+<https://www.example.com/ns/ext>
+        dcterms:type                        rdfs:Resource ;
+        rdfs:label                          "test resource"@fi;
+        dcap:preferredXMLNamespacePrefix    "extres" .
+
+test:TestClass  rdf:type     owl:Class ;
+        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:label           "test label"@fi ;
+        dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        dcterms:identifier   "TestClass"^^xsd:NCName ;
+        dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        owl:versionInfo      "VALID" ;


### PR DESCRIPTION
Changelog:
-  changed comment to editorialNote
- Allow for null lists on DTO
- Update Class endpoint
-  Unit tests for updating and creating classes
- Updated validation rules for class
  - editorial note -> length
  - subclassof and equivalentclass allow null
  - label -> null | empty check
- Searches are now GET request so parameters come in the form of parameters instead of a json body 