### PR TITLE
Yti 2371 terminology to datamodel

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelExpandDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelExpandDTO.java
@@ -1,13 +1,10 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-public class DataModelDTO {
-
+public class DataModelExpandDTO {
     private ModelType type;
     private String prefix;
     private Status status;
@@ -16,10 +13,9 @@ public class DataModelDTO {
     private Set<String> languages = Set.of();
     private Set<UUID> organizations = Set.of();
     private Set<String> groups = Set.of();
-
     private Set<String> internalNamespaces = Set.of();
     private Set<ExternalNamespaceDTO> externalNamespaces = Set.of();
-    private Set<String> terminologies = Set.of();
+    private Set<TerminologyDTO> terminologies = Set.of();
 
     public ModelType getType() {
         return type;
@@ -85,9 +81,12 @@ public class DataModelDTO {
         this.groups = groups;
     }
 
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+    public Set<String> getInternalNamespaces() {
+        return internalNamespaces;
+    }
+
+    public void setInternalNamespaces(Set<String> internalNamespaces) {
+        this.internalNamespaces = internalNamespaces;
     }
 
     public Set<ExternalNamespaceDTO> getExternalNamespaces() {
@@ -98,19 +97,11 @@ public class DataModelDTO {
         this.externalNamespaces = externalNamespaces;
     }
 
-    public Set<String> getInternalNamespaces() {
-        return internalNamespaces;
-    }
-
-    public void setInternalNamespaces(Set<String> internalNamespaces) {
-        this.internalNamespaces = internalNamespaces;
-    }
-
-    public Set<String> getTerminologies() {
+    public Set<TerminologyDTO> getTerminologies() {
         return terminologies;
     }
 
-    public void setTerminologies(Set<String> terminologies) {
+    public void setTerminologies(Set<TerminologyDTO> terminologies) {
         this.terminologies = terminologies;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyDTO.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Map;
+
+public class TerminologyDTO {
+    private Map<String, String> label = Map.of();
+    private String uri;
+    public TerminologyDTO(String uri) {
+        this.uri = uri;
+    }
+    public Map<String, String> getLabel() {
+        return label;
+    }
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+    public String getUri() {
+        return uri;
+    }
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyNodeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyNodeDTO.java
@@ -1,0 +1,84 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TerminologyNodeDTO {
+    private String uri;
+    private Type type;
+    private TerminologyProperties properties;
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public TerminologyProperties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(TerminologyProperties properties) {
+        this.properties = properties;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TerminologyProperties {
+        private List<LocalizedValue> prefLabel;
+
+        public List<LocalizedValue> getPrefLabel() {
+            return prefLabel;
+        }
+
+        public void setPrefLabel(List<LocalizedValue> prefLabel) {
+            this.prefLabel = prefLabel;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Type {
+        private String id;
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LocalizedValue {
+        private String lang;
+        private String value;
+
+        public void setLang(String lang) {
+            this.lang = lang;
+        }
+
+        public String getLang() {
+            return lang;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -60,6 +60,7 @@ public class Datamodel {
         logger.info("Create model {}", modelDTO);
         check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
 
+        terminologyService.resolveTerminology(modelDTO.getTerminologies());
         var jenaModel = mapper.mapToJenaModel(modelDTO);
 
         jenaService.createDataModel(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class ModelMapper {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+
+public class TerminologyMapper {
+
+    private TerminologyMapper() {
+    }
+
+    public static Model mapToJenaModel(String graph, TerminologyNodeDTO terminologyDTO) {
+        Model model = ModelFactory.createDefaultModel();
+        var resource = model.createResource(graph);
+
+        resource.addProperty(RDF.type, SKOS.ConceptScheme);
+        terminologyDTO.getProperties().getPrefLabel().forEach(label ->
+                resource.addProperty(RDFS.label, model.createLiteral(label.getValue(), label.getLang())));
+
+        return model;
+    }
+
+    public static TerminologyDTO mapToTerminologyDTO(String graph, Model model) {
+        var dto = new TerminologyDTO(graph);
+        var label = MapperUtils.localizedPropertyToMap(model.getResource(graph), RDFS.label);
+        dto.setLabel(label);
+        return dto;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -35,6 +37,9 @@ public class JenaService {
     private final RDFConnection importWrite;
     private final RDFConnection importRead;
     private final RDFConnection importSparql;
+    private final RDFConnection conceptRead;
+    private final RDFConnection conceptWrite;
+    private final RDFConnection conceptSparql;
 
     private final Cache<String, Model> modelCache;
 
@@ -46,6 +51,9 @@ public class JenaService {
         this.importWrite = RDFConnection.connect(endpoint + "/imports/data");
         this.importRead = RDFConnection.connect(endpoint + "/imports/get");
         this.importSparql = RDFConnection.connect(endpoint + "/imports/sparql");
+        this.conceptWrite = RDFConnection.connect(endpoint + "/concept/data");
+        this.conceptRead = RDFConnection.connect(endpoint + "/concept/get");
+        this.conceptSparql = RDFConnection.connect(endpoint + "/concept/sparql");
 
         this.modelCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTime, TimeUnit.SECONDS)
@@ -199,6 +207,22 @@ public class JenaService {
             return importSparql.queryAsk(askBuilder.build());
         }catch(HttpException ex){
             throw new JenaQueryException();
+        }
+    }
+
+    public void putTerminologyToConcepts(String graph, Model model) {
+        conceptWrite.put(graph, model);
+    }
+
+    public Model getTerminology(String graph) {
+        try {
+            return modelCache.get(graph, () -> {
+                logger.debug("Fetch terminology from Fuseki {}", graph);
+                return conceptRead.fetch(graph);
+            });
+        } catch (Exception e) {
+            logger.warn("Error fetching terminology information {}", e.getMessage());
+            return null;
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -21,8 +21,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -39,7 +37,6 @@ public class JenaService {
     private final RDFConnection importSparql;
     private final RDFConnection conceptRead;
     private final RDFConnection conceptWrite;
-    private final RDFConnection conceptSparql;
 
     private final Cache<String, Model> modelCache;
 
@@ -53,7 +50,6 @@ public class JenaService {
         this.importSparql = RDFConnection.connect(endpoint + "/imports/sparql");
         this.conceptWrite = RDFConnection.connect(endpoint + "/concept/data");
         this.conceptRead = RDFConnection.connect(endpoint + "/concept/get");
-        this.conceptSparql = RDFConnection.connect(endpoint + "/concept/sparql");
 
         this.modelCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTime, TimeUnit.SECONDS)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -1,0 +1,77 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.TerminologyMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class TerminologyService {
+    private static final Logger LOG = LoggerFactory.getLogger(TerminologyService.class);
+
+    @Value("${awsEnv:}")
+    private String awsEnv;
+
+    private final WebClient.Builder webClientBuilder;
+    private final JenaService jenaService;
+
+    public TerminologyService(WebClient.Builder webClientBuilder, JenaService jenaService) {
+        this.webClientBuilder = webClientBuilder;
+        this.jenaService = jenaService;
+    }
+
+    /**
+     * Fetch terminology information and persist to Fuseki
+     * @param terminologyUris set of uris
+     */
+    public void resolveTerminology(Set<String> terminologyUris) {
+
+        for (String u : terminologyUris) {
+            var uri = URI.create(u);
+            var baseUrl = uri.getScheme().concat("://").concat(uri.getHost());
+            var client = webClientBuilder.clientConnector(new ReactorClientHttpConnector(
+                    HttpClient.create().followRedirect(true)
+            )).baseUrl(baseUrl).build();
+
+            try {
+                var result = client.get().uri(builder -> builder
+                                .path(uri.getPath())
+                                .queryParam("env", awsEnv)
+                                .build()
+                        )
+                        .accept(MediaType.APPLICATION_JSON)
+                        .retrieve()
+                        .bodyToMono(new ParameterizedTypeReference<List<TerminologyNodeDTO>>() {
+                        })
+                        .block();
+
+                if (result == null) {
+                    continue;
+                }
+                var node = result.stream()
+                        .filter(n -> n.getType().getId().equals("TerminologicalVocabulary"))
+                        .findFirst();
+
+                if (node.isPresent()) {
+                    jenaService.putTerminologyToConcepts(uri.toString(), TerminologyMapper.mapToJenaModel(u, node.get()));
+                } else {
+                    LOG.warn("Could not find node with type TerminologicalVocabulary from {}", uri);
+                }
+            } catch (Exception e) {
+                LOG.warn("Could not resolve terminology {}, {}", uri, e.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -37,6 +37,7 @@ public class DataModelValidator extends BaseValidator implements
         checkInternalNamespaces(context, dataModel);
         checkExternalNamespaces(context, dataModel);
 
+        checkTerminologies(context, dataModel);
         return !isConstraintViolationAdded();
     }
 
@@ -231,6 +232,16 @@ public class DataModelValidator extends BaseValidator implements
         }
         if(!prefix.matches(ValidationConstants.PREFIX_REGEX)){
             addConstraintViolation(context, "prefix-not-matching-pattern", property);
+        }
+    }
+
+    private void checkTerminologies(ConstraintValidatorContext context, DataModelDTO dataModel) {
+        if (dataModel.getTerminologies() == null) {
+            return;
+        }
+
+        if (!dataModel.getTerminologies().stream().allMatch(uri -> uri.matches("^https?://uri.suomi.fi/terminology/(.*)"))) {
+            addConstraintViolation(context, "invalid-terminology-uri", "terminologies");
         }
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
@@ -1,0 +1,52 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.TerminologyMapper;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TerminologyMapperTest {
+
+    @Test
+    void mapToJenaModel() {
+        String graph = "http://uri.suomi.fi/terminology/test";
+        var dto = new TerminologyNodeDTO();
+        var properties = new TerminologyNodeDTO.TerminologyProperties();
+        var label = new TerminologyNodeDTO.LocalizedValue();
+        label.setValue("Test");
+        label.setLang("en");
+        properties.setPrefLabel(List.of(label));
+
+        dto.setUri(graph);
+        dto.setProperties(properties);
+
+        var model = TerminologyMapper.mapToJenaModel(graph, dto);
+        var resource = model.getResource(graph);
+
+        assertEquals(graph, resource.getURI());
+        assertEquals("Test@en", resource.getProperty(RDFS.label).getObject().toString());
+    }
+
+    @Test
+    void mapTerminologyDTO() {
+        var model = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/terminology.ttl");
+        assertNotNull(stream);
+
+        RDFDataMgr.read(model, stream, Lang.TURTLE);
+
+        var terminologyDTO = TerminologyMapper.mapToTerminologyDTO(
+                "http://uri.suomi.fi/terminology/test/terminological-vocabulary-0", model);
+
+        assertEquals(Map.of("fi", "Testisanasto", "en", "Test terminology"), terminologyDTO.getLabel());
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -7,6 +7,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -60,6 +61,9 @@ class DatamodelTest {
 
     @MockBean
     private ModelMapper modelMapper;
+
+    @MockBean
+    private TerminologyService terminologyService;
 
     @Autowired
     private Datamodel datamodel;
@@ -150,7 +154,7 @@ class DatamodelTest {
     void shouldReturnModel() throws Exception {
         var mockModel = mock(Model.class);
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
-        when(modelMapper.mapToDataModelDTO(anyString(), any(Model.class))).thenReturn(new DataModelDTO());
+        when(modelMapper.mapToDataModelDTO(anyString(), any(Model.class))).thenReturn(new DataModelExpandDTO());
 
         this.mvc
                 .perform(get("/v2/model/test")
@@ -284,6 +288,7 @@ class DatamodelTest {
             dataModelDTO.setType(ModelType.LIBRARY);
         }
         dataModelDTO.setStatus(Status.DRAFT);
+        dataModelDTO.setTerminologies(Set.of("http://uri.suomi.fi/terminology/test"));
         return dataModelDTO;
     }
 
@@ -377,6 +382,10 @@ class DatamodelTest {
         invalidExtRes.setPrefix("test");
         invalidExtRes.setNamespace("http://uri.suomi.fi/datamodel/ns/test");
         dataModelDTO.setExternalNamespaces(Set.of(invalidExtRes));
+        args.add(dataModelDTO);
+
+        dataModelDTO = createDatamodelDTO(false);
+        dataModelDTO.setTerminologies(Set.of("http://invalid.url"));
         args.add(dataModelDTO);
 
         return args.stream().map(Arguments::of);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/TerminologyServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/TerminologyServiceTest.java
@@ -1,0 +1,93 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        TerminologyService.class
+})
+public class TerminologyServiceTest {
+
+    @MockBean
+    private WebClient.Builder builder;
+    @MockBean
+    private JenaService jenaService;
+    private ObjectMapper mapper = new ObjectMapper();
+    @Captor
+    private ArgumentCaptor<String> stringCaptor;
+    @Captor
+    private ArgumentCaptor<Model> modelCaptor;
+    @Autowired
+    private TerminologyService service;
+
+    static final String GRAPH = "http://uri.suomi.fi/terminology/test";
+
+    @Test
+    void testResolveTerminology() throws IOException {
+        var stream = getClass().getResourceAsStream("/terminology_response.json");
+        assertNotNull(stream);
+        var terminologyData = Arrays.asList(mapper.readValue(stream, TerminologyNodeDTO[].class));
+        mockWebClient(terminologyData);
+
+        service.resolveTerminology(Set.of(GRAPH));
+
+        verify(jenaService).putTerminologyToConcepts(stringCaptor.capture(), modelCaptor.capture());
+        var label = MapperUtils.localizedPropertyToMap(modelCaptor.getValue().getResource(GRAPH), RDFS.label);
+
+        assertEquals(GRAPH, stringCaptor.getValue());
+        assertEquals("Testisanasto", label.get("fi"));
+    }
+
+    @Test
+    void testTerminologyNotFound() {
+        mockWebClient(null);
+        service.resolveTerminology(Set.of(GRAPH));
+        verifyNoInteractions(jenaService);
+    }
+
+    private void mockWebClient(List<TerminologyNodeDTO> result) {
+        var client = mock(WebClient.class);
+        when(builder.clientConnector(any(ClientHttpConnector.class))).thenReturn(builder);
+        when(builder.baseUrl(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(client);
+
+        var req = mock(WebClient.RequestHeadersUriSpec.class);
+        var res = mock(WebClient.ResponseSpec.class);
+        var mono = mock(Mono.class);
+
+        when(res.bodyToMono(any(ParameterizedTypeReference.class))).thenReturn(mono);
+        when(mono.block()).thenReturn(result);
+
+        when(client.get()).thenReturn(req);
+        when(req.uri(any(Function.class))).thenReturn(req);
+        when(req.accept(any(MediaType.class))).thenReturn(req);
+        when(req.retrieve()).thenReturn(res);
+    }
+}

--- a/src/test/resources/terminology.ttl
+++ b/src/test/resources/terminology.ttl
@@ -1,0 +1,6 @@
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+
+<http://uri.suomi.fi/terminology/test/terminological-vocabulary-0>
+    a               skos:ConceptScheme ;
+    rdfs:label      "Testisanasto"@fi , "Test terminology"@en  .

--- a/src/test/resources/terminology_response.json
+++ b/src/test/resources/terminology_response.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "88236b55-e939-4fe1-a5d8-609980b9d680",
+    "code": "concept-3",
+    "uri": "http://uri.suomi.fi/terminology/defa91d0/concept-3",
+    "number": 3,
+    "createdBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+    "createdDate": "2022-09-22T08:13:31Z",
+    "lastModifiedBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+    "lastModifiedDate": "2022-09-22T08:13:31Z",
+    "type": {
+      "id": "Concept",
+      "graph": {
+        "id": "80f70ae3-7a1e-4155-ab5e-c989e098e7b3"
+      }
+    },
+    "properties": {
+      "status": [
+        {
+          "lang": "",
+          "value": "DRAFT",
+          "regex": "(?s)^.*$"
+        }
+      ]
+    },
+    "references": {},
+    "referrers": {}
+  },
+  {
+    "id": "f8215e58-9afb-4df9-9130-bb1c96f3b546",
+    "code": "terminological-vocabulary-0",
+    "uri": "http://uri.suomi.fi/terminology/defa91d0/terminological-vocabulary-0",
+    "number": 0,
+    "createdBy": "23006bf4-4c09-4438-8224-785fdf108812",
+    "createdDate": "2022-09-22T04:23:51Z",
+    "lastModifiedBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+    "lastModifiedDate": "2022-09-22T04:36:32Z",
+    "type": {
+      "id": "TerminologicalVocabulary",
+      "graph": {
+        "id": "80f70ae3-7a1e-4155-ab5e-c989e098e7b3"
+      }
+    },
+    "properties": {
+      "prefLabel": [
+        {
+          "lang": "fi",
+          "value": "Testisanasto",
+          "regex": "(?s)^.*$"
+        },
+        {
+          "lang": "en",
+          "value": "Test terminology",
+          "regex": "(?s)^.*$"
+        }
+      ]
+    },
+    "references": {
+      "inGroup": [
+        {
+          "id": "9ba19f8d-d688-39cc-b620-ebb7875e6e9b",
+          "code": "v1001"
+        }
+      ],
+      "contributor": [
+        {
+          "id": "7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"
+        }
+      ]
+    },
+    "referrers": {}
+  }
+]


### PR DESCRIPTION
- Add terminologies to payload 
- Resolve terminology and store data, for now only label, to Fuseki
- Validation: must start with valid terminology url, but no need to be resolved.
- Created a separate dto class for the data sent to frontend (might need some refactoring). It contains for now a label for terminogies besides id

Data sent to frontend. If terminology uri is not resolved, the label will be empty.
```
"terminologies": [
        {
            "label": {},
            "uri": "http://uri.suomi.fi/terminology/not-found"
        },
        {
            "label": {
                "fi": "Testi",
                "en": "Test"
            },
            "uri": "http://uri.suomi.fi/terminology/test/terminological-vocabulary-0"
        }
    ]
```