### PR TITLE
get resources from datamodel endpoint

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DCAP.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DCAP.java
@@ -13,4 +13,5 @@ public class DCAP {
 
     public static final Property preferredXMLNamespacePrefix = ResourceFactory.createProperty(URI, "preferredXMLNamespacePrefix");
     public static final Property preferredXMLNamespace = ResourceFactory.createProperty(URI, "preferredXMLNamespace");
+    public static final Property DCAP = ResourceFactory.createProperty(URI, "DCAP");
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelExpandDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelExpandDTO.java
@@ -2,7 +2,6 @@ package fi.vm.yti.datamodel.api.v2.dto;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 public class DataModelExpandDTO {
     private ModelType type;
@@ -11,11 +10,13 @@ public class DataModelExpandDTO {
     private Map<String, String> label = Map.of();
     private Map<String, String> description = Map.of();
     private Set<String> languages = Set.of();
-    private Set<UUID> organizations = Set.of();
-    private Set<String> groups = Set.of();
+    private Set<OrganizationDTO> organizations = Set.of();
+    private Set<ServiceCategoryDTO> groups = Set.of();
     private Set<String> internalNamespaces = Set.of();
     private Set<ExternalNamespaceDTO> externalNamespaces = Set.of();
     private Set<TerminologyDTO> terminologies = Set.of();
+    private String modified;
+    private String created;
 
     public ModelType getType() {
         return type;
@@ -65,19 +66,19 @@ public class DataModelExpandDTO {
         this.languages = languages;
     }
 
-    public Set<UUID> getOrganizations() {
+    public Set<OrganizationDTO> getOrganizations() {
         return organizations;
     }
 
-    public void setOrganizations(Set<UUID> organizations) {
+    public void setOrganizations(Set<OrganizationDTO> organizations) {
         this.organizations = organizations;
     }
 
-    public Set<String> getGroups() {
+    public Set<ServiceCategoryDTO> getGroups() {
         return groups;
     }
 
-    public void setGroups(Set<String> groups) {
+    public void setGroups(Set<ServiceCategoryDTO> groups) {
         this.groups = groups;
     }
 
@@ -103,5 +104,21 @@ public class DataModelExpandDTO {
 
     public void setTerminologies(Set<TerminologyDTO> terminologies) {
         this.terminologies = terminologies;
+    }
+
+    public String getModified() {
+        return modified;
+    }
+
+    public void setModified(String modified) {
+        this.modified = modified;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/OrganizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/OrganizationMapper.java
@@ -4,17 +4,18 @@ import fi.vm.yti.datamodel.api.v2.dto.GroupManagementOrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.Iow;
 
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.*;
 import static fi.vm.yti.datamodel.api.v2.mapper.MapperUtils.getUUID;
@@ -55,20 +56,17 @@ public class OrganizationMapper {
     }
 
     public static Set<OrganizationDTO> mapOrganizationsToDTO(Set<String> organizations, Model organizationModel) {
-        var result = new HashSet<OrganizationDTO>();
-        organizations.forEach(org -> {
+        return organizations.stream().map(org -> {
             var orgRes = organizationModel.getResource(org);
             var labels = localizedPropertyToMap(orgRes, SKOS.prefLabel);
             var id = getUUID(orgRes.getURI());
 
-            Statement stmt = orgRes.getProperty(Iow.parentOrganization);
-            UUID parentId = stmt != null ? getUUID(stmt.getObject().toString()) : null;
-
-            if (id != null) {
-                result.add(new OrganizationDTO(id.toString(), labels, parentId));
+            var parentId = getUUID(MapperUtils.propertyToString(orgRes, Iow.parentOrganization));
+            if(id == null){
+                throw new MappingError("Could not map organization");
             }
-        });
-        return result;
+            return new OrganizationDTO(id.toString(), labels, parentId);
+        }).collect(Collectors.toSet());
     }
 
     public static List<OrganizationDTO> mapToListOrganizationDTO(Model organizationModel) {
@@ -81,8 +79,7 @@ public class OrganizationMapper {
             var labels = localizedPropertyToMap(resource, SKOS.prefLabel);
             var id = getUUID(resource.getURI());
 
-            Statement stmt = resource.getProperty(Iow.parentOrganization);
-            UUID parentId = stmt != null ? getUUID(stmt.getObject().toString()) : null;
+            var parentId = getUUID(MapperUtils.propertyToString(resource, Iow.parentOrganization));
 
             if (id != null) {
                 result.add(new OrganizationDTO(id.toString(), labels, parentId));

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ServiceCategoryMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ServiceCategoryMapper.java
@@ -1,0 +1,45 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ServiceCategoryMapper {
+
+    private ServiceCategoryMapper(){
+        //static class
+    }
+
+    public static Set<ServiceCategoryDTO> mapServiceCategoriesToDTO(Set<String> ids, Model serviceCategories) {
+        return ids.stream().map(org -> {
+            var res = serviceCategories.getResource(org);
+            var labels = MapperUtils.localizedPropertyToMap(res, RDFS.label);
+            var identifier = MapperUtils.propertyToString(res, SKOS.notation);
+            if(identifier == null || labels.isEmpty()){
+                throw new MappingError("Could not map Service category");
+            }
+            return new ServiceCategoryDTO(res.getURI(), labels, identifier);
+        }).collect(Collectors.toSet());
+    }
+
+    public static List<ServiceCategoryDTO> mapToListServiceCategoryDTO(Model serviceCategoryModel) {
+        var iterator = serviceCategoryModel.listResourcesWithProperty(RDF.type, FOAF.Group);
+        List<ServiceCategoryDTO> result = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            var resource = iterator.next().asResource();
+            var labels = MapperUtils.localizedPropertyToMap(resource, RDFS.label);
+            var identifier = resource.getProperty(SKOS.notation).getObject().toString();
+            result.add(new ServiceCategoryDTO(resource.getURI(), labels, identifier));
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
@@ -5,8 +5,8 @@ import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.*;
 import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
-import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.mapper.OrganizationMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.ServiceCategoryMapper;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
@@ -16,12 +16,8 @@ import java.util.List;
 public class FrontendService {
 
     private final JenaService jenaService;
-    private final ModelMapper modelMapper;
-
-    public FrontendService(JenaService jenaService,
-                           ModelMapper modelMapper) {
+    public FrontendService(JenaService jenaService) {
         this.jenaService = jenaService;
-        this.modelMapper = modelMapper;
     }
 
     public List<OrganizationDTO> getOrganizations(@NotNull String sortLanguage, boolean includeChildOrganizations) {
@@ -37,7 +33,7 @@ public class FrontendService {
 
     public List<ServiceCategoryDTO> getServiceCategories(@NotNull String sortLanguage) {
         var serviceCategories = jenaService.getServiceCategories();
-        var dtos = modelMapper.mapToListServiceCategoryDTO(serviceCategories);
+        var dtos = ServiceCategoryMapper.mapToListServiceCategoryDTO(serviceCategories);
 
         sortByLabel(sortLanguage, dtos);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ServiceCategoryMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ServiceCategoryMapperTest.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.mapper.ServiceCategoryMapper;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ServiceCategoryMapperTest {
+
+    @Test
+    void testMapServiceCategoriesToDTO() {
+        var model = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/service-categories.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(model, stream, Lang.TURTLE);
+
+        var serviceCategories = ServiceCategoryMapper.mapToListServiceCategoryDTO(model);
+
+        assertEquals(3, serviceCategories.size());
+
+        var cat = serviceCategories.get(0);
+
+        assertEquals("P11", cat.getIdentifier());
+        assertEquals("http://urn.fi/URN:NBN:fi:au:ptvl:v1105", cat.getId());
+        assertEquals("Elinkeinot", cat.getLabel().get("fi"));
+        assertEquals("Industries", cat.getLabel().get("en"));
+        assertEquals("Näringar", cat.getLabel().get("sv"));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -30,6 +30,8 @@ import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = {
@@ -89,6 +91,7 @@ class ClassControllerTest {
 
         //Check that functions are called
         verify(this.jenaService, times(2)).doesResolvedNamespaceExist(anyString());
+        verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
         verify(this.jenaService).getDataModel(anyString());
         verify(this.classMapper)
                 .createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class));
@@ -121,6 +124,7 @@ class ClassControllerTest {
                 .andExpect(status().isOk());
 
         //Check that functions are called
+        verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
         verify(jenaService).getDataModel(anyString());
         verify(this.classMapper)
                 .createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class));
@@ -250,6 +254,32 @@ class ClassControllerTest {
         args.add(classDTO);
 
         return args.stream().map(Arguments::of);
+    }
+
+    @Test
+    void shouldGetClass() throws Exception {
+        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
+        when(jenaService.getDataModel(anyString())).thenReturn(mock(Model.class));
+
+        mvc.perform(get("/v2/class/test/class"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldResourceNotExistGet() throws Exception {
+        mvc.perform(get("/v2/class/test/class"))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldModelNotExistGet() throws Exception {
+        when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
+
+        mvc.perform(get("/v2/class/test/class"))
+                .andDo(print())
+                .andExpect(status().isNotFound());
     }
 
     private static ClassDTO createClassDTO(boolean update){


### PR DESCRIPTION
Changelog:
- Get datamodel endpoint returns more information from service categories and organizations and modified and created dates
  - ServiceCategoryDTO and OrganizationDTO already existed and were used on Frontend controller

**Simplified creation of class**
- model prefix is now modeluri
- checking if class exists is now done in controller instead
- removed jenaservice from mapper

**DTO mapping of class simplified**
- checking if class exists done in controller instead
- checking permissions done in controller
- removed all services from class mapper

**new service categories mapper**
- moved from model mapper
- static

**Better modelmapper**
- Maps orgs and servicecategories to dto with more information
- Created and modified dates
- Throws error now if type is not one of specified instead of defaulting

**Fixed and simplified some tests**