### PR TITLE
Feature yti 2606 codelist support

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
@@ -37,7 +37,7 @@ public class RestConfig {
     }
 
     @Bean("uriResolveClient")
-    WebClient terminologyWebClient() {
+    WebClient uriResolveClient() {
         return WebClient.builder()
                 .defaultHeaders(headers -> headers.addAll(defaultHttpHeaders))
                 .baseUrl(URI_SUOMI_FI)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/CodeListDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/CodeListDTO.java
@@ -1,0 +1,37 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CodeListDTO {
+
+    private String id;
+    private Map<String, String> prefLabel;
+    private Status status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Map<String, String> getPrefLabel() {
+        return prefLabel;
+    }
+
+    public void setPrefLabel(Map<String, String> prefLabel) {
+        this.prefLabel = prefLabel;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelDTO.java
@@ -20,6 +20,7 @@ public class DataModelDTO {
     private Set<String> internalNamespaces = Set.of();
     private Set<ExternalNamespaceDTO> externalNamespaces = Set.of();
     private Set<String> terminologies = Set.of();
+    private Set<String> codeLists;
     private String contact;
 
     public ModelType getType() {
@@ -113,6 +114,14 @@ public class DataModelDTO {
 
     public void setTerminologies(Set<String> terminologies) {
         this.terminologies = terminologies;
+    }
+
+    public Set<String> getCodeLists() {
+        return codeLists;
+    }
+
+    public void setCodeLists(Set<String> codeLists) {
+        this.codeLists = codeLists;
     }
 
     public String getContact() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
@@ -15,6 +15,7 @@ public class DataModelInfoDTO extends ResourceInfoBaseDTO {
     private Set<String> internalNamespaces = Set.of();
     private Set<ExternalNamespaceDTO> externalNamespaces = Set.of();
     private Set<TerminologyDTO> terminologies = Set.of();
+    private Set<CodeListDTO> codeLists = Set.of();
 
     private String contact;
 
@@ -112,5 +113,13 @@ public class DataModelInfoDTO extends ResourceInfoBaseDTO {
 
     public void setContact(String contact) {
         this.contact = contact;
+    }
+
+    public Set<CodeListDTO> getCodeLists() {
+        return codeLists;
+    }
+
+    public void setCodeLists(Set<CodeListDTO> codeLists) {
+        this.codeLists = codeLists;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
@@ -17,4 +17,6 @@ public class Iow {
     public static final Property contact = ResourceFactory.createProperty(URI, "contact");
     public static final Property creator = ResourceFactory.createProperty(URI, "creator");
     public static final Property modifier = ResourceFactory.createProperty(URI, "modifier");
+    public static final Property codeLists = ResourceFactory.createProperty(URI, "codeLists");
+    public static final Property CodeScheme = ResourceFactory.createProperty(URI, "CodeScheme");
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -7,6 +7,7 @@ import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
+import fi.vm.yti.datamodel.api.v2.service.CodeListService;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
@@ -42,6 +43,8 @@ public class Datamodel {
 
     private final TerminologyService terminologyService;
 
+    private final CodeListService codelistService;
+
     private final AuthenticatedUserProvider userProvider;
 
     private final GroupManagementService groupManagementService;
@@ -51,6 +54,7 @@ public class Datamodel {
                      OpenSearchIndexer openSearchIndexer,
                      ModelMapper modelMapper,
                      TerminologyService terminologyService,
+                     CodeListService codelistService,
                      AuthenticatedUserProvider userProvider,
                      GroupManagementService groupManagementService) {
         this.authorizationManager = authorizationManager;
@@ -58,6 +62,7 @@ public class Datamodel {
         this.openSearchIndexer = openSearchIndexer;
         this.jenaService = jenaService;
         this.terminologyService = terminologyService;
+        this.codelistService = codelistService;
         this.userProvider = userProvider;
         this.groupManagementService = groupManagementService;
     }
@@ -71,6 +76,7 @@ public class Datamodel {
         check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
 
         terminologyService.resolveTerminology(modelDTO.getTerminologies());
+        codelistService.resolveCodelistScheme(modelDTO.getCodeLists());
         var jenaModel = mapper.mapToJenaModel(modelDTO, userProvider.getUser());
 
         jenaService.putDataModelToCore(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);
@@ -95,6 +101,7 @@ public class Datamodel {
         check(authorizationManager.hasRightToModel(prefix, oldModel));
 
         terminologyService.resolveTerminology(modelDTO.getTerminologies());
+        codelistService.resolveCodelistScheme(modelDTO.getCodeLists());
 
         var jenaModel = mapper.mapToUpdateJenaModel(prefix, modelDTO, oldModel, userProvider.getUser());
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CodeListMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CodeListMapper.java
@@ -1,0 +1,36 @@
+package fi.vm.yti.datamodel.api.v2.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.CodeListDTO;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+
+public class CodeListMapper {
+
+    private CodeListMapper(){
+        //static class
+    }
+
+    public static Model mapToJenaModel(String graph, CodeListDTO codelistDTO){
+        var model = ModelFactory.createDefaultModel();
+        var resource = model.createResource(graph)
+                .addProperty(RDF.type, Iow.CodeScheme);
+        codelistDTO.getPrefLabel().forEach((lang, val) -> resource.addProperty(RDFS.label, model.createLiteral(val, lang)));
+        resource.addProperty(OWL.versionInfo, codelistDTO.getStatus().toString());
+        return model;
+    }
+
+    public static CodeListDTO mapToCodeListDTO(String graph, Model model) {
+        var dto = new CodeListDTO();
+        var resource = model.getResource(graph);
+        var label = MapperUtils.localizedPropertyToMap(resource, RDFS.label);
+        dto.setPrefLabel(label);
+        dto.setId(graph);
+        dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, OWL.versionInfo)));
+        return dto;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
@@ -6,7 +6,6 @@ import fi.vm.yti.datamodel.api.v2.dto.TerminologyDTO;
 import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.*;
 
@@ -17,22 +16,13 @@ public class TerminologyMapper {
     private TerminologyMapper() {
     }
 
-    public static Model mapTerminologyToJenaModel(String graph, TerminologyNodeDTO terminologyDTO, Model model) {
-        Resource resource;
-        if (model == null) {
-            model = ModelFactory.createDefaultModel();
-            resource = model.createResource(graph);
-            resource.addProperty(RDF.type, SKOS.ConceptScheme);
-        } else {
-            resource = model.getResource(graph);
-            resource.removeAll(RDFS.label);
-        }
+    public static Model mapTerminologyToJenaModel(String graph, TerminologyNodeDTO terminologyDTO) {
+        var model = ModelFactory.createDefaultModel();
+        var resource = model.createResource(graph)
+                        .addProperty(RDF.type, SKOS.ConceptScheme);
 
         var prefLabels = terminologyDTO.getProperties().getPrefLabel();
-        for (var label : prefLabels) {
-            resource.addProperty(RDFS.label, model.createLiteral(label.getValue(), label.getLang()));
-        }
-
+        prefLabels.forEach(label -> resource.addProperty(RDFS.label, model.createLiteral(label.getValue(), label.getLang())));
         return model;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/CodeListService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/CodeListService.java
@@ -1,0 +1,66 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import fi.vm.yti.datamodel.api.v2.dto.CodeListDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.CodeListMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+import java.util.Set;
+
+@Service
+public class CodeListService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CodeListService.class);
+
+    /**
+     * Control which environment is used for resolving terminology uris.
+     * Possible values: awsdev, awstest and awslocal. Resolve from prod if empty
+     */
+    @Value("${env:}")
+    private String awsEnv;
+    private final WebClient client;
+    private final JenaService jenaService;
+
+    public CodeListService(
+            @Qualifier("uriResolveClient") WebClient webClient,
+            JenaService jenaService) {
+        this.jenaService = jenaService;
+        this.client = webClient;
+    }
+
+    /**
+     * Fetch CodeList information and persist to Fuseki
+     * @param codeLists set of uris
+     */
+    public void resolveCodelistScheme(Set<String> codeLists) {
+        codeLists.forEach(codeList -> {
+            var uri = URI.create(codeList);
+            LOG.debug("Fetching codelist {}", uri);
+            try {
+                var result = client.get().uri(builder -> builder
+                                .path(uri.getPath())
+                                .queryParam("env", awsEnv)
+                                .build())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .retrieve()
+                        .bodyToMono(new ParameterizedTypeReference<CodeListDTO>() {})
+                        .block();
+
+                if (result != null) {
+                    var model = CodeListMapper.mapToJenaModel(codeList, result);
+                    jenaService.putCodelistSchemeToSchemes(codeList, model);
+                }
+            } catch (Exception e) {
+                LOG.warn("Could not resolve codelist scheme {}, {}", uri, e.getMessage());
+            }
+        });
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -6,7 +6,6 @@ import fi.vm.yti.datamodel.api.v2.dto.ResourceInfoDTO;
 import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResolvingException;
 import fi.vm.yti.datamodel.api.v2.mapper.TerminologyMapper;
-import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -70,8 +69,7 @@ public class TerminologyService {
                         .findFirst();
 
                 if (node.isPresent()) {
-                    var terminologyModel = jenaService.getTerminology(uri.toString());
-                    Model model = TerminologyMapper.mapTerminologyToJenaModel(u, node.get(), terminologyModel);
+                    var model = TerminologyMapper.mapTerminologyToJenaModel(u, node.get());
                     jenaService.putTerminologyToConcepts(uri.toString(), model);
                 } else {
                     LOG.warn("Could not find node with type TerminologicalVocabulary from {}", uri);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.validator;
 
 import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.SKOS;
@@ -39,7 +40,9 @@ public class DataModelValidator extends BaseValidator implements
         checkInternalNamespaces(context, dataModel);
         checkExternalNamespaces(context, dataModel);
 
+
         checkTerminologies(context, dataModel);
+        checkCodeLists(context, dataModel);
         return !isConstraintViolationAdded();
     }
 
@@ -264,6 +267,20 @@ public class DataModelValidator extends BaseValidator implements
 
         if (!dataModel.getTerminologies().stream().allMatch(uri -> uri.matches("^https?://uri.suomi.fi/terminology/(.*)"))) {
             addConstraintViolation(context, "invalid-terminology-uri", "terminologies");
+        }
+    }
+
+    private void checkCodeLists(ConstraintValidatorContext context, DataModelDTO dataModel) {
+        if (dataModel.getCodeLists() == null) {
+            return;
+        }
+
+        if(!updateModel && dataModel.getType().equals(ModelType.LIBRARY)){
+            addConstraintViolation(context, "library-not-supported", "codeLists");
+        }
+
+        if (!dataModel.getCodeLists().stream().allMatch(uri -> uri.matches("^https?://uri.suomi.fi/codelist/(.*)"))) {
+            addConstraintViolation(context, "invalid-codelist-uri", "codeLists");
         }
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/CodeListMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/CodeListMapperTest.java
@@ -1,0 +1,44 @@
+package fi.vm.yti.datamodel.api.mapper;
+
+import fi.vm.yti.datamodel.api.v2.dto.CodeListDTO;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+import fi.vm.yti.datamodel.api.v2.mapper.CodeListMapper;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CodeListMapperTest {
+
+    @Test
+    void mapTerminologyToJenaModel() {
+        String graph = "http://uri.suomi.fi/codelist/test/testlist";
+        var dto = new CodeListDTO();
+        dto.setId(graph);
+        dto.setStatus(Status.DRAFT);
+        dto.setPrefLabel(Map.of("en", "Test"));
+
+        var model = CodeListMapper.mapToJenaModel(graph, dto);
+        var resource = model.getResource(graph);
+
+        assertEquals(graph, resource.getURI());
+        assertEquals("Test@en", resource.getProperty(RDFS.label).getObject().toString());
+        assertEquals("DRAFT", resource.getProperty(OWL.versionInfo).getObject().toString());
+    }
+
+    @Test
+    void mapTerminologyDTO() {
+        var model = MapperTestUtils.getModelFromFile("/codelist.ttl");
+
+        var dto = CodeListMapper.mapToCodeListDTO(
+                "http://uri.suomi.fi/codelist/test/testcodelist", model);
+
+        assertEquals(Map.of("fi", "testkoodisto", "en", "Test codelist"), dto.getPrefLabel());
+        assertEquals(Status.DRAFT, dto.getStatus());
+        assertEquals("http://uri.suomi.fi/codelist/test/testcodelist", dto.getId());
+
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -79,6 +79,8 @@ class ModelMapperTest {
         dto.setType(ModelType.PROFILE);
         dto.setInternalNamespaces(Set.of("http://uri.suomi.fi/datamodel/ns/newint"));
         dto.setContact("test@localhost");
+        dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test/testcodelist"));
+        dto.setTerminologies(Set.of("http://uri.suomi.fi/terminology/test"));
         var externalDTO = new ExternalNamespaceDTO();
         externalDTO.setName("test dto");
         externalDTO.setNamespace("http://www.w3.org/2000/01/rdf-schema#");
@@ -104,6 +106,8 @@ class ModelMapperTest {
 
         assertEquals(mockUser.getId().toString(), MapperUtils.propertyToString(modelResource, Iow.creator));
         assertEquals(mockUser.getId().toString(), MapperUtils.propertyToString(modelResource, Iow.modifier));
+        assertEquals("http://uri.suomi.fi/codelist/test/testcodelist", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+        assertEquals("http://uri.suomi.fi/terminology/test", MapperUtils.propertyToString(modelResource, DCTerms.references));
 
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
     }
@@ -133,6 +137,7 @@ class ModelMapperTest {
         dto.setLanguages(Set.of("fi", "sv"));
         dto.setOrganizations(Set.of(organizationId));
         dto.setContact("new@localhost");
+        dto.setTerminologies(Set.of("http://uri.suomi.fi/terminology/newtest"));
 
         dto.setInternalNamespaces(Set.of("http://uri.suomi.fi/datamodel/ns/newint"));
         var externalDTO = new ExternalNamespaceDTO();
@@ -160,6 +165,8 @@ class ModelMapperTest {
 
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
 
+        assertEquals("http://uri.suomi.fi/terminology/test", MapperUtils.propertyToString(modelResource, DCTerms.references));
+
         Model model = mapper.mapToUpdateJenaModel("test", dto, m, mockUser);
 
         //changed values
@@ -184,7 +191,38 @@ class ModelMapperTest {
         assertEquals(mockUser.getId().toString(), modelResource.getProperty(Iow.modifier).getString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", modelResource.getProperty(Iow.creator).getObject().toString());
 
+        assertEquals("http://uri.suomi.fi/terminology/newtest", MapperUtils.propertyToString(modelResource, DCTerms.references));
+
         assertEquals("new@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
+    }
+
+    @Test
+    void testMapToUpdateModelProfile(){
+        //Testing profile specific properties
+        var m = MapperTestUtils.getModelFromFile("/test_datamodel_profile.ttl");
+        when(jenaService.getDataModel("test")).thenReturn(m);
+        var mockModel = ModelFactory.createDefaultModel();
+        mockModel.createResource("http://uri.suomi.fi/datamodel/ns/newint")
+                .addProperty(RDF.type, DCAP.DCAP)
+                .addProperty(DCAP.preferredXMLNamespacePrefix, "test");
+        when(jenaService.getDataModel(anyString())).thenReturn(mockModel);
+
+        YtiUser mockUser = EndpointUtils.mockUser;
+
+        DataModelDTO dto = new DataModelDTO();
+        dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test/newcodelist"));
+
+        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
+        assertEquals("http://uri.suomi.fi/codelist/test/testcodelist", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+
+        Model model = mapper.mapToUpdateJenaModel("test", dto, m, mockUser);
+
+
+        //changed values
+        modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
+        assertEquals("http://uri.suomi.fi/codelist/test/newcodelist", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+
+
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/TerminologyMapperTest.java
@@ -30,7 +30,7 @@ class TerminologyMapperTest {
         dto.setUri(graph);
         dto.setProperties(properties);
 
-        var model = TerminologyMapper.mapTerminologyToJenaModel(graph, dto, null);
+        var model = TerminologyMapper.mapTerminologyToJenaModel(graph, dto);
         var resource = model.getResource(graph);
 
         assertEquals(graph, resource.getURI());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -6,6 +6,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
+import fi.vm.yti.datamodel.api.v2.service.CodeListService;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
@@ -66,6 +67,9 @@ class DatamodelTest {
 
     @MockBean
     private TerminologyService terminologyService;
+
+    @MockBean
+    private CodeListService codeListService;
 
     @MockBean
     private GroupManagementService groupManagementService;
@@ -428,6 +432,10 @@ class DatamodelTest {
 
         dataModelDTO = createDatamodelDTO(false);
         dataModelDTO.setTerminologies(Set.of("http://invalid.url"));
+        args.add(dataModelDTO);
+
+        dataModelDTO = createDatamodelDTO(false);
+        dataModelDTO.setCodeLists(Set.of("http://invalid.url"));
         args.add(dataModelDTO);
 
         dataModelDTO = createDatamodelDTO(false);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/CodeListServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/CodeListServiceTest.java
@@ -1,0 +1,87 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.datamodel.api.v2.dto.CodeListDTO;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        CodeListService.class
+})
+class CodeListServiceTest {
+
+    @MockBean
+    @Qualifier("uriResolveClient")
+    private WebClient client;
+    @MockBean
+    private JenaService jenaService;
+    private final ObjectMapper mapper = new ObjectMapper();
+    @Captor
+    private ArgumentCaptor<String> stringCaptor;
+    @Captor
+    private ArgumentCaptor<Model> modelCaptor;
+    @Autowired
+    private CodeListService service;
+
+    static final String GRAPH = "http://uri.suomi.fi/terminology/test/testcodelist";
+
+    @Test
+    void testResolveTerminology() throws IOException {
+        var stream = getClass().getResourceAsStream("/codelist_response.json");
+        assertNotNull(stream);
+        var codelistData = mapper.readValue(stream, CodeListDTO.class);
+        mockWebClient(codelistData);
+
+        service.resolveCodelistScheme(Set.of(GRAPH));
+
+        verify(jenaService).putCodelistSchemeToSchemes(stringCaptor.capture(), modelCaptor.capture());
+        var label = MapperUtils.localizedPropertyToMap(modelCaptor.getValue().getResource(GRAPH), RDFS.label);
+
+        assertEquals(GRAPH, stringCaptor.getValue());
+        assertEquals("testcodelist", label.get("fi"));
+    }
+
+    @Test
+    void testTerminologyNotFound() {
+        mockWebClient(null);
+        service.resolveCodelistScheme(Set.of(GRAPH));
+        verifyNoInteractions(jenaService);
+    }
+
+    private void mockWebClient(CodeListDTO result) {
+        var req = mock(WebClient.RequestHeadersUriSpec.class);
+        var res = mock(WebClient.ResponseSpec.class);
+        var mono = mock(Mono.class);
+
+        when(res.bodyToMono(any(ParameterizedTypeReference.class))).thenReturn(mono);
+        when(mono.block()).thenReturn(result);
+
+        when(client.get()).thenReturn(req);
+        when(req.uri(any(Function.class))).thenReturn(req);
+        when(req.accept(any(MediaType.class))).thenReturn(req);
+        when(req.retrieve()).thenReturn(res);
+    }
+}

--- a/src/test/resources/codelist.ttl
+++ b/src/test/resources/codelist.ttl
@@ -1,0 +1,9 @@
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+
+<http://uri.suomi.fi/codelist/test/testcodelist>
+    a               iow:CodeScheme ;
+    rdfs:label      "testkoodisto"@fi , "Test codelist"@en  ;
+    owl:versionInfo "DRAFT" .

--- a/src/test/resources/codelist_response.json
+++ b/src/test/resources/codelist_response.json
@@ -1,0 +1,54 @@
+{
+  "id": "1239d128-5560-4574-8d98-6dc38d8ed1ce",
+  "codeValue": "CODEVALUE",
+  "uri": "http://uri.suomi.fi/codelist/test/testcodelist",
+  "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/test/codeschemes/testcodelist",
+  "codesUrl": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/test/codeschemes/testcodelist/codes/",
+  "extensionsUrl": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/test/codeschemes/testcodelist/extensions/",
+  "prefLabel": {
+    "fi": "testcodelist"
+  },
+  "definition": {
+    "fi": "testcodelist definition"
+  },
+  "description": {
+    "fi": "testcodelist description"
+  },
+  "created": "2023-05-15T13:44:34.635Z",
+  "modified": "2023-05-15T13:44:34.635Z",
+  "contentModified": "2023-05-15T13:44:34.635Z",
+  "statusModified": "2023-05-15T13:44:34.635Z",
+  "status": "DRAFT",
+  "infoDomains": [
+    {
+      "uri": "http://uri.suomi.fi/codelist/jupo/serviceclassification/code/P4",
+      "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/jupo/codeschemes/serviceclassification/codes/P4"
+    }
+  ],
+  "languageCodes": [
+    {
+      "uri": "http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes/code/fi",
+      "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/interoperabilityplatform/codeschemes/languagecodes/codes/fi"
+    },
+    {
+      "uri": "http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes/code/sv",
+      "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/interoperabilityplatform/codeschemes/languagecodes/codes/sv"
+    },
+    {
+      "uri": "http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes/code/en",
+      "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/interoperabilityplatform/codeschemes/languagecodes/codes/en"
+    }
+  ],
+  "organizations": [
+    {
+      "id": "7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"
+    }
+  ],
+  "cumulative": false,
+  "codeRegistry": {
+    "uri": "http://uri.suomi.fi/codelist/test",
+    "url": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/test"
+  },
+  "totalNrOfSearchHitsCodes": 0,
+  "totalNrOfSearchHitsExtensions": 0
+}

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -26,7 +26,8 @@
         owl:versionInfo                 "VALID" ;
         iow:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        iow:contact                     "test@localhost"                       .
+        iow:contact                     "test@localhost"                       ;
+        dcterms:references              "http://uri.suomi.fi/terminology/test" .
 
 <https://www.example.com/ns/ext>
         dcterms:type                        rdfs:Resource ;

--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -26,7 +26,9 @@
         owl:versionInfo                 "VALID" ;
         iow:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        iow:contact                     "test@localhost"                       .
+        iow:contact                     "test@localhost"                       ;
+        iow:codeLists                   "http://uri.suomi.fi/codelist/test/testcodelist" .
+
 
 <https://www.example.com/ns/ext>
         dcterms:type                        rdfs:Resource ;


### PR DESCRIPTION
Changelog:
- Codelist support for application profile
  - Mapper
  - Service
  - DTO
- Simplified terminology mapping and service, there is no need to get the old model for a terminology if we are replacing all of its contents anyway, better to just put a new one in its place
- rename uriresolveclient
- Unit tests