### PR TITLE
YTI-2480 + YTI-2477: opensearch for attr and assoc

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceType.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceType.java
@@ -3,6 +3,7 @@ package fi.vm.yti.datamodel.api.v2.dto;
 public enum ResourceType {
 
     ATTRIBUTE,
-    ASSOCIATION
+    ASSOCIATION,
+    CLASS
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -5,6 +5,7 @@ import fi.vm.yti.datamodel.api.v2.dto.ClassDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidClass;
@@ -30,12 +31,14 @@ public class ClassController {
     private final AuthorizationManager authorizationManager;
     private final JenaService jenaService;
     private final ClassMapper classMapper;
+    private final ResourceMapper resourceMapper;
     private final OpenSearchIndexer openSearchIndexer;
 
-    public ClassController(AuthorizationManager authorizationManager, JenaService jenaService, ClassMapper classMapper, OpenSearchIndexer openSearchIndexer){
+    public ClassController(AuthorizationManager authorizationManager, JenaService jenaService, ClassMapper classMapper, ResourceMapper resourceMapper, OpenSearchIndexer openSearchIndexer){
         this.authorizationManager = authorizationManager;
         this.jenaService = jenaService;
         this.classMapper = classMapper;
+        this.resourceMapper = resourceMapper;
         this.openSearchIndexer = openSearchIndexer;
     }
 
@@ -51,8 +54,8 @@ public class ClassController {
 
         var classURi = classMapper.createClassAndMapToModel(prefix, model, classDTO);
         jenaService.putDataModelToCore(ModelConstants.SUOMI_FI_NAMESPACE + prefix, model);
-        var indexClass = classMapper.mapToIndexClass(model, classURi);
-        openSearchIndexer.createClassToIndex(indexClass);
+        var indexClass = resourceMapper.mapToIndexResource(model, classURi);
+        openSearchIndexer.createResourceToIndex(indexClass);
     }
 
     @Operation(summary = "Update a class in a model")
@@ -75,8 +78,8 @@ public class ClassController {
         classMapper.mapToUpdateClass(model, graph, classResource, classDTO);
         jenaService.putDataModelToCore(graph, model);
 
-        var indexClass = classMapper.mapToIndexClass(model, classURI);
-        openSearchIndexer.updateClassToIndex(indexClass);
+        var indexClass = resourceMapper.mapToIndexResource(model, classURI);
+        openSearchIndexer.updateResourceToIndex(indexClass);
     }
 
     @Operation(summary = "Get a class from a data model")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -4,7 +4,7 @@ import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.*;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexClass;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
@@ -75,10 +75,10 @@ public class FrontendController {
         return searchIndexService.searchModels(request, userProvider.getUser());
     }
 
-    @Operation(summary = "Search classes", description = "List of classes")
-    @ApiResponse(responseCode = "200", description = "List of classes as JSON")
-    @GetMapping(path = "/searchInternalClasses", produces = APPLICATION_JSON_VALUE)
-    public SearchResponseDTO<IndexClass> getClasses(ClassSearchRequest request) throws IOException {
-        return searchIndexService.searchInternalClasses(request, userProvider.getUser());
+    @Operation(summary = "Search resources", description = "List of resources")
+    @ApiResponse(responseCode = "200", description = "List of resources as JSON")
+    @GetMapping(path = "/searchInternalResources", produces = APPLICATION_JSON_VALUE)
+    public SearchResponseDTO<IndexResource> getInternalResources(ResourceSearchRequest request) throws IOException {
+        return searchIndexService.searchInternalResources(request, userProvider.getUser());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -53,10 +53,10 @@ public class ResourceController {
         }
         check(authorizationManager.hasRightToModel(prefix, model));
 
-        resourceMapper.mapToResource(graphUri, model, dto);
-        jenaService.putDataModelToCore(ModelConstants.SUOMI_FI_NAMESPACE + prefix, model);
-       // var indexClass = classMapper.mapToIndexClass(model, classURi);
-        //openSearchIndexer.createClassToIndex(indexClass);
+        var resourceUri = resourceMapper.mapToResource(graphUri, model, dto);
+        jenaService.putDataModelToCore(graphUri, model);
+        var indexClass = resourceMapper.mapToIndexResource(model, resourceUri);
+        openSearchIndexer.createResourceToIndex(indexClass);
     }
 
     @Operation(summary = "Update a resource in a model")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -1,11 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
-import fi.vm.yti.datamodel.api.v2.dto.ClassDTO;
-import fi.vm.yti.datamodel.api.v2.dto.Iow;
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexClass;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
@@ -143,34 +139,6 @@ public class ClassMapper {
             classDTO.setEditorialNote(MapperUtils.propertyToString(classResource, SKOS.editorialNote));
         }
         return classDTO;
-    }
-
-    public IndexClass mapToIndexClass(Model model, String classUri){
-        var indexClass = new IndexClass();
-        if(!jenaService.doesResourceExistInGraph(classUri.substring(0, classUri.indexOf('#')), classUri)){
-            throw new ResourceNotFoundException(classUri);
-        }
-        var classResource = model.getResource(classUri);
-        indexClass.setId(classUri);
-        indexClass.setLabel(MapperUtils.localizedPropertyToMap(classResource, RDFS.label));
-        indexClass.setStatus(Status.valueOf(MapperUtils.propertyToString(classResource, OWL.versionInfo)));
-        indexClass.setIsDefinedBy(MapperUtils.propertyToString(classResource, RDFS.isDefinedBy));
-        indexClass.setIdentifier(classResource.getLocalName());
-        indexClass.setNamespace(classResource.getNameSpace());
-        indexClass.setModified(classResource.getProperty(DCTerms.modified).getString());
-        indexClass.setCreated(classResource.getProperty(DCTerms.created).getString());
-
-        var note = MapperUtils.localizedPropertyToMap(classResource, SKOS.note);
-        if(!note.isEmpty()){
-            indexClass.setNote(note);
-        }
-
-        var contentModified = classResource.getProperty(Iow.contentModified);
-        if(contentModified != null){
-            indexClass.setContentModified(contentModified.getString());
-        }
-
-        return indexClass;
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -1,11 +1,14 @@
 package fi.vm.yti.datamodel.api.v2.opensearch.dto;
 
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
+
 import java.util.Set;
 
-public class ClassSearchRequest extends BaseSearchRequest{
+public class ResourceSearchRequest extends BaseSearchRequest{
 
     private String fromAddedNamespaces;
     private Set<String> groups;
+    private Set<ResourceType> resourceTypes;
 
     public String getFromAddedNamespaces() {
         return fromAddedNamespaces;
@@ -21,5 +24,13 @@ public class ClassSearchRequest extends BaseSearchRequest{
 
     public void setGroups(Set<String> groups) {
         this.groups = groups;
+    }
+
+    public Set<ResourceType> getResourceTypes() {
+        return resourceTypes;
+    }
+
+    public void setResourceTypes(Set<ResourceType> resourceTypes) {
+        this.resourceTypes = resourceTypes;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
@@ -1,13 +1,25 @@
 package fi.vm.yti.datamodel.api.v2.opensearch.index;
 
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
+
 import java.util.Map;
 
-public class IndexClass extends IndexBase {
+public class IndexResource extends IndexBase {
+
+    private ResourceType resourceType;
     private String isDefinedBy;
     private String contentModified;
     private Map<String, String> note;
     private String identifier;
     private String namespace;
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(ResourceType resourceType) {
+        this.resourceType = resourceType;
+    }
 
     public void setIsDefinedBy(String isDefinedBy) {
         this.isDefinedBy = isDefinedBy;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
@@ -3,9 +3,9 @@ package fi.vm.yti.datamodel.api.v2.service;
 import fi.vm.yti.datamodel.api.index.OpenSearchConnector;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.*;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexClass;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
-import fi.vm.yti.datamodel.api.v2.opensearch.queries.ClassQueryFactory;
+import fi.vm.yti.datamodel.api.v2.opensearch.queries.ResourceQueryFactory;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.CountQueryFactory;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.ModelQueryFactory;
 import fi.vm.yti.security.Role;
@@ -86,7 +86,7 @@ public class SearchIndexService {
         }
     }
 
-    public SearchResponseDTO<IndexClass> searchInternalClasses(ClassSearchRequest request, YtiUser user) throws IOException {
+    public SearchResponseDTO<IndexResource> searchInternalResources(ResourceSearchRequest request, YtiUser user) throws IOException {
         Set<String> allowedDatamodels = new HashSet<>();
         if(!user.isSuperuser()){
                 var organizations = getOrganizationsForUser(user);
@@ -99,10 +99,10 @@ public class SearchIndexService {
                         .filter(hit -> hit.source() != null)
                         .map(hit -> hit.source().getId()).collect(Collectors.toSet());
         }
-        return searchInternalClasses(request, allowedDatamodels);
+        return searchInternalResources(request, allowedDatamodels);
     }
 
-       public SearchResponseDTO<IndexClass> searchInternalClasses(ClassSearchRequest request, Set<String> allowedDatamodels) throws IOException {
+       public SearchResponseDTO<IndexResource> searchInternalResources(ResourceSearchRequest request, Set<String> allowedDatamodels) throws IOException {
         Set<String> namespaces = null;
 
         if(request.getFromAddedNamespaces() != null){
@@ -120,10 +120,10 @@ public class SearchIndexService {
                     .map(hit -> hit.source().getId()).collect(Collectors.toSet());
         }
 
-        SearchRequest build = ClassQueryFactory.createInternalClassQuery(request, namespaces, groupRestrictedNamespaces, allowedDatamodels);
-        SearchResponse<IndexClass> response = client.search(build, IndexClass.class);
+        SearchRequest build = ResourceQueryFactory.createInternalResourceQuery(request, namespaces, groupRestrictedNamespaces, allowedDatamodels);
+        SearchResponse<IndexResource> response = client.search(build, IndexResource.class);
 
-        var result = new SearchResponseDTO<IndexClass>();
+        var result = new SearchResponseDTO<IndexResource>();
         result.setResponseObjects(response.hits().hits().stream()
                 .map(Hit::source)
                 .toList()

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -174,46 +174,6 @@ class ClassMapperTest {
     }
 
     @Test
-    void testMapToIndexClass(){
-        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
-        Model m = ModelFactory.createDefaultModel();
-        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
-        assertNotNull(stream);
-        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
-
-        var indexClass = mapper.mapToIndexClass(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
-
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
-        assertEquals("test note fi", indexClass.getNote().get("fi"));
-        assertEquals(Status.VALID, indexClass.getStatus());
-        assertEquals("TestClass", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
-        assertEquals(1, indexClass.getLabel().size());
-        assertEquals("test label", indexClass.getLabel().get("fi"));
-    }
-
-    @Test
-    void testMapToIndexClassMinimal(){
-        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
-        Model m = ModelFactory.createDefaultModel();
-        var stream = getClass().getResourceAsStream("/models/test_datamodel_with_minimal_class.ttl");
-        assertNotNull(stream);
-        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
-
-        var indexClass = mapper.mapToIndexClass(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
-
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
-        assertEquals(Status.VALID, indexClass.getStatus());
-        assertEquals("TestClass", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
-        assertEquals(1, indexClass.getLabel().size());
-        assertEquals("test label", indexClass.getLabel().get("fi"));
-        assertNull(indexClass.getNote());
-    }
-
-    @Test
     void testMapToUpdateClass(){
         Model m = ModelFactory.createDefaultModel();
         var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @Import({
@@ -231,5 +233,45 @@ class ResourceMapperTest {
         assertEquals("https://www.example.com/ns/ext#SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+    }
+
+    @Test
+    void testMapToIndexResource(){
+        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/test_datamodel_with_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        var indexClass = mapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
+        assertEquals("test note fi", indexClass.getNote().get("fi"));
+        assertEquals(Status.VALID, indexClass.getStatus());
+        assertEquals("TestClass", indexClass.getIdentifier());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals(1, indexClass.getLabel().size());
+        assertEquals("test label", indexClass.getLabel().get("fi"));
+    }
+
+    @Test
+    void testMapToIndexResourceMinimal(){
+        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/models/test_datamodel_with_minimal_class.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+
+        var indexClass = mapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
+        assertEquals(Status.VALID, indexClass.getStatus());
+        assertEquals("TestClass", indexClass.getIdentifier());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals(1, indexClass.getLabel().size());
+        assertEquals("test label", indexClass.getLabel().get("fi"));
+        assertNull(indexClass.getNote());
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -2,7 +2,8 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.*;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexClass;
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
@@ -53,6 +54,9 @@ class ClassControllerTest {
     @MockBean
     private ClassMapper classMapper;
 
+    @MockBean
+    private ResourceMapper resourceMapper;
+
     @Autowired
     private ClassController classController;
 
@@ -75,7 +79,7 @@ class ClassControllerTest {
 
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
         when(classMapper.createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class))).thenReturn("test");
-        when(classMapper.mapToIndexClass(any(Model.class), anyString())).thenReturn(mock(IndexClass.class));
+        when(resourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(mock(IndexResource.class));
 
         this.mvc
                 .perform(put("/v2/class/test")
@@ -88,13 +92,13 @@ class ClassControllerTest {
         verify(this.jenaService).getDataModel(anyString());
         verify(this.classMapper)
                 .createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class));
-        verify(this.classMapper)
-                .mapToIndexClass(eq(mockModel), anyString());
+        verify(this.resourceMapper)
+                .mapToIndexResource(eq(mockModel), anyString());
         verifyNoMoreInteractions(this.classMapper);
         verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.jenaService);
         verify(this.openSearchIndexer)
-                .createClassToIndex(any(IndexClass.class));
+                .createResourceToIndex(any(IndexResource.class));
         verifyNoMoreInteractions(this.openSearchIndexer);
     }
 
@@ -108,7 +112,7 @@ class ClassControllerTest {
 
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
         when(classMapper.createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class))).thenReturn("test");
-        when(classMapper.mapToIndexClass(any(Model.class), anyString())).thenReturn(mock(IndexClass.class));
+        when(resourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(mock(IndexResource.class));
 
         this.mvc
                 .perform(put("/v2/class/test")
@@ -120,13 +124,13 @@ class ClassControllerTest {
         verify(jenaService).getDataModel(anyString());
         verify(this.classMapper)
                 .createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class));
-        verify(this.classMapper)
-                .mapToIndexClass(eq(mockModel), anyString());
+        verify(this.resourceMapper)
+                .mapToIndexResource(eq(mockModel), anyString());
         verifyNoMoreInteractions(this.classMapper);
         verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.jenaService);
         verify(this.openSearchIndexer)
-                .createClassToIndex(any(IndexClass.class));
+                .createResourceToIndex(any(IndexResource.class));
         verifyNoMoreInteractions(this.openSearchIndexer);
     }
 
@@ -192,7 +196,7 @@ class ClassControllerTest {
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
         when(mockModel.getResource(anyString())).thenReturn(mock(Resource.class));
         when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
-        when(classMapper.mapToIndexClass(any(Model.class), anyString())).thenReturn(mock(IndexClass.class));
+        when(resourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(mock(IndexResource.class));
 
         this.mvc
                 .perform(put("/v2/class/test/class")
@@ -206,13 +210,13 @@ class ClassControllerTest {
         verify(this.jenaService).getDataModel(anyString());
         verify(this.classMapper)
                 .mapToUpdateClass(any(Model.class), anyString(), any(Resource.class), any(ClassDTO.class));
-        verify(this.classMapper)
-                .mapToIndexClass(eq(mockModel), anyString());
+        verify(this.resourceMapper)
+                .mapToIndexResource(eq(mockModel), anyString());
         verifyNoMoreInteractions(this.classMapper);
         verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.jenaService);
         verify(this.openSearchIndexer)
-                .updateClassToIndex(any(IndexClass.class));
+                .updateResourceToIndex(any(IndexResource.class));
         verifyNoMoreInteractions(this.openSearchIndexer);
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
@@ -1,6 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.endpoint;
 
-import fi.vm.yti.datamodel.api.v2.opensearch.dto.ClassSearchRequest;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
@@ -61,12 +61,12 @@ class FrontendControllerTest {
     }
 
     @Test
-    void searchInternalClassesTest() throws Exception {
-        this.mvc.perform(get("/v2/frontend/searchInternalClasses")
+    void searchInternalResourcesTest() throws Exception {
+        this.mvc.perform(get("/v2/frontend/searchInternalResources")
                             .contentType("application/json")
-                        .content(EndpointUtils.convertObjectToJsonString(new ClassSearchRequest())))
+                        .content(EndpointUtils.convertObjectToJsonString(new ResourceSearchRequest())))
                         .andExpect(status().isOk());
-        verify(searchIndexService).searchInternalClasses(any(ClassSearchRequest.class), any(YtiUser.class));
+        verify(searchIndexService).searchInternalResources(any(ResourceSearchRequest.class), any(YtiUser.class));
 
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -74,6 +74,7 @@ class ResourceControllerTest {
         var mockModel = mock(Model.class);
 
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
+        when(mapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class))).thenReturn("test");
 
         this.mvc
                 .perform(put("/v2/resource/test")
@@ -89,10 +90,9 @@ class ResourceControllerTest {
         verify(this.mapper)
                 .mapToResource(anyString(), any(Model.class), any(ResourceDTO.class));
         verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
+        verify(this.mapper).mapToIndexResource(any(Model.class), anyString());
         verifyNoMoreInteractions(this.mapper);
-        verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.jenaService);
-        //TODO add indexing tests once added
     }
 
     @Test
@@ -105,6 +105,7 @@ class ResourceControllerTest {
         var mockModel = mock(Model.class);
 
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
+        when(mapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class))).thenReturn("test");
 
         this.mvc
                 .perform(put("/v2/resource/test")
@@ -117,9 +118,10 @@ class ResourceControllerTest {
         verify(this.jenaService).getDataModel(anyString());
         verify(this.mapper)
                 .mapToResource(anyString(), any(Model.class), any(ResourceDTO.class));
-        verifyNoMoreInteractions(this.mapper);
         verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
         verifyNoMoreInteractions(this.jenaService);
+        verify(this.mapper).mapToIndexResource(any(Model.class), anyString());
+        verifyNoMoreInteractions(this.mapper);
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
@@ -3,7 +3,7 @@ package fi.vm.yti.datamodel.api.v2.opensearch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.datamodel.api.index.OpenSearchConnector;
-import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
@@ -41,7 +41,7 @@ class OpenSearchIndexerTest {
     ModelMapper modelMapper;
 
     @MockBean
-    ClassMapper classMapper;
+    ResourceMapper resourceMapper;
 
     @MockBean
     OpenSearchClient client;
@@ -64,14 +64,14 @@ class OpenSearchIndexerTest {
     }
 
     @Test
-    void initClassIndexTest() throws IOException {
+    void initResourceIndexTest() throws IOException {
         var model = mock(Model.class);
         var subjects = mock(ResIterator.class);
         when(jenaService.constructWithQuery(any(Query.class))).thenReturn(model);
         when(model.listSubjects()).thenReturn(subjects);
         when(objectMapper.valueToTree(any())).thenReturn(mock(JsonNode.class));
 
-        openSearchIndexer.initClassIndex();
+        openSearchIndexer.initResourceIndex();
 
         verify(this.jenaService).constructWithQuery(any(Query.class));
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -1,9 +1,10 @@
 package fi.vm.yti.datamodel.api.v2.opensearch;
 
 import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
-import fi.vm.yti.datamodel.api.v2.opensearch.dto.ClassSearchRequest;
-import fi.vm.yti.datamodel.api.v2.opensearch.queries.ClassQueryFactory;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
+import fi.vm.yti.datamodel.api.v2.opensearch.queries.ResourceQueryFactory;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.QueryFactoryUtils;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -15,11 +16,11 @@ import java.util.Set;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 
-class ClassQueryFactoryTest {
+class ResourceQueryFactoryTest {
     
     @Test
     void createInternalClassQueryValues() throws Exception {
-        var request = new ClassSearchRequest();
+        var request = new ResourceSearchRequest();
         request.setQuery("test query");
         request.setGroups(Set.of("P11", "P1"));
         request.setFromAddedNamespaces("http://uri.suomi.fi/datamodel/ns/test");
@@ -27,13 +28,14 @@ class ClassQueryFactoryTest {
         request.setPageSize(100);
         request.setStatus(Set.of(Status.DRAFT, Status.VALID));
         request.setSortLang("en");
+        request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
         var groupNamespaces = Set.of("http://uri.suomi.fi/datamodel/ns/groupNs");
         var addedNamespaces = Set.of("http://uri.suomi.fi/datamodel/ns/addedNs");
 
         var allowedIncompleteDatamodels = Set.of("http://uri.suomi.fi/datamodel/ns/test");
 
-        var classQuery = ClassQueryFactory.createInternalClassQuery(request, addedNamespaces, groupNamespaces, allowedIncompleteDatamodels);
+        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, addedNamespaces, groupNamespaces, allowedIncompleteDatamodels);
 
         String expected = OpenSearchUtils.getJsonString("/es/classRequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(classQuery), JSONCompareMode.LENIENT);
@@ -44,9 +46,9 @@ class ClassQueryFactoryTest {
 
     @Test
     void createInternalClassQueryDefaults() {
-        var request = new ClassSearchRequest();
+        var request = new ResourceSearchRequest();
 
-        var classQuery = ClassQueryFactory.createInternalClassQuery(request, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
 
         assertEquals("Page from value not matching", QueryFactoryUtils.DEFAULT_PAGE_FROM, classQuery.from());
         assertEquals("Page size value not matching", QueryFactoryUtils.DEFAULT_PAGE_SIZE, classQuery.size());

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -19,6 +19,11 @@
         },
         {
           "terms": {
+            "resourceType": ["ATTRIBUTE", "ASSOCIATION"]
+          }
+        },
+        {
+          "terms": {
             "isDefinedBy": ["http://uri.suomi.fi/datamodel/ns/addedNs"]
           }
         },


### PR DESCRIPTION
Changelog:
- Map to index reource
  - Class uses this one as well
- Refactored `searchInternalClasses` to `searchInternalResources`
  - You can search all resources and limit with `resourceType`
- Reindexing takes in attributes and associations as wel now