### PR TITLE
YTI-2506 Add concept to resources

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
@@ -11,7 +11,7 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
     private Status status;
     private Set<String> equivalentClass;
     private Set<String> subClassOf;
-    private String subject;
+    private ConceptDTO subject;
     private String identifier;
     private Map<String, String> note;
     private String uri;
@@ -60,11 +60,11 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
         this.subClassOf = subClassOf;
     }
 
-    public String getSubject() {
+    public ConceptDTO getSubject() {
         return subject;
     }
 
-    public void setSubject(String subject) {
+    public void setSubject(ConceptDTO subject) {
         this.subject = subject;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ConceptDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ConceptDTO.java
@@ -6,8 +6,7 @@ public class ConceptDTO {
     private String conceptURI;
     private Map<String, String> label = Map.of();
     private Map<String, String> definition = Map.of();
-    private String terminologyURI;
-    private Map<String, String> terminologyLabel = Map.of();
+    private TerminologyDTO terminology;
     private Status status;
 
     public Map<String, String> getLabel() {
@@ -34,14 +33,6 @@ public class ConceptDTO {
         this.conceptURI = conceptURI;
     }
 
-    public String getTerminologyURI() {
-        return terminologyURI;
-    }
-
-    public void setTerminologyURI(String terminologyURI) {
-        this.terminologyURI = terminologyURI;
-    }
-
     public Status getStatus() {
         return status;
     }
@@ -50,10 +41,11 @@ public class ConceptDTO {
         this.status = status;
     }
 
-    public Map<String, String> getTerminologyLabel() {
-        return terminologyLabel;
+    public TerminologyDTO getTerminology() {
+        return terminology;
     }
-    public void setTerminologyLabel(Map<String, String> terminologyLabel) {
-        this.terminologyLabel = terminologyLabel;
+
+    public void setTerminology(TerminologyDTO terminology) {
+        this.terminology = terminology;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ConceptDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ConceptDTO.java
@@ -1,0 +1,59 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Map;
+
+public class ConceptDTO {
+    private String conceptURI;
+    private Map<String, String> label = Map.of();
+    private Map<String, String> definition = Map.of();
+    private String terminologyURI;
+    private Map<String, String> terminologyLabel = Map.of();
+    private Status status;
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public Map<String, String> getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(Map<String, String> definition) {
+        this.definition = definition;
+    }
+
+    public String getConceptURI() {
+        return conceptURI;
+    }
+
+    public void setConceptURI(String conceptURI) {
+        this.conceptURI = conceptURI;
+    }
+
+    public String getTerminologyURI() {
+        return terminologyURI;
+    }
+
+    public void setTerminologyURI(String terminologyURI) {
+        this.terminologyURI = terminologyURI;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public Map<String, String> getTerminologyLabel() {
+        return terminologyLabel;
+    }
+    public void setTerminologyLabel(Map<String, String> terminologyLabel) {
+        this.terminologyLabel = terminologyLabel;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoDTO.java
@@ -11,7 +11,7 @@ public class ResourceInfoDTO extends ResourceInfoBaseDTO {
     private Status status;
     private Set<String> subResourceOf;
     private Set<String> equivalentResource;
-    private String subject;
+    private ConceptDTO subject;
     private String identifier;
     private Map<String, String> note;
     private String contact;
@@ -68,11 +68,11 @@ public class ResourceInfoDTO extends ResourceInfoBaseDTO {
         this.equivalentResource = equivalentResource;
     }
 
-    public String getSubject() {
+    public ConceptDTO getSubject() {
         return subject;
     }
 
-    public void setSubject(String subject) {
+    public void setSubject(ConceptDTO subject) {
         this.subject = subject;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyNodeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/TerminologyNodeDTO.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -9,6 +10,7 @@ public class TerminologyNodeDTO {
     private String uri;
     private Type type;
     private TerminologyProperties properties;
+    private TerminologyReferences references;
 
     public Type getType() {
         return type;
@@ -34,9 +36,19 @@ public class TerminologyNodeDTO {
         this.properties = properties;
     }
 
+    public TerminologyReferences getReferences() {
+        return references;
+    }
+
+    public void setReferences(TerminologyReferences references) {
+        this.references = references;
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class TerminologyProperties {
-        private List<LocalizedValue> prefLabel;
+        private List<LocalizedValue> prefLabel = new ArrayList<>();
+        private List<LocalizedValue> status = new ArrayList<>();
+        private List<LocalizedValue> definition = new ArrayList<>();
 
         public List<LocalizedValue> getPrefLabel() {
             return prefLabel;
@@ -44,6 +56,22 @@ public class TerminologyNodeDTO {
 
         public void setPrefLabel(List<LocalizedValue> prefLabel) {
             this.prefLabel = prefLabel;
+        }
+
+        public List<LocalizedValue> getStatus() {
+            return status;
+        }
+
+        public void setStatus(List<LocalizedValue> status) {
+            this.status = status;
+        }
+
+        public List<LocalizedValue> getDefinition() {
+            return definition;
+        }
+
+        public void setDefinition(List<LocalizedValue> definition) {
+            this.definition = definition;
         }
     }
 
@@ -79,6 +107,19 @@ public class TerminologyNodeDTO {
 
         public void setValue(String value) {
             this.value = value;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TerminologyReferences {
+        private List<TerminologyNodeDTO> prefLabelXl = new ArrayList<>();
+
+        public List<TerminologyNodeDTO> getPrefLabelXl() {
+            return prefLabelXl;
+        }
+
+        public void setPrefLabelXl(List<TerminologyNodeDTO> prefLabelXl) {
+            this.prefLabelXl = prefLabelXl;
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -134,7 +134,12 @@ public class ClassMapper {
         dto.setStatus(Status.valueOf(MapperUtils.propertyToString(classResource, OWL.versionInfo)));
         dto.setSubClassOf(MapperUtils.arrayPropertyToSet(classResource, RDFS.subClassOf));
         dto.setEquivalentClass(MapperUtils.arrayPropertyToSet(classResource, OWL.equivalentClass));
-        dto.setSubject(MapperUtils.propertyToString(classResource, DCTerms.subject));
+        var subject = MapperUtils.propertyToString(classResource, DCTerms.subject);
+        if (subject != null) {
+            var conceptDTO = new ConceptDTO();
+            conceptDTO.setConceptURI(subject);
+            dto.setSubject(conceptDTO);
+        }
         dto.setIdentifier(classResource.getLocalName());
         dto.setNote(MapperUtils.localizedPropertyToMap(classResource, SKOS.note));
         if (hasRightToModel) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -132,7 +132,7 @@ public class ResourceMapper {
         indexResource.setNamespace(resource.getNameSpace());
         indexResource.setModified(resource.getProperty(DCTerms.modified).getString());
         indexResource.setCreated(resource.getProperty(DCTerms.created).getString());
-
+        indexResource.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
         var note = MapperUtils.localizedPropertyToMap(resource, SKOS.note);
         if(!note.isEmpty()){
             indexResource.setNote(note);
@@ -178,7 +178,12 @@ public class ResourceMapper {
         dto.setStatus(status);
         dto.setSubResourceOf(MapperUtils.arrayPropertyToSet(resourceResource, RDFS.subPropertyOf));
         dto.setEquivalentResource(MapperUtils.arrayPropertyToSet(resourceResource, OWL.equivalentProperty));
-        dto.setSubject(MapperUtils.propertyToString(resourceResource, DCTerms.subject));
+        String subject = MapperUtils.propertyToString(resourceResource, DCTerms.subject);
+        if (subject != null) {
+            var conceptDTO = new ConceptDTO();
+            conceptDTO.setConceptURI(subject);
+            dto.setSubject(conceptDTO);
+        }
         dto.setIdentifier(resourceResource.getLocalName());
         dto.setNote(MapperUtils.localizedPropertyToMap(resourceResource, SKOS.note));
         if (hasRightToModel) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
@@ -78,7 +78,6 @@ public class TerminologyMapper {
 
         var dto = new ConceptDTO();
         dto.setConceptURI(conceptURI);
-        dto.setTerminologyURI(MapperUtils.propertyToString(resource, SKOS.inScheme));
 
         var status = Status.DRAFT;
         try {
@@ -89,7 +88,10 @@ public class TerminologyMapper {
         dto.setStatus(status);
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel));
         dto.setDefinition(MapperUtils.localizedPropertyToMap(resource, SKOS.definition));
-        dto.setTerminologyLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+
+        var terminology = new TerminologyDTO(MapperUtils.propertyToString(resource, SKOS.inScheme));
+        terminology.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+        dto.setTerminology(terminology);
         return dto;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
@@ -14,6 +14,7 @@ public class IndexResource extends IndexBase {
     private String namespace;
     private String domain;
     private String range;
+    private String subject;
 
     public ResourceType getResourceType() {
         return resourceType;
@@ -77,5 +78,13 @@ public class IndexResource extends IndexBase {
 
     public void setRange(String range) {
         this.range = range;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
@@ -184,6 +184,8 @@ public class OpenSearchIndexer {
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, RDFS.subPropertyOf, "?subPropertyOf");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, OWL.equivalentClass, "?equivalentClass");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, OWL.equivalentProperty, "?equivalentProperty");
+        SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, DCTerms.subject, "?subject");
+
         var indexClasses = jenaService.constructWithQuery(constructBuilder.build());
         var list = new ArrayList<IndexResource>();
         indexClasses.listSubjects().forEach(next -> {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -92,18 +92,19 @@ public class TerminologyService {
         var uri = URI.create(conceptURI);
         LOG.debug("Fetching concept {}", uri);
 
-        var result = client.get().uri(uriBuilder -> uriBuilder
-                        .path(uri.getPath())
-                        .queryParam("env", awsEnv)
-                        .build()
-                )
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<List<TerminologyNodeDTO>>() {
-                })
-                .block();
-
-        if (result == null || result.isEmpty()) {
+        List<TerminologyNodeDTO> result;
+        try {
+            result = client.get().uri(uriBuilder -> uriBuilder
+                            .path(uri.getPath())
+                            .queryParam("env", awsEnv)
+                            .build()
+                    )
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<List<TerminologyNodeDTO>>() {
+                    })
+                    .block();
+        } catch(Exception e) {
             LOG.warn("Could not resolve concept uri {}", uri);
             throw new ResolvingException("Concept not found", String.format("Concept %s not found", conceptURI));
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -1,7 +1,12 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import fi.vm.yti.datamodel.api.v2.dto.ClassInfoDTO;
+import fi.vm.yti.datamodel.api.v2.dto.ConceptDTO;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceInfoDTO;
 import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResolvingException;
 import fi.vm.yti.datamodel.api.v2.mapper.TerminologyMapper;
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -14,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 @Service
 public class TerminologyService {
@@ -42,6 +48,8 @@ public class TerminologyService {
     public void resolveTerminology(Set<String> terminologyUris) {
 
         for (String u : terminologyUris) {
+            // use uris without terminological-vocabulary-0 suffix
+            u = u.replaceAll("terminological-vocabulary-\\d+$", "");
             var uri = URI.create(u);
             LOG.debug("Fetching terminology {}", uri);
             try {
@@ -64,7 +72,9 @@ public class TerminologyService {
                         .findFirst();
 
                 if (node.isPresent()) {
-                    jenaService.putTerminologyToConcepts(uri.toString(), TerminologyMapper.mapToJenaModel(u, node.get()));
+                    var terminologyModel = jenaService.getTerminology(uri.toString());
+                    Model model = TerminologyMapper.mapTerminologyToJenaModel(u, node.get(), terminologyModel);
+                    jenaService.putTerminologyToConcepts(uri.toString(), model);
                 } else {
                     LOG.warn("Could not find node with type TerminologicalVocabulary from {}", uri);
                 }
@@ -72,6 +82,60 @@ public class TerminologyService {
                 LOG.warn("Could not resolve terminology {}, {}", uri, e.getMessage());
             }
         }
+    }
+
+    public void resolveConcept(String conceptURI) {
+        if (conceptURI == null) {
+            return;
+        }
+
+        var uri = URI.create(conceptURI);
+        LOG.debug("Fetching concept {}", uri);
+
+        var result = client.get().uri(uriBuilder -> uriBuilder
+                        .path(uri.getPath())
+                        .queryParam("env", awsEnv)
+                        .build()
+                )
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<TerminologyNodeDTO>>() {
+                })
+                .block();
+
+        if (result == null || result.isEmpty()) {
+            LOG.warn("Could not resolve concept uri {}", uri);
+            throw new ResolvingException("Concept not found", String.format("Concept %s not found", conceptURI));
+        }
+
+        String terminologyURI = conceptURI.substring(0, conceptURI.lastIndexOf("/") + 1);
+        var terminologyModel = jenaService.getTerminology(terminologyURI);
+        if (terminologyModel == null) {
+            LOG.warn("Terminology {} not added to model", terminologyURI);
+            throw new ResolvingException("Terminology not added to the model",
+                    String.format("Add %s to the model", terminologyURI));
+        }
+
+        TerminologyMapper.mapConceptToTerminologyModel(terminologyModel, terminologyURI,
+                conceptURI, result.get(0));
+
+        jenaService.putTerminologyToConcepts(terminologyURI, terminologyModel);
+    }
+
+    public Consumer<ClassInfoDTO> mapConceptToClass() {
+        return (var dto) -> dto.setSubject(getMappedConceptDTO(dto.getSubject()));
+    }
+
+    public Consumer<ResourceInfoDTO> mapConceptToResource() {
+        return (var dto) -> dto.setSubject(getMappedConceptDTO(dto.getSubject()));
+    }
+
+    private ConceptDTO getMappedConceptDTO(ConceptDTO dto) {
+        if (dto == null || dto.getConceptURI() == null || dto.getConceptURI().isEmpty()) {
+            return null;
+        }
+        var conceptModel = jenaService.getConcept(dto.getConceptURI());
+        return TerminologyMapper.mapToConceptDTO(conceptModel, dto.getConceptURI());
     }
 
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -119,7 +119,7 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", dto.getSubClassOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getLabel().size());
         assertEquals("test label", dto.getLabel().get("fi"));
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals(2, dto.getNote().size());
         assertEquals("test note fi", dto.getNote().get("fi"));
         assertEquals("test note en", dto.getNote().get("en"));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -380,7 +380,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
         assertEquals(1, dto.getEquivalentResource().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAttribute", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
         assertEquals("test note fi", dto.getNote().get("fi"));
@@ -412,7 +412,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
         assertEquals(1, dto.getEquivalentResource().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAssociation", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
         assertEquals("test note fi", dto.getNote().get("fi"));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
@@ -117,9 +117,9 @@ class TerminologyMapperTest {
         assertEquals("määritelmä", conceptDTO.getDefinition().get("fi"));
         assertEquals("definition", conceptDTO.getDefinition().get("en"));
         assertEquals(conceptURI, conceptDTO.getConceptURI());
-        assertEquals(conceptURI.replace("concept-1", ""), conceptDTO.getTerminologyURI());
-        assertEquals("Testisanasto", conceptDTO.getTerminologyLabel().get("fi"));
-        assertEquals("Test terminology", conceptDTO.getTerminologyLabel().get("en"));
+        assertEquals(conceptURI.replace("concept-1", ""), conceptDTO.getTerminology().getUri());
+        assertEquals("Testisanasto", conceptDTO.getTerminology().getLabel().get("fi"));
+        assertEquals("Test terminology", conceptDTO.getTerminology().getLabel().get("en"));
     }
 
     private static TerminologyNodeDTO.LocalizedValue getLocalizedValue(String lang, String value) {

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -8,6 +8,7 @@ import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
@@ -65,7 +66,12 @@ class ClassControllerTest {
     @MockBean
     private AuthenticatedUserProvider userProvider;
 
-    private final Consumer<ResourceInfoBaseDTO> userMapper = (var dto) -> {} ;
+    @MockBean
+    private TerminologyService terminologyService;
+
+    private final Consumer<ResourceInfoBaseDTO> userMapper = (var dto) -> {};
+
+    private final Consumer<ClassInfoDTO> conceptMapper = (var dto) -> {};
 
     private static final YtiUser USER = EndpointUtils.mockUser;
 
@@ -83,6 +89,7 @@ class ClassControllerTest {
         when(authorizationManager.hasRightToAnyOrganization(anyCollection())).thenReturn(true);
         when(authorizationManager.hasRightToModel(any(), any())).thenReturn(true);
         when(userProvider.getUser()).thenReturn(USER);
+        when(terminologyService.mapConceptToClass()).thenReturn(conceptMapper);
     }
 
     @Test
@@ -105,6 +112,7 @@ class ClassControllerTest {
             verify(this.jenaService, times(2)).doesResolvedNamespaceExist(anyString());
             verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(this.jenaService).getDataModel(anyString());
+            verify(terminologyService).resolveConcept(anyString());
             classMapper.verify(() -> ClassMapper.createClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class)));
             verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
             verifyNoMoreInteractions(this.jenaService);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -7,6 +7,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
@@ -65,10 +66,14 @@ class ResourceControllerTest {
     @MockBean
     private GroupManagementService groupManagementService;
 
+    @MockBean
+    private TerminologyService terminologyService;
+
     @Autowired
     private ResourceController resourceController;
 
     private final Consumer<ResourceInfoBaseDTO> userMapper = (var dto) -> {};
+    private final Consumer<ResourceInfoDTO> conceptMapper = (var dto) -> {};
 
     private static final YtiUser USER = EndpointUtils.mockUser;
 
@@ -83,6 +88,7 @@ class ResourceControllerTest {
         when(authorizationManager.hasRightToModel(any(), any())).thenReturn(true);
         when(userProvider.getUser()).thenReturn(USER);
         when(groupManagementService.mapUser()).thenReturn(userMapper);
+        when(terminologyService.mapConceptToResource()).thenReturn(conceptMapper);
     }
 
     @Test
@@ -105,6 +111,7 @@ class ResourceControllerTest {
             verify(this.jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(this.jenaService).getDataModel(anyString());
             verify(jenaService, times(2)).checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int#FakeClass"), anyList(), anyBoolean());
+            verify(terminologyService).resolveConcept(resourceDTO.getSubject());
             mapper.verify(() -> ResourceMapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class), any(YtiUser.class)));
             verify(this.jenaService).putDataModelToCore(anyString(), any(Model.class));
             verifyNoMoreInteractions(this.jenaService);

--- a/src/test/resources/concept_response.json
+++ b/src/test/resources/concept_response.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "a1e658f6-f9ab-4bc9-92f1-4b9a0af70de9",
+    "code": "concept-3",
+    "uri": "http://uri.suomi.fi/terminology/dd0e10ed/concept-3",
+    "number": 3,
+    "createdBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+    "createdDate": "2023-04-12T10:00:03Z",
+    "lastModifiedBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+    "lastModifiedDate": "2023-04-12T10:00:03Z",
+    "type": {
+      "id": "Concept",
+      "graph": {
+        "id": "f53ab70b-be2d-41a0-9ace-c22c1dcd3096"
+      }
+    },
+    "properties": {
+      "status": [
+        {
+          "lang": "",
+          "value": "DRAFT",
+          "regex": "(?s)^.*$"
+        }
+      ]
+    },
+    "references": {
+      "prefLabelXl": [
+        {
+          "id": "56de6a23-bc5a-46f1-bd46-adc1889056d7",
+          "code": "term-6",
+          "uri": "http://uri.suomi.fi/terminology/dd0e10ed/term-6",
+          "number": 6,
+          "createdBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+          "createdDate": "2023-04-12T10:00:03Z",
+          "lastModifiedBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+          "lastModifiedDate": "2023-04-12T10:00:03Z",
+          "type": {
+            "id": "Term",
+            "graph": {
+              "id": "f53ab70b-be2d-41a0-9ace-c22c1dcd3096"
+            }
+          },
+          "properties": {
+            "status": [
+              {
+                "lang": "",
+                "value": "DRAFT",
+                "regex": "(?s)^.*$"
+              }
+            ],
+            "prefLabel": [
+              {
+                "lang": "fi",
+                "value": "Test label",
+                "regex": "(?s)^.*$"
+              }
+            ]
+          },
+          "references": {},
+          "referrers": {}
+        },
+        {
+          "id": "13e0ef38-8538-4b57-b45c-fac5c094c399",
+          "code": "term-7",
+          "uri": "http://uri.suomi.fi/terminology/dd0e10ed/term-7",
+          "number": 7,
+          "createdBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+          "createdDate": "2023-04-12T10:00:03Z",
+          "lastModifiedBy": "ebe948a6-42da-7c4b-421e-de9ff0ddc0ba",
+          "lastModifiedDate": "2023-04-12T10:00:03Z",
+          "type": {
+            "id": "Term",
+            "graph": {
+              "id": "f53ab70b-be2d-41a0-9ace-c22c1dcd3096"
+            }
+          },
+          "properties": {
+            "status": [
+              {
+                "lang": "",
+                "value": "DRAFT",
+                "regex": "(?s)^.*$"
+              }
+            ],
+            "prefLabel": [
+              {
+                "lang": "en",
+                "value": "No definition",
+                "regex": "(?s)^.*$"
+              }
+            ]
+          },
+          "references": {},
+          "referrers": {}
+        }
+      ]
+    },
+    "referrers": {}
+  }
+]

--- a/src/test/resources/terminology_with_concept.ttl
+++ b/src/test/resources/terminology_with_concept.ttl
@@ -1,0 +1,12 @@
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+<http://uri.suomi.fi/terminology/dd0e10ed/concept-1>
+        rdfs:label       "Testisanasto"@fi , "Test terminology"@en ;
+        owl:versionInfo  "DRAFT" ;
+        skos:inScheme    <http://uri.suomi.fi/terminology/dd0e10ed/> ;
+        skos:prefLabel   "käsite"@fi , "concept"@en ;
+        skos:definition  "määritelmä"@fi , "definition"@en .
+


### PR DESCRIPTION
- Concepts are resolved from sanastot.suomi.fi and stored to Fuseki, in the same graph as related terminology
- Add concept uri to Opensearch index
- Add mapper consumer to terminology service which enriches concept data for UI