### PR TITLE
YTI-2498: DELETE endpoint

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/index/OpenSearchConnector.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/index/OpenSearchConnector.java
@@ -124,8 +124,8 @@ public class OpenSearchConnector {
         }
     }
 
-    public DeleteResponse removeFromIndex(String id,
-                                          String index) {
+    public void removeFromIndex(String index,
+                                          String id) {
         String encId = DataModelUtils.encode(id);
         try {
             final long startTime = System.currentTimeMillis();
@@ -134,12 +134,10 @@ public class OpenSearchConnector {
                     .id(encId)
                     .refresh(Refresh.WaitFor)
                     .build();
-            DeleteResponse resp = client.delete(req);
+            client.delete(req);
             logger.info("Removed {} from {} (took {} ms)", id, index, System.currentTimeMillis() - startTime);
-            return resp;
         } catch (IOException e) {
             logger.warn(e.getMessage(), e);
-            return null;
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -104,4 +104,22 @@ public class ClassController {
 
         return ClassMapper.mapToClassDTO(model, modelURI, classIdentifier, orgModel, hasRightToModel);
     }
+
+    @Operation(summary = "Delete a class from a data model")
+    @ApiResponse(responseCode = "200", description = "Class deleted successfully")
+    @DeleteMapping(value = "/{prefix}/{classIdentifier}")
+    public void deleteClass(@PathVariable String prefix, @PathVariable String classIdentifier){
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var classURI  = modelURI + "#" + classIdentifier;
+        if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
+            throw new ResourceNotFoundException(classURI);
+        }
+        var model = jenaService.getDataModel(modelURI);
+        if(model == null){
+            throw new ResourceNotFoundException(modelURI);
+        }
+        check(authorizationManager.hasRightToModel(prefix, model));
+        jenaService.deleteResource(classURI);
+        openSearchIndexer.deleteResourceFromIndex(classURI);
+    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -113,4 +113,22 @@ public class Datamodel {
         return !jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
     }
 
+    @Operation(summary = "Delete a model from fuseki")
+    @ApiResponse(responseCode = "200", description = "Model deleted successfully")
+    @DeleteMapping(value = "/{prefix}")
+    public void deleteModel(@PathVariable String prefix) {
+        var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        if(!jenaService.doesDataModelExist(modelUri)){
+            throw new ResourceNotFoundException(modelUri);
+        }
+        var model = jenaService.getDataModel(modelUri);
+        if(model == null){
+            throw new ResourceNotFoundException(modelUri);
+        }
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        jenaService.deleteDataModel(modelUri);
+        openSearchIndexer.deleteModelFromIndex(modelUri);
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -101,4 +101,23 @@ public class ResourceController {
         return ResourceMapper.mapToResourceInfoDTO(model, graphUri, resourceIdentifier, orgModel, hasRightToModel);
     }
 
+    @Operation(summary = "Delete a resource from a data model")
+    @ApiResponse(responseCode = "200", description = "Resource deleted successfully")
+    @DeleteMapping(value = "/{prefix}/{resourceIdentifier}")
+    public void deleteResource(@PathVariable String prefix, @PathVariable String resourceIdentifier){
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var resourceUri  = modelURI + "#" + resourceIdentifier;
+        if(!jenaService.doesResourceExistInGraph(modelURI , resourceUri)){
+            throw new ResourceNotFoundException(resourceUri);
+        }
+        var model = jenaService.getDataModel(modelURI);
+        if(model == null){
+            throw new ResourceNotFoundException(modelURI);
+        }
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        jenaService.deleteResource(resourceUri);
+        openSearchIndexer.deleteResourceFromIndex(resourceUri);
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -193,7 +193,8 @@ public class MapperUtils {
      */
     public static void addResourceRelationship(Set<String> owlImports, Set<String> dcTermsRequires, Resource resource, Property property, String resourceUri){
         var namespace = NodeFactory.createURI(resourceUri).getNameSpace().replace("#", "");
-        if(!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
+        var ownNamespace = resource.getNameSpace().replace("#", "");
+        if(!ownNamespace.equals(namespace) &&!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
             throw new MappingError("Resource namespace not in owl:imports or dcterms:requires");
         }
         resource.addProperty(property, resourceUri);

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -233,6 +233,7 @@ class ResourceMapperTest {
 
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
 
+        assertEquals(ResourceType.CLASS, indexClass.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
@@ -252,6 +253,7 @@ class ResourceMapperTest {
 
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
 
+        assertEquals(ResourceType.ATTRIBUTE, indexClass.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
@@ -271,6 +273,7 @@ class ResourceMapperTest {
 
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
 
+        assertEquals(ResourceType.ASSOCIATION, indexClass.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
@@ -290,6 +293,7 @@ class ResourceMapperTest {
 
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
 
+        assertEquals(ResourceType.CLASS, indexClass.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
@@ -309,6 +313,7 @@ class ResourceMapperTest {
 
         var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
 
+        assertEquals(ResourceType.ATTRIBUTE, indexResource.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
         assertEquals("TestAttribute", indexResource.getIdentifier());
@@ -328,6 +333,7 @@ class ResourceMapperTest {
 
         var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
 
+        assertEquals(ResourceType.ASSOCIATION, indexResource.getResourceType());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
         assertEquals("TestAssociation", indexResource.getIdentifier());


### PR DESCRIPTION
Changelog:
- new jena service functions for deletion
- new delete functions for deletion opensearch
- endpoints for model, class and resource for delete
- removed return value for index deletion
- better bulk response logging

Small bug fix:
You can add a resource relationship if the resource is in the same namespace as the class