### PR TITLE
YTI-2438 map visualization data for classes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PositionDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PositionDTO.java
@@ -1,0 +1,34 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class PositionDTO {
+    private Double x;
+    private Double y;
+
+    public PositionDTO(Double x, Double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public Double getX() {
+        return x;
+    }
+
+    public void setX(Double x) {
+        this.x = x;
+    }
+
+    public Double getY() {
+        return y;
+    }
+
+    public void setY(Double y) {
+        this.y = y;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationClassDTO.java
@@ -1,0 +1,71 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class VisualizationClassDTO {
+    private String identifier;
+    private Map<String, String> label = Map.of();
+    private Set<String> parentClasses = new HashSet<>();
+    private PositionDTO position = new PositionDTO(0.0, 0.0);
+    private List<VisualizationResourceDTO> attributes = List.of();
+    private List<VisualizationResourceDTO> associations = List.of();
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public PositionDTO getPosition() {
+        return position;
+    }
+
+    public void setPosition(PositionDTO position) {
+        this.position = position;
+    }
+
+    public List<VisualizationResourceDTO> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<VisualizationResourceDTO> attributes) {
+        this.attributes = attributes;
+    }
+
+    public List<VisualizationResourceDTO> getAssociations() {
+        return associations;
+    }
+
+    public void setAssociations(List<VisualizationResourceDTO> associations) {
+        this.associations = associations;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public Set<String> getParentClasses() {
+        return parentClasses;
+    }
+
+    public void setParentClasses(Set<String> parentClasses) {
+        this.parentClasses = parentClasses;
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationResourceDTO.java
@@ -1,0 +1,24 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Map;
+
+public class VisualizationResourceDTO {
+    private String identifier;
+    private Map<String, String> label;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
@@ -1,0 +1,40 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping("v2/visualization")
+@Tag(name = "Visualization" )
+public class VisualizationController {
+
+    private final JenaService jenaService;
+
+    public VisualizationController(JenaService jenaService) {
+        this.jenaService = jenaService;
+    }
+
+    @Operation(summary = "Get data for model visualization")
+    @ApiResponse(responseCode = "200", description = "Visualization data found for model")
+    @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)
+    public List<VisualizationClassDTO> getVisualizationData(@PathVariable String prefix) {
+        var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = jenaService.getDataModel(graph);
+        var positions = ModelFactory.createDefaultModel();
+        return VisualizationMapper.mapVisualizationData(prefix, model, positions);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +36,11 @@ public class VisualizationController {
         var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = jenaService.getDataModel(graph);
         var positions = ModelFactory.createDefaultModel();
+
+        if(model == null) {
+            throw new ResourceNotFoundException(graph);
+        }
+
         return VisualizationMapper.mapVisualizationData(prefix, model, positions);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -1,0 +1,99 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.DCAP;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.PositionDTO;
+import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.SimpleSelector;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class VisualizationMapper {
+    private static final Logger LOG = LoggerFactory.getLogger(VisualizationMapper.class);
+    private VisualizationMapper() {
+    }
+    public static List<VisualizationClassDTO> mapVisualizationData(String prefix, Model model, Model positions) {
+        var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        LOG.info("Map visualization data for {}", graph);
+        var classIds = model.listStatements(
+                new SimpleSelector(null, RDF.type, OWL.Class));
+
+        HashMap<String, String> namespaces = getNamespaces(model, graph);
+
+        var result = new ArrayList<VisualizationClassDTO>();
+        while (classIds.hasNext()) {
+            String classId = classIds.next().getSubject().getURI();
+            var resource = model.getResource(classId);
+            var classDTO = new VisualizationClassDTO();
+            classDTO.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+            classDTO.setIdentifier(resource.getProperty(DCTerms.identifier).getString());
+            classDTO.setParentClasses(getParentClasses(resource, namespaces));
+
+            // TODO save and map positions
+            var positionResource = positions.getResource(classId);
+            if (positionResource == null) {
+                classDTO.setPosition(new PositionDTO(0.0, 0.0));
+            }
+            result.add(classDTO);
+        }
+
+        return result;
+    }
+
+    /**
+     * Map external and internal namespaces and prefixes
+     * @param model model
+     * @param graph graph
+     */
+    private static HashMap<String, String> getNamespaces(Model model, String graph) {
+        var namespaces = new HashMap<String, String>();
+        var modelResource = model.getResource(graph);
+        Arrays.asList(OWL.imports, DCTerms.requires)
+                .forEach(prop -> modelResource.listProperties(prop).toList().forEach(ns -> {
+                    var uri = ns.getObject().toString();
+                    if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
+                        namespaces.put(uri, uri.replace(ModelConstants.SUOMI_FI_NAMESPACE, ""));
+                    } else {
+                        namespaces.put(uri, model.getResource(uri).getProperty(DCAP.preferredXMLNamespacePrefix).getString());
+                    }
+                }));
+        return namespaces;
+    }
+
+    @NotNull
+    private static HashSet<String> getParentClasses(Resource resource, Map<String, String> namespaceMap) {
+        var parentClasses = new HashSet<String>();
+        var subClassOf = resource.listProperties(RDFS.subClassOf).toList();
+        subClassOf.forEach(parent -> {
+            String s = parent.getObject().toString();
+            // skip default parent class (owl#Thing)
+            if ("http://www.w3.org/2002/07/owl#Thing".equals(s)) {
+                return;
+            }
+
+            var parts = s.split("#");
+            if (parts.length != 2) {
+                return;
+            }
+
+            var extPrefix = namespaceMap.get(parts[0]);
+            if (extPrefix != null) {
+                // parent class in the external namespace or other model in Interoperability platform
+                parentClasses.add(extPrefix + ":" + parts[1]);
+            } else {
+                // parent class in the same model
+                parentClasses.add(parts[1]);
+            }
+        });
+        return parentClasses;
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
@@ -1,0 +1,48 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VisualizationDataMapperTest {
+
+    @Test
+    void mapVisualizationData() {
+        Model model = ModelFactory.createDefaultModel();
+        Model positions = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/models/test_datamodel_visualization.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(model, stream, RDFLanguages.TURTLE);
+
+        var result = VisualizationMapper.mapVisualizationData("test", model, positions);
+
+        assertEquals(3, result.size());
+
+        var class1 = result.stream().filter(r -> r.getIdentifier().equals("testclass1"))
+                .findFirst();
+        assertTrue(class1.isPresent());
+
+        var class2 = result.stream().filter(r -> r.getIdentifier().equals("testclass2"))
+                .findFirst();
+        assertTrue(class2.isPresent());
+
+        var class3 = result.stream().filter(r -> r.getIdentifier().equals("testclass3"))
+                .findFirst();
+        assertTrue(class3.isPresent());
+
+        assertEquals("Label 1", class1.get().getLabel().get("fi"));
+        assertEquals("testmodel:TestClass", class1.get().getParentClasses().iterator().next());
+
+        var parent2 = class2.get().getParentClasses().iterator().next();
+        assertEquals("testclass1", parent2);
+
+        var parent3 = class3.get().getParentClasses().iterator().next();
+        assertEquals("ext:ExternalClass", parent3);
+
+    }
+}

--- a/src/test/resources/models/test_datamodel_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_visualization.ttl
@@ -1,0 +1,37 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+<http://uri.suomi.fi/datamodel/ns/test>
+        a                     dcap:DCAP ;
+        dcterms:requires      "https://www.example.com/ns/external" ;
+        owl:imports           "http://uri.suomi.fi/datamodel/ns/testmodel" .
+
+test:TestClass1  rdf:type     owl:Class ;
+        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcterms:identifier   "testclass1"^^xsd:NCName ;
+        rdfs:label           "Label 1"@fi ;
+        rdfs:subClassOf      "http://uri.suomi.fi/datamodel/ns/testmodel#TestClass" .
+
+test:TestClass2  rdf:type     owl:Class ;
+        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcterms:identifier   "testclass2"^^xsd:NCName ;
+        rdfs:label           "Label 2"@fi ;
+        rdfs:subClassOf      "http://uri.suomi.fi/datamodel/ns/test#testclass1" .
+
+test:TestClass3  rdf:type     owl:Class ;
+        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcterms:identifier   "testclass3"^^xsd:NCName ;
+        rdfs:label           "Label 3"@fi ;
+        rdfs:subClassOf      "https://www.example.com/ns/external#ExternalClass" .
+
+<https://www.example.com/ns/external>
+        dcterms:type                        rdfs:Resource ;
+        rdfs:label                          "External namespace 1"@fi;
+        dcap:preferredXMLNamespacePrefix    "ext" .


### PR DESCRIPTION
- DTO classes for visualization data
- Visualization data mapper, for now only mapping for classes
- parent classes (based on subClassOf property) are mapped with prefix e.g. test:ClassName if in external model. If the parent class is in the same model, only class identifier is added to the list
- Position mapping will be implemented later