### PR TITLE
YTI-2497 resolve URIs and redirect to resource

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -16,16 +16,10 @@ import fi.vm.yti.security.AuthenticatedUserProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.io.StringWriter;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -148,31 +142,5 @@ public class Datamodel {
 
         jenaService.deleteDataModel(modelUri);
         openSearchIndexer.deleteModelFromIndex(modelUri);
-    }
-
-    @Operation(summary = "Get a datamodel as file")
-    @ApiResponse(responseCode = "200", description = "")
-    @GetMapping(value = "/{prefix}/file", produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8"})
-    public ResponseEntity<String> getDataModelAsFile(@PathVariable String prefix, @RequestHeader(value = HttpHeaders.ACCEPT) String accept){
-        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var model = jenaService.getDataModel(modelURI);
-
-        if(model == null){
-            throw new ResourceNotFoundException(modelURI);
-        }
-        model.setNsPrefixes(ModelConstants.PREFIXES);
-        var stringWriter = new StringWriter();
-        switch (accept) {
-            case "text/turtle":
-                RDFDataMgr.write(stringWriter, model, Lang.TURTLE);
-                break;
-            case "application/rdf+xml":
-                RDFDataMgr.write(stringWriter, model, Lang.RDFXML);
-                break;
-            case "application/ld+json":
-            default:
-                RDFDataMgr.write(stringWriter, model, Lang.JSONLD);
-        }
-        return ResponseEntity.ok().body(stringWriter.toString());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -1,0 +1,85 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.SKOS;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.StringWriter;
+@RestController
+@RequestMapping("v2/export")
+@Tag(name = "Export" )
+@Validated
+public class ExportController {
+
+    private final JenaService jenaService;
+    private final AuthorizationManager authorizationManager;
+
+    public ExportController(JenaService jenaService,
+                            AuthorizationManager authorizationManager) {
+        this.jenaService = jenaService;
+        this.authorizationManager = authorizationManager;
+    }
+
+    @Operation(summary = "Get a datamodel or a single resource serialized")
+    @ApiResponse(responseCode = "200", description = "Get and serialize resource successfully")
+    @ApiResponse(responseCode = "404", description = "Resource not found")
+    @GetMapping(value = {"{prefix}", "/{prefix}/{resource}"},
+            produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8"})
+    public ResponseEntity<String> export(@PathVariable String prefix,
+                                         @PathVariable(required = false) String resource,
+                                         @RequestHeader(value = HttpHeaders.ACCEPT) String accept){
+        Model exportedModel;
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = jenaService.getDataModel(modelURI);
+
+        if(model == null){
+            throw new ResourceNotFoundException(modelURI);
+        }
+
+        if (resource != null) {
+            var res = model.getResource(modelURI + "#" + resource);
+            var properties = res.listProperties();
+            if (!properties.hasNext()) {
+                throw new ResourceNotFoundException(res.getURI());
+            }
+            exportedModel = properties.toModel();
+        } else {
+            exportedModel = model;
+        }
+
+        exportedModel.setNsPrefixes(ModelConstants.PREFIXES);
+
+        // remove editorial notes from resources
+        if (!authorizationManager.hasRightToModel(prefix, model)) {
+            var hiddenValues = model.listStatements(
+                    new SimpleSelector(null, SKOS.editorialNote, (String) null)).toList();
+            exportedModel.remove(hiddenValues);
+        }
+
+        var stringWriter = new StringWriter();
+        switch (accept) {
+            case "text/turtle":
+                RDFDataMgr.write(stringWriter, exportedModel, Lang.TURTLE);
+                break;
+            case "application/rdf+xml":
+                RDFDataMgr.write(stringWriter, exportedModel, Lang.RDFXML);
+                break;
+            case "application/ld+json":
+            default:
+                RDFDataMgr.write(stringWriter, exportedModel, Lang.JSONLD);
+        }
+        return ResponseEntity.ok().body(stringWriter.toString());
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
@@ -1,0 +1,83 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.iri.IRIFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("v2/resolve")
+@Tag(name = "Resolve" )
+public class ResolveController {
+    private static final Logger LOG = LoggerFactory.getLogger(ResolveController.class);
+    static final IRIFactory iriFactory = IRIFactory.iriImplementation();
+
+    @Operation(summary = "Resolve content by its IRI")
+    @ApiResponse(responseCode = "303", description = "Resolves given uri and redirects the request per accept header")
+    @ApiResponse(responseCode = "404", description = "Resource not found")
+    @Parameter(name = "iri", description = "Resource IRI")
+    @GetMapping
+    public ResponseEntity<String> resolve(@RequestParam String iri, @RequestHeader(value = HttpHeaders.ACCEPT) String accept) {
+        LOG.info("Resolve resource {}, accept: {}", iri, accept);
+
+        if (!checkIRI(iriFactory.create(iri))) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        String resourcePath = iri.substring(ModelConstants.SUOMI_FI_NAMESPACE.length());
+        var parts = resourcePath.split("\\W");
+        String resource = null;
+
+        if (parts.length == 0) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        var modelPrefix = parts[0];
+        if (parts.length == 2) {
+            // single resource
+            resource = parts[1];
+        }
+
+        var currentUrl = ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUri();
+        var redirectURL = new StringBuilder();
+        redirectURL.append(currentUrl.getScheme())
+                .append("://")
+                .append(currentUrl.getHost())
+                .append(currentUrl.getHost().equals("localhost") ? ":3000" : "");
+
+        if ("text/html".equals(accept)) {
+            // redirect to the site
+            redirectURL
+                .append("/model/")
+                .append(modelPrefix)
+                .append(resource != null ? "#" + resource : "");
+
+        } else {
+            // redirect to serialized resource
+            redirectURL
+                .append("/datamodel-api/v2/export/")
+                .append(modelPrefix)
+                .append(resource != null ? "/" + resource : "");
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.SEE_OTHER)
+                .header(HttpHeaders.LOCATION, redirectURL.toString())
+                .build();
+    }
+
+    private static boolean checkIRI(IRI iri) {
+        return !iri.hasViolation(false)
+                && iri.toString().startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -55,7 +56,7 @@ public class ResolveController {
                 .append(currentUrl.getHost())
                 .append(currentUrl.getHost().equals("localhost") ? ":3000" : "");
 
-        if ("text/html".equals(accept)) {
+        if (accept != null && accept.contains(MimeTypeUtils.TEXT_HTML_VALUE)) {
             // redirect to the site
             redirectURL
                 .append("/model/")

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -497,23 +496,4 @@ class DatamodelTest {
         verifyNoInteractions(openSearchIndexer);
     }
 
-    @Test
-    void shouldGetModelAsFileNotSupportedType() throws Exception {
-        mvc.perform(get("/v2/model/test/file")
-                        .header("Accept", "application/pdf"))
-                .andExpect(status().isNotAcceptable());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"application/ld+json", "text/turtle", "application/rdf+xml"})
-    void shouldGetModelWithAcceptHeader(String accept) throws Exception {
-        when(jenaService.getDataModel(anyString())).thenReturn(ModelFactory.createDefaultModel());
-
-        mvc.perform(get("/v2/model/test/file")
-                        .header("Accept", accept))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(accept));
-        verify(jenaService).getDataModel(anyString());
-        verifyNoMoreInteractions(jenaService);
-    }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
@@ -1,0 +1,86 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = ExportController.class)
+@ActiveProfiles("junit")
+class ExportControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private JenaService jenaService;
+
+    @MockBean
+    private AuthorizationManager authorizationManager;
+
+    @Autowired
+    private ExportController exportController;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.exportController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void shouldGetModelAsFileNotSupportedType() throws Exception {
+        mvc.perform(get("/v2/export/test")
+                        .header("Accept", "application/pdf"))
+                .andExpect(status().isNotAcceptable());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/ld+json", "text/turtle", "application/rdf+xml"})
+    void shouldGetModelWithAcceptHeader(String accept) throws Exception {
+        when(jenaService.getDataModel(anyString())).thenReturn(ModelFactory.createDefaultModel());
+
+        mvc.perform(get("/v2/export/test")
+                        .header("Accept", accept))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(accept));
+        verify(jenaService).getDataModel(anyString());
+        verifyNoMoreInteractions(jenaService);
+    }
+
+    @Test
+    void shouldRemoveTriplesHiddenFromUnauthenticatedUser() throws Exception {
+        var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
+        when(jenaService.getDataModel(anyString())).thenReturn(model);
+        when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(false);
+
+        mvc.perform(get("/v2/export/test")
+                        .header("Accept", "text/turtle"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(Matchers.not(Matchers.containsString("skos:editorialNote"))));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveControllerTest.java
@@ -1,0 +1,77 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.*;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = ResolveController.class)
+@ActiveProfiles("junit")
+class ResolveControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ResolveController resolveController;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.resolveController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void testRedirectSiteModel() throws Exception {
+        var accept = "text/html";
+        mvc.perform(get("/v2/resolve")
+                        .param("iri", "http://uri.suomi.fi/datamodel/ns/test")
+                        .header(HttpHeaders.ACCEPT, accept))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, endsWith("/model/test")));
+    }
+
+    @Test
+    void testRedirectSiteResource() throws Exception {
+        var accept = "text/html";
+        mvc.perform(get("/v2/resolve")
+                        .param("iri", "http://uri.suomi.fi/datamodel/ns/test#someClass")
+                        .header(HttpHeaders.ACCEPT, accept))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, endsWith("/model/test#someClass")));
+    }
+
+    @Test
+    void testRedirectSerializedResource() throws Exception {
+        var accept = "text/turtle";
+        mvc.perform(get("/v2/resolve")
+                        .param("iri", "http://uri.suomi.fi/datamodel/ns/test#someClass")
+                        .header(HttpHeaders.ACCEPT, accept))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, endsWith("/datamodel-api/v2/export/test/someClass")));
+    }
+
+    @Test
+    void testInvalidIRI() throws Exception {
+        var accept = "text/turtle";
+        mvc.perform(get("/v2/resolve")
+                        .param("iri", "http://invalid.com")
+                        .header(HttpHeaders.ACCEPT, accept))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- Moved data serialization from DatamodelController to ExportController 
- Hide some data from unauthenticated users (skos:editorialNote)
- Created controller for URI resolving (ResolveController)
- Determine if either single resource or the whole model is requested and redirect request forward per accept header. Redirect to site only if accept header is `text/html`, otherwise redirect to ExportController to get serialized data
