### PR TITLE
YTI-2591 new nodeshape mapping and saving

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.dto;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,6 +17,8 @@ public class ClassDTO {
     private String identifier;
     private Map<String, String> note;
     private String targetClass; //Only allowed in Application profile classes
+    private String targetNode;
+    private List<String> properties;
 
     public Map<String, String> getLabel() {
         return label;
@@ -87,6 +90,22 @@ public class ClassDTO {
 
     public void setTargetClass(String targetClass) {
         this.targetClass = targetClass;
+    }
+
+    public String getTargetNode() {
+        return targetNode;
+    }
+
+    public void setTargetNode(String targetNode) {
+        this.targetNode = targetNode;
+    }
+
+    public List<String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<String> properties) {
+        this.properties = properties;
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,8 +18,8 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
     private String uri;
     private Set<OrganizationDTO> contributor;
     private String contact;
-    private List<SimpleResourceDTO> attribute;
-    private List<SimpleResourceDTO> association;
+    private List<SimpleResourceDTO> attribute = new ArrayList<>();
+    private List<SimpleResourceDTO> association = new ArrayList<>();
     private String targetClass;
 
     public Map<String, String> getLabel() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ExternalClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ExternalClassDTO.java
@@ -1,0 +1,43 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public class ExternalClassDTO {
+    private Map<String, String> label;
+    private String uri;
+    private List<ExternalResourceDTO> attributes;
+    private List<ExternalResourceDTO> associations;
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public List<ExternalResourceDTO> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<ExternalResourceDTO> attributes) {
+        this.attributes = attributes;
+    }
+
+    public List<ExternalResourceDTO> getAssociations() {
+        return associations;
+    }
+
+    public void setAssociations(List<ExternalResourceDTO> associations) {
+        this.associations = associations;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ExternalResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ExternalResourceDTO.java
@@ -1,0 +1,24 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Map;
+
+public class ExternalResourceDTO {
+    private Map<String, String> label;
+    private String uri;
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -7,7 +7,6 @@ import fi.vm.yti.security.YtiUser;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
@@ -19,7 +18,9 @@ import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.util.ArrayList;
-import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class ClassMapper {
@@ -33,47 +34,46 @@ public class ClassMapper {
     public static String createClassAndMapToModel(String modelURI, Model model, ClassDTO dto, YtiUser user){
         logger.info("Adding class to {}", modelURI);
         var modelResource = model.getResource(modelURI);
-        var creationDate = new XSDDateTime(Calendar.getInstance());
         var classUri = modelURI + "#" + dto.getIdentifier();
         var classResource = model.createResource(classUri)
-                .addProperty(OWL.versionInfo, dto.getStatus().name())
-                .addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(creationDate))
-                .addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(creationDate))
-                .addProperty(Iow.creator, user.getId().toString())
-                .addProperty(Iow.modifier, user.getId().toString());
+                .addProperty(OWL.versionInfo, dto.getStatus().name());
+
+        MapperUtils.addCreationMetadata(classResource, user);
 
         var langs = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
-
-        var modelType = MapperUtils.getModelTypeFromResource(modelResource);
-        if(modelType.equals(ModelType.LIBRARY)){
-            classResource.addProperty(RDF.type, OWL.Class);
-            MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SKOS.note, model);
-            MapperUtils.addOptionalStringProperty(classResource, SKOS.editorialNote, dto.getEditorialNote());
-        }else{
-            classResource.addProperty(RDF.type, SH.NodeShape);
-            classResource.addProperty(SH.targetClass, ResourceFactory.createResource(dto.getTargetClass()));
-            MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SH.description, model);
-            MapperUtils.addOptionalStringProperty(classResource, DCTerms.description, dto.getEditorialNote());
-        }
 
         classResource.addProperty(RDFS.isDefinedBy, modelResource);
         classResource.addProperty(DCTerms.identifier, ResourceFactory.createTypedLiteral(dto.getIdentifier(), XSDDatatype.XSDNCName));
         //Labels
         MapperUtils.addLocalizedProperty(langs, dto.getLabel(), classResource, RDFS.label, model);
-        //Note
+        //Concept from terminology
         MapperUtils.addOptionalUriProperty(classResource, DCTerms.subject, dto.getSubject());
 
-        var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
-        var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
-        //Equivalent class
-        if(dto.getEquivalentClass() != null){
-            dto.getEquivalentClass().forEach(eq -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, OWL.equivalentClass, eq));
-        }
-        //Sub Class
-        if(dto.getSubClassOf() == null || dto.getSubClassOf().isEmpty()){
-            classResource.addProperty(RDFS.subClassOf, OWL.Thing); //Add OWL:Thing if nothing else is specified
+        //Editorial note, not visible for unauthenticated users
+        MapperUtils.addOptionalStringProperty(classResource, SKOS.editorialNote, dto.getEditorialNote());
+
+        var modelType = MapperUtils.getModelTypeFromResource(modelResource);
+        if(modelType.equals(ModelType.LIBRARY)){
+            classResource.addProperty(RDF.type, OWL.Class);
+            MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SKOS.note, model);
+
+            var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
+            var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
+            //Equivalent class
+            if(dto.getEquivalentClass() != null){
+                dto.getEquivalentClass().forEach(eq -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, OWL.equivalentClass, eq));
+            }
+            //Sub Class
+            if(dto.getSubClassOf() == null || dto.getSubClassOf().isEmpty()){
+                classResource.addProperty(RDFS.subClassOf, OWL.Thing); //Add OWL:Thing if nothing else is specified
+            }else{
+                dto.getSubClassOf().forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, RDFS.subClassOf, sub));
+            }
         }else{
-            dto.getSubClassOf().forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, RDFS.subClassOf, sub));
+            classResource.addProperty(RDF.type, SH.NodeShape);
+            classResource.addProperty(SH.targetClass, ResourceFactory.createResource(dto.getTargetClass()));
+            classResource.addProperty(SH.node, ResourceFactory.createResource(dto.getTargetNode()));
+            MapperUtils.addLocalizedProperty(langs, dto.getNote(), classResource, SH.description, model);
         }
 
         modelResource.addProperty(DCTerms.hasPart, classResource);
