### PR TITLE
YTI-2500 add temporary null check for creator user id

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
@@ -67,6 +67,9 @@ public class GroupManagementService {
     public Consumer<ResourceInfoBaseDTO> mapUser() {
         // TODO: fetch users and set them to cache
         return (var dto) -> {
+            if (dto.getCreator().getId() == null || dto.getModifier().getId() == null) {
+                return;
+            }
             var creator = userCache.getIfPresent(dto.getCreator().getId());
             var modifier = userCache.getIfPresent(dto.getModifier().getId());
             if (creator != null) {


### PR DESCRIPTION
Existing data models don't have creator information. Add this check until user migration has been implemented