### PR TITLE
YTI-2547: linked resources to uris

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -39,10 +39,11 @@ public class ClassMapper {
                 .addProperty(OWL.versionInfo, dto.getStatus().name())
                 .addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(creationDate))
                 .addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(creationDate))
-                .addProperty(RDFS.isDefinedBy, modelURI)
                 .addProperty(Iow.creator, user.getId().toString())
                 .addProperty(Iow.modifier, user.getId().toString());
 
+
+        classResource.addProperty(RDFS.isDefinedBy, ResourceFactory.createResource(modelURI));
         classResource.addProperty(DCTerms.identifier, ResourceFactory.createTypedLiteral(dto.getIdentifier(), XSDDatatype.XSDNCName));
         //Labels
         var modelResource = model.getResource(modelURI);
@@ -51,7 +52,7 @@ public class ClassMapper {
         //Note
         MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SKOS.note, model);
         MapperUtils.addOptionalStringProperty(classResource, SKOS.editorialNote, dto.getEditorialNote());
-        MapperUtils.addOptionalStringProperty(classResource, DCTerms.subject, dto.getSubject());
+        MapperUtils.addOptionalUriProperty(classResource, DCTerms.subject, dto.getSubject());
 
         var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
         var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
@@ -66,7 +67,7 @@ public class ClassMapper {
             dto.getSubClassOf().forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, RDFS.subClassOf, sub));
         }
 
-        modelResource.addProperty(DCTerms.hasPart, classUri);
+        modelResource.addProperty(DCTerms.hasPart, classResource);
 
         return classUri;
     }
