### PR TITLE
YTI-2493: limited datamodel searching

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/OpenSearchException.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/error/OpenSearchException.java
@@ -1,0 +1,15 @@
+package fi.vm.yti.datamodel.api.v2.endpoint.error;
+
+public class OpenSearchException extends RuntimeException{
+
+    private final String index;
+
+    public OpenSearchException(String message, String index){
+        super(message);
+        this.index = index;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -6,15 +6,24 @@ import java.util.Set;
 
 public class ResourceSearchRequest extends BaseSearchRequest{
 
-    private String fromAddedNamespaces;
+    private String limitToDataModel;
+    private boolean fromAddedNamespaces;
     private Set<String> groups;
     private Set<ResourceType> resourceTypes;
 
-    public String getFromAddedNamespaces() {
+    public String getLimitToDataModel() {
+        return limitToDataModel;
+    }
+
+    public void setLimitToDataModel(String limitToDataModel) {
+        this.limitToDataModel = limitToDataModel;
+    }
+
+    public boolean isFromAddedNamespaces() {
         return fromAddedNamespaces;
     }
 
-    public void setFromAddedNamespaces(String fromAddedNamespaces) {
+    public void setFromAddedNamespaces(boolean fromAddedNamespaces) {
         this.fromAddedNamespaces = fromAddedNamespaces;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
@@ -66,6 +66,14 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.badRequest().body(apiError);
     }
 
+    @ExceptionHandler(OpenSearchException.class)
+    protected  ResponseEntity<Object> handleOpenSearchException(OpenSearchException exception){
+        var apiError = new ApiGenericError(BAD_REQUEST);
+        apiError.setMessage(exception.getMessage());
+        apiError.setDetails("Index: " + exception.getIndex());
+        return ResponseEntity.badRequest().body(apiError);
+    }
+
     @ExceptionHandler(ResolvingException.class)
     protected  ResponseEntity<Object> handleMappingError(ResolvingException error){
         var apiError = new ApiGenericError(BAD_REQUEST);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -23,7 +23,8 @@ class ResourceQueryFactoryTest {
         var request = new ResourceSearchRequest();
         request.setQuery("test query");
         request.setGroups(Set.of("P11", "P1"));
-        request.setFromAddedNamespaces("http://uri.suomi.fi/datamodel/ns/test");
+        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setFromAddedNamespaces(true);
         request.setPageFrom(1);
         request.setPageSize(100);
         request.setStatus(Set.of(Status.DRAFT, Status.VALID));


### PR DESCRIPTION
Changelog:
- searching for internal resources can now be limited to a single datamodel
-  fromAddedNamespaces now a boolean and gets from limited datamodel
- Better exception handling for opensearch.

Note: There will be a separate PR for frontend for implementation of this in the UI