@@ -81,20 +81,77 @@ public class ClassMapper {
         return classUri;
     }
 
+    public static List<String> mapPlaceholderPropertyShapes(Model applicationProfileModel, String classURI,
+                                                            Model propertiesModel, YtiUser user) {
+        var iterator = propertiesModel.listSubjects();
+        var classResource = applicationProfileModel.getResource(classURI);
+        var propertyResourceURIs = new ArrayList<String>();
+        while (iterator.hasNext()) {
+            var uri = iterator.next().getURI();
+            var identifier = NodeFactory.createURI(uri).getLocalName();
+            var targetResource = propertiesModel.getResource(uri);
+            var propertyShapeResource = applicationProfileModel.createResource(classResource.getNameSpace() + identifier);
+            var label = targetResource.getProperty(RDFS.label);
+
+            if (label != null) {
+                // external class labels are defined often in only one language
+                if (label.getLanguage().equals("")) {
+                    MapperUtils.addLocalizedProperty(Set.of("en"),
+                            Map.of("en", label.getObject().toString()),
+                            propertyShapeResource,
+                            RDFS.label,
+                            applicationProfileModel);
+                } else {
+                    propertyShapeResource.addProperty(RDFS.label, label.getObject());
+                }
+            }
+
+            propertyShapeResource.addProperty(SH.path, ResourceFactory.createResource(uri))
+                    .addProperty(DCTerms.identifier, ResourceFactory.createTypedLiteral(identifier, XSDDatatype.XSDNCName))
+                    .addProperty(RDF.type, SH.PropertyShape)
+                    .addProperty(RDF.type, targetResource.getProperty(RDF.type).getObject())
+                    .addProperty(RDFS.isDefinedBy, classResource.getProperty(RDFS.isDefinedBy).getObject())
+                    .addProperty(OWL.versionInfo, Status.DRAFT.name());
+
+            MapperUtils.addCreationMetadata(propertyShapeResource, user);
+
+            classResource.addProperty(SH.property, propertyShapeResource);
+            propertyResourceURIs.add(propertyShapeResource.getURI());
+        }
+        return propertyResourceURIs;
+    }
+
     public static void mapToUpdateClass(Model model, String graph, Resource classResource, ClassDTO classDTO, YtiUser user) {
         logger.info("Updating class in graph {}", graph);
-        var updateDate = new XSDDateTime(Calendar.getInstance());
         var modelResource = model.getResource(graph);
         var languages = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
+        MapperUtils.updateStringProperty(classResource, SKOS.editorialNote, classDTO.getEditorialNote());
 
         var modelType = MapperUtils.getModelTypeFromResource(modelResource);
         if(modelType.equals(ModelType.LIBRARY)){
             MapperUtils.updateLocalizedProperty(languages, classDTO.getNote(), classResource, SKOS.note, model);
-            MapperUtils.updateStringProperty(classResource, SKOS.editorialNote, classDTO.getEditorialNote());
+
+            var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
+            var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
+
+            var equivalentClasses = classDTO.getEquivalentClass();
+            if(equivalentClasses != null){
+                classResource.removeAll(OWL.equivalentClass);
+                equivalentClasses.forEach(eq -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, OWL.equivalentClass, eq));
+            }
+
+            var subClassOf = classDTO.getSubClassOf();
+            if (subClassOf != null){
+                classResource.removeAll(RDFS.subClassOf);
+                if(subClassOf.isEmpty()){
+                    classResource.addProperty(RDFS.subClassOf, OWL.Thing); //Add OWL:Thing if no subClassOf is specified
+                }else{
+                    subClassOf.forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, RDFS.subClassOf, sub));
+                }
+            }
         }else{
             MapperUtils.updateUriProperty(classResource, SH.targetClass, classDTO.getTargetClass());
             MapperUtils.updateLocalizedProperty(languages, classDTO.getNote(), classResource, SH.description, model);
-            MapperUtils.updateStringProperty(classResource, DCTerms.description, classDTO.getEditorialNote());
         }
         MapperUtils.updateLocalizedProperty(languages, classDTO.getLabel(), classResource, RDFS.label, model);
         MapperUtils.updateUriProperty(classResource, DCTerms.subject, classDTO.getSubject());
