### PR TITLE
YTI-2541: get class resources endpoint

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,6 +17,8 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
     private String uri;
     private Set<OrganizationDTO> contributor;
     private String contact;
+    private List<SimpleResourceDTO> attribute;
+    private List<SimpleResourceDTO> association;
 
     public Map<String, String> getLabel() {
         return label;
@@ -103,5 +106,21 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
 
     public void setContact(String contact) {
         this.contact = contact;
+    }
+
+    public List<SimpleResourceDTO> getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(List<SimpleResourceDTO> attribute) {
+        this.attribute = attribute;
+    }
+
+    public List<SimpleResourceDTO> getAssociation() {
+        return association;
+    }
+
+    public void setAssociation(List<SimpleResourceDTO> association) {
+        this.association = association;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
@@ -1,0 +1,43 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Map;
+
+public class SimpleResourceDTO {
+
+    private String uri;
+    private Map<String, String> label;
+    private String identifier;
+    private String modelId;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public void setModelId(String namespace) {
+        this.modelId = namespace;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -30,6 +30,10 @@ public class MapperUtils {
         }
     }
 
+    public static String getModelIdFromNamespace(String namespace){
+        return namespace.substring(namespace.lastIndexOf("/") + 1);
+    }
+
     /**
      * Localized property to Map of (language, value)
      * @param resource Resource to get property from

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -5,6 +5,7 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.JenaException;
 
 import java.util.*;
@@ -170,6 +171,22 @@ public class MapperUtils {
     }
 
     /**
+     * Update Uri property
+     * If string is empty|blank value is removed
+     * @param resource Resource
+     * @param property Property
+     * @param value Value
+     */
+    public static void updateUriProperty(Resource resource, Property property, String value){
+        if(value != null){
+            resource.removeAll(property);
+            if(!value.isBlank()){
+                resource.addProperty(property, ResourceFactory.createResource(value));
+            }
+        }
+    }
+
+    /**
      * Adds an optional string property
      * This has a null check, so it does not need to be separately added
      * @param resource Resource
@@ -179,6 +196,12 @@ public class MapperUtils {
     public static void addOptionalStringProperty(Resource resource, Property property, String value){
         if(value != null && !value.isBlank()){
             resource.addProperty(property, value);
+        }
+    }
+
+    public static void addOptionalUriProperty(Resource resource, Property property, String value){
+        if(value != null && !value.isBlank()){
+            resource.addProperty(property, ResourceFactory.createResource(value));
         }
     }
 
@@ -197,7 +220,7 @@ public class MapperUtils {
         if(!ownNamespace.equals(namespace) &&!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
             throw new MappingError("Resource namespace not in owl:imports or dcterms:requires");
         }
-        resource.addProperty(property, resourceUri);
+        resource.addProperty(property, ResourceFactory.createResource(resourceUri));
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -3,16 +3,10 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
-import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
 import fi.vm.yti.security.YtiUser;
-import org.apache.jena.arq.querybuilder.ConstructBuilder;
-import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.*;
 
@@ -207,81 +201,6 @@ public class ResourceMapper {
 
         dto.setDomain(MapperUtils.propertyToString(resourceResource, RDFS.domain));
         dto.setRange(MapperUtils.propertyToString(resourceResource, RDFS.range));
-        return dto;
-    }
-
-    public static Query buildDomainAndRangeResourceQuery(String classUri){
-        var resourceName = "?resource";
-        var isDefinedBy = "?isDefinedBy";
-        var constructBuilder = new ConstructBuilder().addPrefixes(ModelConstants.PREFIXES);
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDF.type, "?type");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.label, "?label");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, OWL.versionInfo, "?versionInfo");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.modified, "?modified");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.created, "?created");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, Iow.modifier, "?modifier");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, Iow.creator, "?creator");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.isDefinedBy, isDefinedBy);
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, RDFS.subPropertyOf, "?subProperty");
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, OWL.equivalentProperty, "?eqProperty");
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, SKOS.note, "?note");
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, SKOS.editorialNote, "?editorialNote");
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, DCTerms.subject, "?subject");
-        var uri = NodeFactory.createURI(classUri);
-        var domainQuery = new WhereBuilder().addWhere(resourceName, RDFS.domain, uri)
-                .addWhere(resourceName, RDFS.domain, "?domain");
-        var rangeQuery = new WhereBuilder().addWhere(resourceName, RDFS.range, uri)
-                .addWhere(resourceName, RDFS.range, "?range");
-        constructBuilder.addWhere(domainQuery.addUnion(rangeQuery))
-                .addConstruct(resourceName, RDFS.range, "?range")
-                .addConstruct(resourceName, RDFS.domain, "?domain")
-                .addConstruct(resourceName, DCTerms.contributor, "?contributor")
-                .addWhere(isDefinedBy, DCTerms.contributor, "?contributor")
-                .addConstruct(resourceName, Iow.contact, "?contact")
-                .addOptional(isDefinedBy, Iow.contact, "?contact");
-        return constructBuilder.build();
-    }
-
-
-    public static ResourceInfoDTO mapToResourceInfoDtoFromConstruct(Resource resource, boolean hasRightToModel, Consumer<ResourceInfoBaseDTO> userMapper, Model orgModel){
-        var dto = new ResourceInfoDTO();
-        var type = resource.getProperty(RDF.type).getResource();
-        if(type.equals(OWL.ObjectProperty)){
-            dto.setType(ResourceType.ASSOCIATION);
-        }else if(type.equals(OWL.DatatypeProperty)){
-            dto.setType(ResourceType.ATTRIBUTE);
-        }else{
-            throw new MappingError("Unsupported rdf:type");
-        }
-        dto.setUri(resource.getURI());
-        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
-        var status = Status.valueOf(resource.getProperty(OWL.versionInfo).getObject().toString().toUpperCase());
-        dto.setStatus(status);
-        dto.setSubResourceOf(MapperUtils.arrayPropertyToSet(resource, RDFS.subPropertyOf));
-        dto.setEquivalentResource(MapperUtils.arrayPropertyToSet(resource, OWL.equivalentProperty));
-        dto.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
-        dto.setIdentifier(resource.getLocalName());
-        dto.setNote(MapperUtils.localizedPropertyToMap(resource, SKOS.note));
-        if (hasRightToModel) {
-            dto.setEditorialNote(MapperUtils.propertyToString(resource, SKOS.editorialNote));
-        }
-        var created = resource.getProperty(DCTerms.created).getLiteral().getString();
-        var modified = resource.getProperty(DCTerms.modified).getLiteral().getString();
-        dto.setCreated(created);
-        dto.setModified(modified);
-        dto.setCreator(new UserDTO(MapperUtils.propertyToString(resource, Iow.creator)));
-        dto.setModifier(new UserDTO(MapperUtils.propertyToString(resource, Iow.modifier)));
-        if (userMapper != null) {
-            userMapper.accept(dto);
-        }
-        dto.setDomain(MapperUtils.propertyToString(resource, RDFS.domain));
-        dto.setRange(MapperUtils.propertyToString(resource, RDFS.range));
-
-        //these are datamodel specific values, but we have pulled them into the resource using a construct query
-        dto.setContact(MapperUtils.propertyToString(resource, Iow.contact));
-        var contributors = MapperUtils.arrayPropertyToSet(resource, DCTerms.contributor);
-        dto.setContributor(OrganizationMapper.mapOrganizationsToDTO(contributors, orgModel));
-
         return dto;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -3,10 +3,16 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
+import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
 import fi.vm.yti.security.YtiUser;
+import org.apache.jena.arq.querybuilder.ConstructBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.*;
 
@@ -29,10 +35,10 @@ public class ResourceMapper {
                 .addProperty(OWL.versionInfo, dto.getStatus().name())
                 .addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(creationDate))
                 .addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(creationDate))
-                .addProperty(RDFS.isDefinedBy, graphUri)
                 .addProperty(Iow.creator, user.getId().toString())
                 .addProperty(Iow.modifier, user.getId().toString());
 
+        resourceResource.addProperty(RDFS.isDefinedBy, ResourceFactory.createResource(graphUri));
         resourceResource.addProperty(DCTerms.identifier, ResourceFactory.createTypedLiteral(dto.getIdentifier(), XSDDatatype.XSDNCName));
         //Labels
         var modelResource = model.getResource(graphUri);
@@ -41,7 +47,7 @@ public class ResourceMapper {
         //Note
         MapperUtils.addLocalizedProperty(langs, dto.getNote(), resourceResource, SKOS.note, model);
         MapperUtils.addOptionalStringProperty(resourceResource, SKOS.editorialNote, dto.getEditorialNote());
-        MapperUtils.addOptionalStringProperty(resourceResource, DCTerms.subject, dto.getSubject());
+        MapperUtils.addOptionalUriProperty(resourceResource, DCTerms.subject, dto.getSubject());
 
         var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
         var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
@@ -60,10 +66,10 @@ public class ResourceMapper {
             dto.getSubResourceOf().forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, resourceResource, RDFS.subPropertyOf, sub));
         }
 
-        MapperUtils.addOptionalStringProperty(resourceResource, RDFS.domain, dto.getDomain());
-        MapperUtils.addOptionalStringProperty(resourceResource, RDFS.range, dto.getRange());
+        MapperUtils.addOptionalUriProperty(resourceResource, RDFS.domain, dto.getDomain());
+        MapperUtils.addOptionalUriProperty(resourceResource, RDFS.range, dto.getRange());
 
-        modelResource.addProperty(DCTerms.hasPart, resourceUri);
+        modelResource.addProperty(DCTerms.hasPart, ResourceFactory.createResource(resourceUri));
         return resourceUri;
     }
 
@@ -81,7 +87,7 @@ public class ResourceMapper {
         MapperUtils.updateLocalizedProperty(languages, dto.getLabel(), resource, RDFS.label, model);
         MapperUtils.updateLocalizedProperty(languages, dto.getNote(), resource, SKOS.note, model);
         MapperUtils.updateStringProperty(resource, SKOS.editorialNote, dto.getEditorialNote());
-        MapperUtils.updateStringProperty(resource, DCTerms.subject, dto.getSubject());
+        MapperUtils.updateUriProperty(resource, DCTerms.subject, dto.getSubject());
 
         var status = dto.getStatus();
         if (status != null) {
@@ -111,8 +117,8 @@ public class ResourceMapper {
             }
         }
 
-        MapperUtils.updateStringProperty(resource, RDFS.domain, dto.getDomain());
-        MapperUtils.updateStringProperty(resource, RDFS.range, dto.getRange());
+        MapperUtils.updateUriProperty(resource, RDFS.domain, dto.getDomain());
+        MapperUtils.updateUriProperty(resource, RDFS.range, dto.getRange());
 
         resource.removeAll(DCTerms.modified);
         resource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(updateDate));
@@ -201,6 +207,81 @@ public class ResourceMapper {
 
         dto.setDomain(MapperUtils.propertyToString(resourceResource, RDFS.domain));
         dto.setRange(MapperUtils.propertyToString(resourceResource, RDFS.range));
+        return dto;
+    }
+
+    public static Query buildDomainAndRangeResourceQuery(String classUri){
+        var resourceName = "?resource";
+        var isDefinedBy = "?isDefinedBy";
+        var constructBuilder = new ConstructBuilder().addPrefixes(ModelConstants.PREFIXES);
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDF.type, "?type");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.label, "?label");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, OWL.versionInfo, "?versionInfo");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.modified, "?modified");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.created, "?created");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, Iow.modifier, "?modifier");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, Iow.creator, "?creator");
+        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.isDefinedBy, isDefinedBy);
+        SparqlUtils.addConstructOptional(resourceName, constructBuilder, RDFS.subPropertyOf, "?subProperty");
+        SparqlUtils.addConstructOptional(resourceName, constructBuilder, OWL.equivalentProperty, "?eqProperty");
+        SparqlUtils.addConstructOptional(resourceName, constructBuilder, SKOS.note, "?note");
+        SparqlUtils.addConstructOptional(resourceName, constructBuilder, SKOS.editorialNote, "?editorialNote");
+        SparqlUtils.addConstructOptional(resourceName, constructBuilder, DCTerms.subject, "?subject");
+        var uri = NodeFactory.createURI(classUri);
+        var domainQuery = new WhereBuilder().addWhere(resourceName, RDFS.domain, uri)
+                .addWhere(resourceName, RDFS.domain, "?domain");
+        var rangeQuery = new WhereBuilder().addWhere(resourceName, RDFS.range, uri)
+                .addWhere(resourceName, RDFS.range, "?range");
+        constructBuilder.addWhere(domainQuery.addUnion(rangeQuery))
+                .addConstruct(resourceName, RDFS.range, "?range")
+                .addConstruct(resourceName, RDFS.domain, "?domain")
+                .addConstruct(resourceName, DCTerms.contributor, "?contributor")
+                .addWhere(isDefinedBy, DCTerms.contributor, "?contributor")
+                .addConstruct(resourceName, Iow.contact, "?contact")
+                .addOptional(isDefinedBy, Iow.contact, "?contact");
+        return constructBuilder.build();
+    }
+
+
+    public static ResourceInfoDTO mapToResourceInfoDtoFromConstruct(Resource resource, boolean hasRightToModel, Consumer<ResourceInfoBaseDTO> userMapper, Model orgModel){
+        var dto = new ResourceInfoDTO();
+        var type = resource.getProperty(RDF.type).getResource();
+        if(type.equals(OWL.ObjectProperty)){
+            dto.setType(ResourceType.ASSOCIATION);
+        }else if(type.equals(OWL.DatatypeProperty)){
+            dto.setType(ResourceType.ATTRIBUTE);
+        }else{
+            throw new MappingError("Unsupported rdf:type");
+        }
+        dto.setUri(resource.getURI());
+        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+        var status = Status.valueOf(resource.getProperty(OWL.versionInfo).getObject().toString().toUpperCase());
+        dto.setStatus(status);
+        dto.setSubResourceOf(MapperUtils.arrayPropertyToSet(resource, RDFS.subPropertyOf));
+        dto.setEquivalentResource(MapperUtils.arrayPropertyToSet(resource, OWL.equivalentProperty));
+        dto.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
+        dto.setIdentifier(resource.getLocalName());
+        dto.setNote(MapperUtils.localizedPropertyToMap(resource, SKOS.note));
+        if (hasRightToModel) {
+            dto.setEditorialNote(MapperUtils.propertyToString(resource, SKOS.editorialNote));
+        }
+        var created = resource.getProperty(DCTerms.created).getLiteral().getString();
+        var modified = resource.getProperty(DCTerms.modified).getLiteral().getString();
+        dto.setCreated(created);
+        dto.setModified(modified);
+        dto.setCreator(new UserDTO(MapperUtils.propertyToString(resource, Iow.creator)));
+        dto.setModifier(new UserDTO(MapperUtils.propertyToString(resource, Iow.modifier)));
+        if (userMapper != null) {
+            userMapper.accept(dto);
+        }
+        dto.setDomain(MapperUtils.propertyToString(resource, RDFS.domain));
+        dto.setRange(MapperUtils.propertyToString(resource, RDFS.range));
+
+        //these are datamodel specific values, but we have pulled them into the resource using a construct query
+        dto.setContact(MapperUtils.propertyToString(resource, Iow.contact));
+        var contributors = MapperUtils.arrayPropertyToSet(resource, DCTerms.contributor);
+        dto.setContributor(OrganizationMapper.mapOrganizationsToDTO(contributors, orgModel));
+
         return dto;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SparqlUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SparqlUtils.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.datamodel.api.v2.utils;
+
+import org.apache.jena.arq.querybuilder.ConstructBuilder;
+import org.apache.jena.rdf.model.Property;
+
+public class SparqlUtils {
+
+
+    private SparqlUtils(){
+        //Util class
+    }
+
+    public static void addConstructProperty(String graphVariable, ConstructBuilder builder, Property property, String propertyName) {
+        builder.addConstruct(graphVariable, property, propertyName)
+                .addWhere(graphVariable, property, propertyName);
+    }
+
+    public static void addConstructOptional(String graphVariable, ConstructBuilder builder, Property property, String propertyName) {
+        builder.addConstruct(graphVariable, property, propertyName)
+                .addOptional(graphVariable, property, propertyName);
+    }
+}
+

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -148,7 +148,7 @@ public class DataModelValidator extends BaseValidator implements
     private void checkOrganizations(ConstraintValidatorContext context, DataModelDTO dataModel){
         var organizations = dataModel.getOrganizations();
         var existingOrgs = jenaService.getOrganizations();
-        if(organizations == null || organizations.isEmpty()){
+        if(!updateModel && (organizations == null || organizations.isEmpty())){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "organization");
             return;
         }
@@ -168,7 +168,7 @@ public class DataModelValidator extends BaseValidator implements
     private void checkGroups(ConstraintValidatorContext context, DataModelDTO dataModel){
         var groups = dataModel.getGroups();
         var existingGroups = jenaService.getServiceCategories();
-        if(groups == null || groups.isEmpty()){
+        if(!updateModel && (groups == null || groups.isEmpty())){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "groups");
             return;
         }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -57,7 +58,7 @@ class ResourceMapperTest {
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.ObjectProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -111,7 +112,7 @@ class ResourceMapperTest {
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.ObjectProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -160,7 +161,7 @@ class ResourceMapperTest {
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.DatatypeProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -212,7 +213,7 @@ class ResourceMapperTest {
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.DatatypeProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -564,7 +565,7 @@ class ResourceMapperTest {
         assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -618,7 +619,7 @@ class ResourceMapperTest {
         assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -678,7 +679,37 @@ class ResourceMapperTest {
         RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
 
         assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestClass", new ResourceDTO(), EndpointUtils.mockUser));
+    }
 
+    @Test
+    void mapFromConstructQuery(){
+        Model m = ModelFactory.createDefaultModel();
+        var stream = getClass().getResourceAsStream("/models/test_resource_query_model.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
+        var list = new ArrayList<ResourceInfoDTO>();
+        m.listSubjects().forEach(next -> {
+            var dto = ResourceMapper.mapToResourceInfoDtoFromConstruct(next, false, null, getOrgModel());
+            list.add(dto);
+        });
+
+        assertEquals(1, list.size());
+        var dto = list.get(0);
+        assertEquals(ResourceType.ATTRIBUTE, dto.getType());
+        assertEquals(1, dto.getLabel().size());
+        assertEquals("test", dto.getLabel().get("fi"));
+        assertNull(dto.getEditorialNote());
+        assertEquals(Status.DRAFT, dto.getStatus());
+        assertEquals("http://www.w3.org/2002/07/owl#topDataProperty", dto.getSubResourceOf().stream().findFirst().orElse(null));
+        assertNull(dto.getSubject());
+        assertEquals("rangetest2", dto.getIdentifier());
+        assertEquals(1, dto.getNote().size());
+        assertEquals("2023-04-06T05:45:48.662Z", dto.getModified());
+        assertEquals("2023-04-06T05:45:48.662Z", dto.getCreated());
+        assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
+        assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#rangetest2", dto.getUri());
+        assertEquals("local@localhost", dto.getContact());
     }
 
     private Model getOrgModel(){

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -681,37 +681,6 @@ class ResourceMapperTest {
         assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestClass", new ResourceDTO(), EndpointUtils.mockUser));
     }
 
-    @Test
-    void mapFromConstructQuery(){
-        Model m = ModelFactory.createDefaultModel();
-        var stream = getClass().getResourceAsStream("/models/test_resource_query_model.ttl");
-        assertNotNull(stream);
-        RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
-        var list = new ArrayList<ResourceInfoDTO>();
-        m.listSubjects().forEach(next -> {
-            var dto = ResourceMapper.mapToResourceInfoDtoFromConstruct(next, false, null, getOrgModel());
-            list.add(dto);
-        });
-
-        assertEquals(1, list.size());
-        var dto = list.get(0);
-        assertEquals(ResourceType.ATTRIBUTE, dto.getType());
-        assertEquals(1, dto.getLabel().size());
-        assertEquals("test", dto.getLabel().get("fi"));
-        assertNull(dto.getEditorialNote());
-        assertEquals(Status.DRAFT, dto.getStatus());
-        assertEquals("http://www.w3.org/2002/07/owl#topDataProperty", dto.getSubResourceOf().stream().findFirst().orElse(null));
-        assertNull(dto.getSubject());
-        assertEquals("rangetest2", dto.getIdentifier());
-        assertEquals(1, dto.getNote().size());
-        assertEquals("2023-04-06T05:45:48.662Z", dto.getModified());
-        assertEquals("2023-04-06T05:45:48.662Z", dto.getCreated());
-        assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
-        assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#rangetest2", dto.getUri());
-        assertEquals("local@localhost", dto.getContact());
-    }
-
     private Model getOrgModel(){
         var model = ModelFactory.createDefaultModel();
               model.createResource("urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -13,6 +13,7 @@ import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.YtiUser;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -342,6 +343,19 @@ class ClassControllerTest {
         verifyNoMoreInteractions(jenaService);
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verifyNoInteractions(openSearchIndexer);
+    }
+
+    @Test
+    void shouldListClassResources() throws Exception {
+        when(jenaService.constructWithQuery(any(Query.class))).thenReturn(ModelFactory.createDefaultModel());
+
+        mvc.perform(get("/v2/class/test/class/resources"))
+                .andExpect(status().isOk());
+
+        verify(jenaService).constructWithQuery(any(Query.class));
+        verify(jenaService).getOrganizations();
+
+        verifyNoMoreInteractions(jenaService);
     }
 
     private static ClassDTO createClassDTO(boolean update){

--- a/src/test/resources/models/test_resource_query_model.ttl
+++ b/src/test/resources/models/test_resource_query_model.ttl
@@ -1,0 +1,24 @@
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix dcap:  <http://purl.org/ws-mmi-dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix dcterm: <http://purl.org/dc/terms/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://uri.suomi.fi/datamodel/ns/test#rangetest2>
+        a                    owl:DatatypeProperty ;
+        rdfs:label           "test"@fi ;
+        rdfs:range           <http://uri.suomi.fi/datamodel/ns/testkirj#NewNewId> ;
+        rdfs:subPropertyOf   owl:topDataProperty ;
+        dcterms:contributor  <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+        dcterms:created      "2023-04-06T05:45:48.662Z"^^xsd:dateTime ;
+        dcterms:modified     "2023-04-06T05:45:48.662Z"^^xsd:dateTime ;
+        iow:contact          "local@localhost" ;
+        iow:creator          "9c872f32-6c45-4108-a443-bb2b0dad216d" ;
+        iow:modifier         "9c872f32-6c45-4108-a443-bb2b0dad216d" ;
+        owl:versionInfo      "DRAFT" ;
+        skos:editorialNote   "editorial note" ;
+        skos:note            "note"@fi .


### PR DESCRIPTION
Changelog:
- Added simpleResource information to class GET endpoint
- moved some functions to SparqlUtils
- Fixed some validation for update allowing them to be null New map from construct
- New construct query for domain and range
- all linked resources in attributes and associations are now saved in fuseki as uris instead of plaintext
```json
	"attribute": [
		{
			"uri": "http://uri.suomi.fi/datamodel/ns/example#attribute4",
			"label": {
				"fi": "example"
			},
			"identifier": "attribute4",
			"modelId": "example"
		},
	],
	"association": []
```