@@ -80,7 +81,7 @@ public class ClassMapper {
         MapperUtils.updateLocalizedProperty(languages, classDTO.getLabel(), classResource, RDFS.label, model);
         MapperUtils.updateLocalizedProperty(languages, classDTO.getNote(), classResource, SKOS.note, model);
         MapperUtils.updateStringProperty(classResource, SKOS.editorialNote, classDTO.getEditorialNote());
-        MapperUtils.updateStringProperty(classResource, DCTerms.subject, classDTO.getSubject());
+        MapperUtils.updateUriProperty(classResource, DCTerms.subject, classDTO.getSubject());
 
         var status = classDTO.getStatus();
         if (status != null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -63,7 +63,7 @@ public class ResourceMapper {
         MapperUtils.addOptionalUriProperty(resourceResource, RDFS.domain, dto.getDomain());
         MapperUtils.addOptionalUriProperty(resourceResource, RDFS.range, dto.getRange());
 
-        modelResource.addProperty(DCTerms.hasPart, ResourceFactory.createResource(resourceUri));
+        modelResource.addProperty(DCTerms.hasPart, resourceResource);
         return resourceUri;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -28,6 +28,7 @@ public class DataModelValidator extends BaseValidator implements
         setConstraintViolationAdded(false);
         checkModelType(context, dataModel);
         checkPrefix(context, dataModel);
+        checkStatus(context, dataModel);
         checkLanguages(context, dataModel);
         checkLabels(context, dataModel);
         checkDescription(context, dataModel);
@@ -79,6 +80,13 @@ public class DataModelValidator extends BaseValidator implements
             addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "type");
         }else if(!updateModel && modelType == null){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "type");
+        }
+    }
+
+    private void checkStatus(ConstraintValidatorContext context, DataModelDTO dataModel) {
+        var status = dataModel.getStatus();
+        if(!updateModel && status == null){
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "status");
         }
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -51,7 +51,7 @@ class ClassMapperTest {
         assertNotNull(classResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", modelResource.getProperty(DCTerms.hasPart).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(1, classResource.listProperties(RDFS.label).toList().size());
         assertEquals("test label", classResource.getProperty(RDFS.label).getLiteral().getString());
@@ -202,7 +202,7 @@ class ClassMapperTest {
         assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -216,7 +216,7 @@ class ClassMapperTest {
         assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -244,7 +244,7 @@ class ClassMapperTest {
         assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -258,7 +258,7 @@ class ClassMapperTest {
         assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -282,7 +282,7 @@ class ClassMapperTest {
         dto.setEditorialNote("");
         dto.setNote(Collections.emptyMap());
 
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -57,14 +57,11 @@ class ModelMapperTest {
 
     @Test
     void testMapToJenaModel() {
-        var mockModel = mock(Model.class);
+        var mockModel = ModelFactory.createDefaultModel();
+        mockModel.createResource("http://uri.suomi.fi/datamodel/ns/newint")
+                        .addProperty(RDF.type, DCAP.DCAP)
+                        .addProperty(DCAP.preferredXMLNamespacePrefix, "test");
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
-        var mockRes = mock(Resource.class);
-        when(mockModel.getResource(anyString())).thenReturn(mockRes);
-        var mockStm = mock(Statement.class);
-        when(mockRes.getProperty(any())).thenReturn(mockStm);
-        when(mockStm.getObject()).thenReturn(ResourceFactory.createPlainLiteral("test"));
-        when(mockStm.getResource()).thenReturn(RDFS.Resource);
 
         UUID organizationId = UUID.randomUUID();
         YtiUser mockUser = EndpointUtils.mockUser;
@@ -123,14 +120,11 @@ class ModelMapperTest {
         RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
 
         when(jenaService.getDataModel("test")).thenReturn(m);
-        var mockModel = mock(Model.class);
+        var mockModel = ModelFactory.createDefaultModel();
+        mockModel.createResource("http://uri.suomi.fi/datamodel/ns/newint")
+                .addProperty(RDF.type, DCAP.DCAP)
+                .addProperty(DCAP.preferredXMLNamespacePrefix, "test");
         when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
-        var mockRes = mock(Resource.class);
-        when(mockModel.getResource(anyString())).thenReturn(mockRes);
-        var mockStm = mock(Statement.class);
-        when(mockRes.getProperty(any())).thenReturn(mockStm);
-        when(mockStm.getObject()).thenReturn(ResourceFactory.createPlainLiteral("test"));
-        when(mockStm.getResource()).thenReturn(RDFS.Resource);
 
         UUID organizationId = UUID.randomUUID();
         YtiUser mockUser = EndpointUtils.mockUser;
@@ -165,10 +159,10 @@ class ModelMapperTest {
         assertEquals(Status.VALID, Status.valueOf(modelResource.getProperty(OWL.versionInfo).getString()));
 
         assertEquals(1, modelResource.listProperties(OWL.imports).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int", modelResource.listProperties(OWL.imports).next().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int", modelResource.listProperties(OWL.imports).next().getObject().toString());
 
         assertEquals(1, modelResource.listProperties(DCTerms.requires).toList().size());
-        assertEquals("https://www.example.com/ns/ext", modelResource.listProperties(DCTerms.requires).next().getString());
+        assertEquals("https://www.example.com/ns/ext", modelResource.listProperties(DCTerms.requires).next().getObject().toString());
 
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
 
@@ -189,10 +183,10 @@ class ModelMapperTest {
         assertEquals(Status.DRAFT, Status.valueOf(modelResource.getProperty(OWL.versionInfo).getString()));
 
         assertEquals(1, modelResource.listProperties(DCTerms.requires).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/newint", modelResource.listProperties(DCTerms.requires).next().getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/newint", modelResource.listProperties(DCTerms.requires).next().getObject().toString());
 
         assertEquals(1, modelResource.listProperties(OWL.imports).toList().size());
-        assertEquals("http://www.w3.org/2000/01/rdf-schema#", modelResource.listProperties(OWL.imports).next().getString());
+        assertEquals("http://www.w3.org/2000/01/rdf-schema#", modelResource.listProperties(OWL.imports).next().getObject().toString());
         assertEquals(mockUser.getId().toString(), modelResource.getProperty(Iow.modifier).getString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", modelResource.getProperty(Iow.creator).getObject().toString());
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -547,7 +547,7 @@ class ResourceMapperTest {
         assertEquals("test attribute", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
@@ -602,7 +602,7 @@ class ResourceMapperTest {
         assertEquals("test association", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());

--- a/src/test/resources/models/test_datamodel_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_visualization.ttl
@@ -10,26 +10,26 @@
 
 <http://uri.suomi.fi/datamodel/ns/test>
         a                     dcap:DCAP ;
-        dcterms:requires      "https://www.example.com/ns/external" ;
-        owl:imports           "http://uri.suomi.fi/datamodel/ns/testmodel" .
+        dcterms:requires      <https://www.example.com/ns/external> ;
+        owl:imports           <http://uri.suomi.fi/datamodel/ns/testmodel> .
 
 test:TestClass1  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass1"^^xsd:NCName ;
         rdfs:label           "Label 1"@fi ;
-        rdfs:subClassOf      "http://uri.suomi.fi/datamodel/ns/testmodel#TestClass" .
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/testmodel#TestClass> .
 
 test:TestClass2  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass2"^^xsd:NCName ;
         rdfs:label           "Label 2"@fi ;
-        rdfs:subClassOf      "http://uri.suomi.fi/datamodel/ns/test#testclass1" .
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test#testclass1> .
 
 test:TestClass3  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass3"^^xsd:NCName ;
         rdfs:label           "Label 3"@fi ;
-        rdfs:subClassOf      "https://www.example.com/ns/external#ExternalClass" .
+        rdfs:subClassOf      <https://www.example.com/ns/external#ExternalClass> .
 
 <https://www.example.com/ns/external>
         dcterms:type                        rdfs:Resource ;

--- a/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
+++ b/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
@@ -19,8 +19,8 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     "http://uri.suomi.fi/datamodel/ns/int" ;
-        dcterms:requires                "https://www.example.com/ns/ext" ;
+        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        dcterms:requires                <https://www.example.com/ns/ext> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
         dcap:preferredXMLNamespacePrefix
@@ -34,7 +34,7 @@
         dcap:preferredXMLNamespacePrefix    "extres" .
 
 test:TestClass  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test label"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
@@ -42,7 +42,7 @@ test:TestClass  rdf:type     owl:Class ;
         owl:versionInfo      "VALID" .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test attribute"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAttribute"^^xsd:NCName ;
@@ -50,7 +50,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         owl:versionInfo      "VALID" .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test association"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAssociation"^^xsd:NCName ;

--- a/src/test/resources/models/test_datamodel_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_with_resources.ttl
@@ -19,8 +19,8 @@ dcterms:hasPart                 test:TestAttribute, test:TestClass, test:TestAss
 dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
 dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
 dcterms:language                "fi" ;
-owl:imports                     "http://uri.suomi.fi/datamodel/ns/int" ;
-dcterms:requires                "https://www.example.com/ns/ext" ;
+owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+dcterms:requires                <https://www.example.com/ns/ext> ;
 dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
 dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
 dcap:preferredXMLNamespacePrefix
@@ -34,14 +34,14 @@ rdfs:label                          "test resource"@fi;
 dcap:preferredXMLNamespacePrefix    "extres" .
 
 test:TestClass  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test label"@fi ;
-        rdfs:subClassOf      "http://uri.suomi.fi/datamodel/ns/test#SubClass" ;
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test#SubClass> ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        dcterms:subject      "http://uri.suomi.fi/terminology/test/test1" ;
-        owl:equivalentClass  "http://uri.suomi.fi/datamodel/ns/test#EqClass" ;
+        dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
+        owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test#EqClass> ;
         owl:versionInfo      "VALID" ;
         skos:editorialNote   "comment visible for admin" ;
         skos:note         "test note fi"@fi, "test note en"@en ;
@@ -49,36 +49,36 @@ test:TestClass  rdf:type     owl:Class ;
         iow:modifier          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
-        rdfs:isDefinedBy        "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label              "test attribute"@fi ;
-        rdfs:subPropertyOf      "http://uri.suomi.fi/datamodel/ns/test#SubResource" ;
+        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test#SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAttribute"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        dcterms:subject         "http://uri.suomi.fi/terminology/test/test1" ;
-        owl:equivalentProperty  "http://uri.suomi.fi/datamodel/ns/test#EqResource" ;
+        dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
+        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         skos:note               "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             "http://uri.suomi.fi/datamodel/ns/test#DomainClass" ;
-        rdfs:range              "http://uri.suomi.fi/datamodel/ns/test#RangeClass" .
+        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;
+        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test#RangeClass> .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
-        rdfs:isDefinedBy        "http://uri.suomi.fi/datamodel/ns/test" ;
+        rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label              "test association"@fi ;
-        rdfs:subPropertyOf      "http://uri.suomi.fi/datamodel/ns/test#SubResource" ;
+        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test#SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAssociation"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        dcterms:subject         "http://uri.suomi.fi/terminology/test/test1" ;
-        owl:equivalentProperty  "http://uri.suomi.fi/datamodel/ns/test#EqResource" ;
+        dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
+        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         skos:note               "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             "http://uri.suomi.fi/datamodel/ns/test#DomainClass" ;
-        rdfs:range              "http://uri.suomi.fi/datamodel/ns/test#RangeClass"
+        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;
+        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test#RangeClass>
 

--- a/src/test/resources/test_datamodel.ttl
+++ b/src/test/resources/test_datamodel.ttl
@@ -4,6 +4,8 @@
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix ext:     <https://www.example.com/ns/ext> .
+@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
 
 <http://uri.suomi.fi/datamodel/ns/test>
         a                               dcap:DCAP ;
@@ -14,8 +16,8 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     "http://uri.suomi.fi/datamodel/ns/int" ;
-        dcterms:requires                "https://www.example.com/ns/ext" ;
+        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        dcterms:requires                <https://www.example.com/ns/ext> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
         dcap:preferredXMLNamespacePrefix


### PR DESCRIPTION
Changelog:
- All linked resources in datamodels/classes/attributes/associations are now stores as uris in fuseki
- Remove prefix when removing namespaces
- Add status validation for when creating datamodel