@@ -104,28 +161,7 @@ public class ClassMapper {
             MapperUtils.updateStringProperty(classResource, OWL.versionInfo, status.name());
         }
 
-        var owlImports = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
-        var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
-
-        var equivalentClasses = classDTO.getEquivalentClass();
-        if(equivalentClasses != null){
-            classResource.removeAll(OWL.equivalentClass);
-            equivalentClasses.forEach(eq -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, OWL.equivalentClass, eq));
-        }
-
-        var subClassOf = classDTO.getSubClassOf();
-        if (subClassOf != null){
-            classResource.removeAll(RDFS.subClassOf);
-            if(subClassOf.isEmpty()){
-                classResource.addProperty(RDFS.subClassOf, OWL.Thing); //Add OWL:Thing if no subClassOf is specified
-            }else{
-                subClassOf.forEach(sub -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, RDFS.subClassOf, sub));
-            }
-        }
-        classResource.removeAll(DCTerms.modified);
-        classResource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(updateDate));
-        classResource.removeAll(Iow.modifier);
-        classResource.addProperty(Iow.modifier, user.getId().toString());
+        MapperUtils.addUpdateMetadata(classResource, user);
     }
 
     /**
@@ -188,13 +224,24 @@ public class ClassMapper {
         return dto;
     }
 
-    public static Query getClassResourcesQuery(String classUri){
+    public static ExternalClassDTO mapExternalClassToDTO(Model model, String uri) {
+        var resource = model.getResource(uri);
+
+        var dto = new ExternalClassDTO();
+        dto.setUri(uri);
+        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+        return dto;
+    }
+
+    public static Query getClassResourcesQuery(String classUri, boolean isExternal){
         var constructBuilder = new ConstructBuilder();
         var resourceName = "?resource";
         var uri = NodeFactory.createURI(classUri);
         SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDF.type, "?type");
         SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.label, "?label");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.identifier, "?identifier");
+        if (!isExternal) {
+            SparqlUtils.addConstructProperty(resourceName, constructBuilder, DCTerms.identifier, "?identifier");
+        }
         SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.isDefinedBy, "?isDefinedBy");
         var domainQuery = new WhereBuilder().addWhere(resourceName, RDFS.domain, uri)
                 .addWhere(resourceName, RDFS.domain, "?domain");
@@ -228,6 +275,44 @@ public class ClassMapper {
             dto.setAssociation(associations);
             dto.setAttribute(attributes);
         });
+    }
+
+    public static void addNodeShapeResourcesToDTO(Model model, ClassInfoDTO classDto) {
+        var propertyShapeURIs = model.getResource(classDto.getUri())
+                .listProperties(SH.property).toList().stream()
+                .map(p -> p.getObject().toString())
+                .toList();
+        propertyShapeURIs.forEach(uri -> {
+            var resource = model.getResource(uri);
+            var resDTO = new SimpleResourceDTO();
+            resDTO.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+            resDTO.setIdentifier(NodeFactory.createURI(uri).getLocalName());
+            resDTO.setUri(MapperUtils.propertyToString(resource, RDFS.isDefinedBy));
+
+            if (MapperUtils.hasType(resource, OWL.DatatypeProperty)) {
+                classDto.getAttribute().add(resDTO);
+            } else if (MapperUtils.hasType(resource, OWL.ObjectProperty)) {
+                classDto.getAssociation().add(resDTO);
+            }
+        });
+    }
+
+    public static void addExternalClassResourcesToDTO(Model classResources, ExternalClassDTO dto) {
+        var associations = new ArrayList<ExternalResourceDTO>();
+        var attributes = new ArrayList<ExternalResourceDTO>();
+
+        classResources.listSubjects().forEach(res -> {
+            var resourceDTO = new ExternalResourceDTO();
+            resourceDTO.setUri(res.getURI());
+            resourceDTO.setLabel(MapperUtils.localizedPropertyToMap(res, RDFS.label));
+            if (MapperUtils.hasType(res, OWL.ObjectProperty)) {
+                associations.add(resourceDTO);
+            } else if (MapperUtils.hasType(res, OWL.DatatypeProperty)) {
+                attributes.add(resourceDTO);
+            }
+        });
+        dto.setAttributes(attributes);
+        dto.setAssociations(associations);
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -1,13 +1,18 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
+import fi.vm.yti.datamodel.api.v2.dto.DCAP;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
+import fi.vm.yti.security.YtiUser;
+import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.JenaException;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 
@@ -47,7 +52,8 @@ public class MapperUtils {
     }
 
     /**
-     * Localized property to Map of (language, value)
+     * Localized property to Map of (language, value). If no language specified for property
+     * (e.g. external classes), handle that value as an english content
      * @param resource Resource to get property from
      * @param property Property type
      * @return Map of (language, value)
@@ -57,7 +63,11 @@ public class MapperUtils {
         resource.listProperties(property).forEach(prop -> {
             var lang = prop.getLanguage();
             var value = prop.getString();
-            map.put(lang, value);
+            if (lang == null || lang.trim().equals("")) {
+                map.put("en", value);
+            } else {
+                map.put(lang, value);
+            }
         });
         return map;
     }
@@ -249,8 +259,32 @@ public class MapperUtils {
         if (!resource.hasProperty(RDF.type)) {
             return false;
         }
+        var typeList = resource.listProperties(RDF.type).toList();
         return Arrays.stream(type)
-                .anyMatch(t -> t.equals(resource.getProperty(RDF.type).getResource()));
+                .anyMatch(t -> typeList.stream().anyMatch(r -> r.getResource().equals(t)));
     }
 
+    public static boolean isApplicationProfile(Resource resource) {
+        return hasType(resource, DCAP.DCAP, ResourceFactory.createProperty("http://www.w3.org/2002/07/dcap#DCAP"));
+    }
+
+    public static boolean isOntology(Resource resource) {
+        return hasType(resource, OWL.Ontology);
+    }
+
+    public static void addCreationMetadata(Resource resource, YtiUser user) {
+        var creationDate = new XSDDateTime(Calendar.getInstance());
+        resource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(creationDate))
+                .addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(creationDate))
+                .addProperty(Iow.creator, user.getId().toString())
+                .addProperty(Iow.modifier, user.getId().toString());
+    }
+
+    public static void addUpdateMetadata(Resource resource, YtiUser user) {
+        var updateDate = new XSDDateTime(Calendar.getInstance());
+        resource.removeAll(DCTerms.modified);
+        resource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(updateDate));
+        resource.removeAll(Iow.modifier);
+        resource.addProperty(Iow.modifier, user.getId().toString());
+    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -9,6 +9,7 @@ import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.*;
+import org.topbraid.shacl.vocabulary.SH;
 
 import java.util.Calendar;
 import java.util.function.Consumer;
@@ -143,17 +144,18 @@ public class ResourceMapper {
             indexResource.setContentModified(contentModified.getString());
         }
 
-        var typeProperty = resource.getProperty(RDF.type).getResource();
-        if(typeProperty.equals(OWL.ObjectProperty)){
+        if (MapperUtils.hasType(resource, OWL.ObjectProperty)) {
             indexResource.setResourceType(ResourceType.ASSOCIATION);
-        }else if(typeProperty.equals(OWL.DatatypeProperty)){
+        } else if (MapperUtils.hasType(resource, OWL.DatatypeProperty)) {
             indexResource.setResourceType(ResourceType.ATTRIBUTE);
-        }else{
+        } else {
             indexResource.setResourceType(ResourceType.CLASS);
         }
 
         indexResource.setDomain(MapperUtils.propertyToString(resource, RDFS.domain));
         indexResource.setRange(MapperUtils.propertyToString(resource, RDFS.range));
+
+        indexResource.setTargetClass(MapperUtils.propertyToString(resource, SH.targetClass));
 
         return indexResource;
     }
@@ -164,14 +166,14 @@ public class ResourceMapper {
         var dto = new ResourceInfoDTO();
         var resourceUri = modelUri + "#" + resourceIdentifier;
         var resourceResource = model.getResource(resourceUri);
-        var type = resourceResource.getProperty(RDF.type).getResource();
-        if(type.equals(OWL.ObjectProperty)){
+        if(MapperUtils.hasType(resourceResource, OWL.ObjectProperty)){
             dto.setType(ResourceType.ASSOCIATION);
-        }else if(type.equals(OWL.DatatypeProperty)){
+        }else if(MapperUtils.hasType(resourceResource, OWL.DatatypeProperty)){
             dto.setType(ResourceType.ATTRIBUTE);
         }else{
             throw new MappingError("Unsupported rdf:type");
         }
+
         dto.setUri(resourceUri);
         dto.setLabel(MapperUtils.localizedPropertyToMap(resourceResource, RDFS.label));
         var status = Status.valueOf(resourceResource.getProperty(OWL.versionInfo).getObject().toString().toUpperCase());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -12,6 +12,7 @@ public class ResourceSearchRequest extends BaseSearchRequest{
     private Set<String> groups;
     private Set<ResourceType> resourceTypes;
     private ModelType limitToModelType;
+    private String targetClass;
 
     public String getLimitToDataModel() {
         return limitToDataModel;
@@ -51,5 +52,13 @@ public class ResourceSearchRequest extends BaseSearchRequest{
 
     public void setLimitToModelType(ModelType limitToModelType) {
         this.limitToModelType = limitToModelType;
+    }
+
+    public String getTargetClass() {
+        return targetClass;
+    }
+
+    public void setTargetClass(String targetClass) {
+        this.targetClass = targetClass;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
@@ -15,6 +15,7 @@ public class IndexResource extends IndexBase {
     private String domain;
     private String range;
     private String subject;
+    private String targetClass;
 
     public ResourceType getResourceType() {
         return resourceType;
@@ -86,5 +87,13 @@ public class IndexResource extends IndexBase {
 
     public void setSubject(String subject) {
         this.subject = subject;
+    }
+
+    public String getTargetClass() {
+        return targetClass;
+    }
+
+    public void setTargetClass(String targetClass) {
+        this.targetClass = targetClass;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -65,6 +65,11 @@ public class ResourceQueryFactory {
             must.add(typeQuery);
         }
 
+        if (request.getTargetClass() != null) {
+            var targetClassQuery = QueryFactoryUtils.termQuery("targetClass", request.getTargetClass());
+            must.add(targetClassQuery);
+        }
+
         var finalQuery = QueryBuilders.bool()
                 .must(must)
                 .should(should)

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/MapperTestUtils.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/MapperTestUtils.java
@@ -2,8 +2,12 @@ package fi.vm.yti.datamodel.api.mapper;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -20,5 +24,13 @@ public class MapperTestUtils {
         assertNotNull(stream);
         RDFDataMgr.read(m, stream, RDFLanguages.TURTLE);
         return m;
+    }
+
+    public static Model getOrgModel(){
+        var model = ModelFactory.createDefaultModel();
+        model.createResource("urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")
+                .addProperty(RDF.type, FOAF.Organization)
+                .addProperty(SKOS.prefLabel, ResourceFactory.createLangLiteral("test org", "fi"));
+        return model;
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -1,0 +1,155 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.ClassDTO;
+import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
+import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.topbraid.shacl.vocabulary.SH;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+class NodeShapeMapperTest {
+
+    @Test
+    void testCreateNodeShapeAndMapToProfile() {
+        var model = MapperTestUtils.getModelFromFile("/test_datamodel_profile.ttl");
+        var propertiesQueryResult = MapperTestUtils.getModelFromFile("/properties_result.ttl");
+        var mockUser = EndpointUtils.mockUser;
+
+        ClassDTO dto = new ClassDTO();
+        dto.setIdentifier("TestClass");
+        dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
+        dto.setEditorialNote("comment");
+        dto.setLabel(Map.of("fi", "test label"));
+        dto.setStatus(Status.DRAFT);
+        dto.setNote(Map.of("fi", "test note"));
+        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target#Class");
+
+        ClassMapper.createClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", model, dto, mockUser);
+        ClassMapper.mapPlaceholderPropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test#TestClass",
+                propertiesQueryResult, mockUser);
+
+        Resource modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
+        Resource classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+
+        assertNotNull(modelResource);
+        assertNotNull(classResource);
+
+        assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+
+        assertEquals(1, classResource.listProperties(RDFS.label).toList().size());
+        assertEquals("test label", classResource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", classResource.getProperty(RDFS.label).getLiteral().getLanguage());
+
+        assertEquals(SH.NodeShape, classResource.getProperty(RDF.type).getResource());
+        assertEquals(Status.DRAFT, Status.valueOf(classResource.getProperty(OWL.versionInfo).getObject().toString()));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", classResource.getProperty(RDFS.isDefinedBy).getObject().toString());
+
+        assertEquals(XSDDatatype.XSDNCName, classResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
+        assertEquals("TestClass", classResource.getProperty(DCTerms.identifier).getLiteral().getString());
+
+        assertEquals("comment", MapperUtils.propertyToString(classResource, SKOS.editorialNote));
+        assertEquals("test note", classResource.getProperty(SH.description).getLiteral().getString());
+        assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.creator).getString());
+        assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.modifier).getString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", classResource.getProperty(SH.targetClass).getObject().toString());
+
+        assertEquals(2, classResource.listProperties(SH.property).toList().size());
+        var propertyShapeAttribute = model.getResource("http://uri.suomi.fi/datamodel/ns/test#attribute-1");
+        var propertyShapeAssociation = model.getResource("http://uri.suomi.fi/datamodel/ns/test#association-1");
+
+        assertNotNull(propertyShapeAttribute);
+        assertNotNull(propertyShapeAssociation);
+
+        // PropertyShapes should have two type properties
+        assertTrue(MapperUtils.hasType(propertyShapeAttribute, SH.PropertyShape));
+        assertTrue(MapperUtils.hasType(propertyShapeAttribute, OWL.DatatypeProperty));
+
+        assertTrue(MapperUtils.hasType(propertyShapeAssociation, SH.PropertyShape));
+        assertTrue(MapperUtils.hasType(propertyShapeAssociation, OWL.ObjectProperty));
+
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1",
+                propertyShapeAttribute.getProperty(SH.path).getObject().toString());
+        assertEquals(Status.DRAFT.name(), propertyShapeAttribute.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));
+    }
+
+    @Test
+    void testMapNodeShapeToClassDTO(){
+        var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
+
+        var dto = ClassMapper.mapToClassDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestClass", MapperTestUtils.getOrgModel(), false, null);
+
+        // not authenticated
+        assertNull(dto.getEditorialNote());
+        assertEquals(Status.VALID, dto.getStatus());
+        assertEquals("TestClass", dto.getIdentifier());
+        assertEquals(1, dto.getLabel().size());
+        assertEquals("test label", dto.getLabel().get("fi"));
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
+        assertEquals(2, dto.getNote().size());
+        assertEquals("test technical description fi", dto.getNote().get("fi"));
+        assertEquals("test technical description en", dto.getNote().get("en"));
+        assertEquals("2023-02-03T11:46:36.404Z", dto.getModified());
+        assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
+        assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
+        assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", dto.getTargetClass());
+    }
+
+    @Test
+    void testMapToUpdateClassProfile(){
+        var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var mockUser = EndpointUtils.mockUser;
+
+        var dto = new ClassDTO();
+        dto.setLabel(Map.of("fi", "new label"));
+        dto.setStatus(Status.INVALID);
+        dto.setNote(Map.of("fi", "new note"));
+        dto.setSubject("http://uri.suomi.fi/terminology/qwe");
+        dto.setEditorialNote("new editorial note");
+        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target#NewClass");
+
+        assertEquals(SH.NodeShape, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
+        assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(2, resource.listProperties(SH.description).toList().size());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", resource.getProperty(SH.targetClass).getObject().toString());
+
+        ClassMapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
+
+        assertEquals(SH.NodeShape, resource.getProperty(RDF.type).getResource());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
+        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
+        assertEquals(1, resource.listProperties(SH.description).toList().size());
+        assertEquals("new note", resource.getProperty(SH.description).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(SH.description).getLiteral().getLanguage());
+        assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
+        assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
+    }
+
+}

--- a/src/test/resources/external_class.ttl
+++ b/src/test/resources/external_class.ttl
@@ -1,0 +1,25 @@
+@prefix mo:      <http://purl.org/ontology/mo/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vs:      <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+
+mo:AudioFile
+      rdf:type owl:Class ;
+      rdfs:comment "An audio file, which may be available on a local file system or through http, ftp, etc." ;
+      rdfs:isDefinedBy mo: ;
+      rdfs:label "audio file" ;
+      rdfs:subClassOf mo:Medium , foaf:Document ;
+      mo:level "1" ;
+      vs:term_status "unstable" .
+
+mo:encoding
+      rdf:type owl:DatatypeProperty ;
+      rdfs:comment "Method used to convert analog electronic signals into digital format such as \"MP3 CBR @ 128kbps\", \"OGG @ 160kbps\", \"FLAC\", etc." ;
+      rdfs:domain mo:AudioFile ;
+      rdfs:isDefinedBy mo: ;
+      rdfs:label "encoding" ;
+      rdfs:range rdfs:Literal ;
+      mo:level "1" ;
+      vs:term_status "unstable" .

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -37,15 +37,13 @@ dcap:preferredXMLNamespacePrefix    "extres" .
 test:TestClass  rdf:type     sh:NodeShape ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test label"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test#SubClass> ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test#EqClass> ;
         owl:versionInfo      "VALID" ;
-        dcterms:description   "comment visible for admin" ;
-        sh:description         "test note fi"@fi, "test note en"@en ;
-        iow:creator           "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        iow:modifier          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        sh:targetClass        <http://uri.suomi.fi/datamodel/ns/target#Class> .
+        skos:editorialNote   "comment visible for admin" ;
+        sh:description       "test technical description fi"@fi, "test technical description en"@en ;
+        iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target#Class> .

--- a/src/test/resources/properties_result.ttl
+++ b/src/test/resources/properties_result.ttl
@@ -1,0 +1,23 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1>
+        rdf:type            owl:DatatypeProperty ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
+        rdfs:label          "Attribute attribute-1"@fi ;
+        dcterms:identifier  "attribute-1"^^xsd:NCName ;
+        owl:versionInfo     "VALID" .
+
+<http://uri.suomi.fi/datamodel/ns/test_lib#association-1>
+        rdf:type            owl:ObjectProperty ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
+        rdfs:label          "Association association-1"@fi ;
+        dcterms:identifier  "attribute-1"^^xsd:NCName ;
+        owl:versionInfo     "VALID" .


### PR DESCRIPTION
- While saving new node shape, create also placeholder property shapes based on selection in creation modal
- New endpoints for getting external class and searching all node shapes based on specific class (sh:targetClass)
- Refactoring: checking resource type, separate tests for class and node shape
- Some fixes to indexing: bulk indexing in batches, add resource type to query in index initialization