### PR TITLE
YTI-2506 use terminology uri with suffix

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -48,8 +48,6 @@ public class TerminologyService {
     public void resolveTerminology(Set<String> terminologyUris) {
 
         for (String u : terminologyUris) {
-            // use uris without terminological-vocabulary-0 suffix
-            u = u.replaceAll("terminological-vocabulary-\\d+$", "");
             var uri = URI.create(u);
             LOG.debug("Fetching terminology {}", uri);
             try {


### PR DESCRIPTION
Use terminology uri with suffix because otherwise searching terminologies by uri doesn't work