### PR TITLE
YTI-2371 rename aws env property

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -24,7 +24,7 @@ public class TerminologyService {
      * Control which environment is used for resolving terminology uris.
      * Possible values: awsdev, awstest and awslocal. Resolve from prod if empty
      */
-    @Value("${awsEnv:}")
+    @Value("${env:}")
     private String awsEnv;
 
     private final WebClient.Builder webClientBuilder;


### PR DESCRIPTION
rename awsEnv to env because property with that name already exists in configuration