### PR TITLE
YTI-2591 refactor nodeshape and class handling

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/BaseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/BaseDTO.java
@@ -5,20 +5,59 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.util.Map;
 
 public abstract class BaseDTO {
-    private final String id;
-    private final Map<String, String> label;
-
-    protected BaseDTO(String id, Map<String, String> label) {
-        this.id = id;
-        this.label = label;
-    }
-
-    public String getId() {
-        return id;
-    }
+    private Map<String, String> label;
+    private String identifier;
+    private String subject;
+    private Map<String, String> note;
+    private String editorialNote;
+    private Status status;
 
     public Map<String, String> getLabel() {
         return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getEditorialNote() {
+        return editorialNote;
+    }
+
+    public void setEditorialNote(String editorialNote) {
+        this.editorialNote = editorialNote;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public Map<String, String> getNote() {
+        return note;
+    }
+
+    public void setNote(Map<String, String> note) {
+        this.note = note;
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassDTO.java
@@ -1,48 +1,11 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-public class ClassDTO {
+public class ClassDTO extends BaseDTO {
 
-    private Map<String, String> label;
-    private String editorialNote;
-    private Status status;
     private Set<String> equivalentClass;
     private Set<String> subClassOf;
-    private String subject;
-    private String identifier;
-    private Map<String, String> note;
-    private String targetClass; //Only allowed in Application profile classes
-    private String targetNode;
-    private List<String> properties;
-
-    public Map<String, String> getLabel() {
-        return label;
-    }
-
-    public void setLabel(Map<String, String> label) {
-        this.label = label;
-    }
-
-    public String getEditorialNote() {
-        return editorialNote;
-    }
-
-    public void setEditorialNote(String editorialNote) {
-        this.editorialNote = editorialNote;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 
     public Set<String> getEquivalentClass() {
         return equivalentClass;
@@ -60,56 +23,4 @@ public class ClassDTO {
         this.subClassOf = subClassOf;
     }
 
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public Map<String, String> getNote() {
-        return note;
-    }
-
-    public void setNote(Map<String, String> note) {
-        this.note = note;
-    }
-
-    public String getTargetClass() {
-        return targetClass;
-    }
-
-    public void setTargetClass(String targetClass) {
-        this.targetClass = targetClass;
-    }
-
-    public String getTargetNode() {
-        return targetNode;
-    }
-
-    public void setTargetNode(String targetNode) {
-        this.targetNode = targetNode;
-    }
-
-    public List<String> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(List<String> properties) {
-        this.properties = properties;
-    }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
@@ -1,50 +1,10 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class ClassInfoDTO extends ResourceInfoBaseDTO {
-
-    private Map<String, String> label;
-    private String editorialNote;
-    private Status status;
     private Set<String> equivalentClass;
     private Set<String> subClassOf;
-    private ConceptDTO subject;
-    private String identifier;
-    private Map<String, String> note;
-    private String uri;
-    private Set<OrganizationDTO> contributor;
-    private String contact;
-    private List<SimpleResourceDTO> attribute = new ArrayList<>();
-    private List<SimpleResourceDTO> association = new ArrayList<>();
-    private String targetClass;
-
-    public Map<String, String> getLabel() {
-        return label;
-    }
-
-    public void setLabel(Map<String, String> label) {
-        this.label = label;
-    }
-
-    public String getEditorialNote() {
-        return editorialNote;
-    }
-
-    public void setEditorialNote(String editorialNote) {
-        this.editorialNote = editorialNote;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 
     public Set<String> getEquivalentClass() {
         return equivalentClass;
@@ -60,77 +20,5 @@ public class ClassInfoDTO extends ResourceInfoBaseDTO {
 
     public void setSubClassOf(Set<String> subClassOf) {
         this.subClassOf = subClassOf;
-    }
-
-    public ConceptDTO getSubject() {
-        return subject;
-    }
-
-    public void setSubject(ConceptDTO subject) {
-        this.subject = subject;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public Map<String, String> getNote() {
-        return note;
-    }
-
-    public void setNote(Map<String, String> note) {
-        this.note = note;
-    }
-
-    public String getUri() {
-        return uri;
-    }
-
-    public void setUri(String uri) {
-        this.uri = uri;
-    }
-
-    public Set<OrganizationDTO> getContributor() {
-        return contributor;
-    }
-
-    public void setContributor(Set<OrganizationDTO> contributor) {
-        this.contributor = contributor;
-    }
-
-    public String getContact() {
-        return contact;
-    }
-
-    public void setContact(String contact) {
-        this.contact = contact;
-    }
-
-    public List<SimpleResourceDTO> getAttribute() {
-        return attribute;
-    }
-
-    public void setAttribute(List<SimpleResourceDTO> attribute) {
-        this.attribute = attribute;
-    }
-
-    public List<SimpleResourceDTO> getAssociation() {
-        return association;
-    }
-
-    public void setAssociation(List<SimpleResourceDTO> association) {
-        this.association = association;
-    }
-
-    public String getTargetClass() {
-        return targetClass;
-    }
-
-    public void setTargetClass(String targetClass) {
-        this.targetClass = targetClass;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
@@ -3,7 +3,7 @@ package fi.vm.yti.datamodel.api.v2.dto;
 import java.util.Map;
 import java.util.Set;
 
-public class DataModelInfoDTO extends ResourceInfoBaseDTO {
+public class DataModelInfoDTO extends ResourceCommonDTO {
     private ModelType type;
     private String prefix;
     private Status status;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.List;
+
+public class NodeShapeDTO extends BaseDTO {
+    private String targetClass;
+    private String targetNode;
+    private List<String> properties;
+
+    public String getTargetNode() {
+        return targetNode;
+    }
+
+    public void setTargetNode(String targetNode) {
+        this.targetNode = targetNode;
+    }
+
+    public List<String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<String> properties) {
+        this.properties = properties;
+    }
+
+    public String getTargetClass() {
+        return targetClass;
+    }
+
+    public void setTargetClass(String targetClass) {
+        this.targetClass = targetClass;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
@@ -1,0 +1,22 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+public class NodeShapeInfoDTO extends ResourceInfoBaseDTO {
+    private String targetClass;
+    private String targetNode;
+
+    public String getTargetClass() {
+        return targetClass;
+    }
+
+    public void setTargetClass(String targetClass) {
+        this.targetClass = targetClass;
+    }
+
+    public String getTargetNode() {
+        return targetNode;
+    }
+
+    public void setTargetNode(String targetNode) {
+        this.targetNode = targetNode;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/OrganizationDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/OrganizationDTO.java
@@ -3,16 +3,26 @@ package fi.vm.yti.datamodel.api.v2.dto;
 import java.util.Map;
 import java.util.UUID;
 
-public class OrganizationDTO extends BaseDTO {
-
+public class OrganizationDTO {
+    private final String id;
+    private final Map<String, String> label;
     private final UUID parentOrganization;
 
     public OrganizationDTO(String id, Map<String, String> label, UUID parentOrganization) {
-        super(id, label);
+        this.id = id;
+        this.label = label;
         this.parentOrganization = parentOrganization;
     }
 
     public UUID getParentOrganization() {
         return parentOrganization;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceCommonDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceCommonDTO.java
@@ -1,0 +1,40 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+public class ResourceCommonDTO {
+    private String created;
+    private String modified;
+    private UserDTO modifier;
+    private UserDTO creator;
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public String getModified() {
+        return modified;
+    }
+
+    public void setModified(String modified) {
+        this.modified = modified;
+    }
+
+    public UserDTO getModifier() {
+        return modifier;
+    }
+
+    public void setModifier(UserDTO modifier) {
+        this.modifier = modifier;
+    }
+
+    public UserDTO getCreator() {
+        return creator;
+    }
+
+    public void setCreator(UserDTO creator) {
+        this.creator = creator;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceDTO.java
@@ -2,20 +2,13 @@ package fi.vm.yti.datamodel.api.v2.dto;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.Map;
 import java.util.Set;
 
-public class ResourceDTO {
+public class ResourceDTO extends BaseDTO {
 
     private ResourceType type;
-    private Map<String, String> label;
-    private String editorialNote;
-    private Status status;
     private Set<String> subResourceOf;
     private Set<String> equivalentResource;
-    private String subject;
-    private String identifier;
-    private Map<String, String> note;
     private String domain;
     private String range;
 
@@ -25,22 +18,6 @@ public class ResourceDTO {
 
     public void setType(ResourceType type) {
         this.type = type;
-    }
-
-    public Map<String, String> getLabel() {
-        return label;
-    }
-
-    public void setLabel(Map<String, String> label) {
-        this.label = label;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
     }
 
     public Set<String> getSubResourceOf() {
@@ -57,38 +34,6 @@ public class ResourceDTO {
 
     public void setEquivalentResource(Set<String> equivalentResource) {
         this.equivalentResource = equivalentResource;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
-    public Map<String, String> getNote() {
-        return note;
-    }
-
-    public void setNote(Map<String, String> note) {
-        this.note = note;
-    }
-
-    public String getEditorialNote() {
-        return editorialNote;
-    }
-
-    public void setEditorialNote(String editorialNote) {
-        this.editorialNote = editorialNote;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
     }
 
     public String getDomain() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
@@ -1,40 +1,109 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-public class ResourceInfoBaseDTO {
-    private String created;
-    private String modified;
-    private UserDTO modifier;
-    private UserDTO creator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-    public String getCreated() {
-        return created;
+public class ResourceInfoBaseDTO extends ResourceCommonDTO {
+    private Map<String, String> label;
+    private String editorialNote;
+    private Status status;
+    private ConceptDTO subject;
+    private String identifier;
+    private Map<String, String> note;
+    private String uri;
+    private Set<OrganizationDTO> contributor;
+    private String contact;
+    private List<SimpleResourceDTO> attribute = new ArrayList<>();
+    private List<SimpleResourceDTO> association = new ArrayList<>();
+
+    public Map<String, String> getLabel() {
+        return label;
     }
 
-    public void setCreated(String created) {
-        this.created = created;
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
     }
 
-    public String getModified() {
-        return modified;
+    public String getEditorialNote() {
+        return editorialNote;
     }
 
-    public void setModified(String modified) {
-        this.modified = modified;
+    public void setEditorialNote(String editorialNote) {
+        this.editorialNote = editorialNote;
     }
 
-    public UserDTO getModifier() {
-        return modifier;
+    public Status getStatus() {
+        return status;
     }
 
-    public void setModifier(UserDTO modifier) {
-        this.modifier = modifier;
+    public void setStatus(Status status) {
+        this.status = status;
     }
 
-    public UserDTO getCreator() {
-        return creator;
+    public ConceptDTO getSubject() {
+        return subject;
     }
 
-    public void setCreator(UserDTO creator) {
-        this.creator = creator;
+    public void setSubject(ConceptDTO subject) {
+        this.subject = subject;
     }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Map<String, String> getNote() {
+        return note;
+    }
+
+    public void setNote(Map<String, String> note) {
+        this.note = note;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Set<OrganizationDTO> getContributor() {
+        return contributor;
+    }
+
+    public void setContributor(Set<OrganizationDTO> contributor) {
+        this.contributor = contributor;
+    }
+
+    public String getContact() {
+        return contact;
+    }
+
+    public void setContact(String contact) {
+        this.contact = contact;
+    }
+
+    public List<SimpleResourceDTO> getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(List<SimpleResourceDTO> attribute) {
+        this.attribute = attribute;
+    }
+
+    public List<SimpleResourceDTO> getAssociation() {
+        return association;
+    }
+
+    public void setAssociation(List<SimpleResourceDTO> association) {
+        this.association = association;
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ServiceCategoryDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ServiceCategoryDTO.java
@@ -2,16 +2,27 @@ package fi.vm.yti.datamodel.api.v2.dto;
 
 import java.util.Map;
 
-public class ServiceCategoryDTO extends BaseDTO {
-
+public class ServiceCategoryDTO {
+    private final String id;
+    private final Map<String, String> label;
     private final String identifier;
 
     public ServiceCategoryDTO(String id, Map<String, String> label, String identifier) {
-        super(id, label);
+        this.id = id;
+        this.label = label;
         this.identifier = identifier;
     }
 
     public String getIdentifier() {
         return identifier;
     }
+
+    public String getId() {
+        return id;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -15,18 +15,23 @@ import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
 import fi.vm.yti.datamodel.api.v2.service.TerminologyService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidClass;
+import fi.vm.yti.datamodel.api.v2.validator.ValidNodeShape;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -67,10 +72,46 @@ public class ClassController {
 
     @Operation(summary = "Add a class to a model")
     @ApiResponse(responseCode = "200", description = "Class added to model successfully")
-    @PutMapping(value = "/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/ontology/{prefix}", consumes = APPLICATION_JSON_VALUE)
     public void createClass(@PathVariable String prefix, @RequestBody @ValidClass ClassDTO classDTO){
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        if(jenaService.doesResourceExistInGraph(modelURI, modelURI + "#" + classDTO.getIdentifier())){
+        var model = handleCreateClassOrNodeShape(modelURI, prefix, classDTO);
+        var classURI = ClassMapper.createOntologyClassAndMapToModel(modelURI, model, classDTO, userProvider.getUser());
+        jenaService.putDataModelToCore(modelURI, model);
+        openSearchIndexer.createResourceToIndex(ResourceMapper.mapToIndexResource(model, classURI));
+    }
+
+    @Operation(summary = "Add a node shape to a model")
+    @ApiResponse(responseCode = "200", description = "Class added to model successfully")
+    @PutMapping(value = "/profile/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    public void createNodeShape(@PathVariable String prefix, @RequestBody @ValidNodeShape NodeShapeDTO nodeShapeDTO){
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = handleCreateClassOrNodeShape(modelURI, prefix, nodeShapeDTO);
+
+        var indexedResources = new ArrayList<String>();
+        var classURI = ClassMapper.createNodeShapeAndMapToModel(modelURI, model, nodeShapeDTO, userProvider.getUser());
+        indexedResources.add(classURI);
+
+        var propertiesModel = jenaService.findResources(nodeShapeDTO.getProperties());
+        var properties = ClassMapper.mapPlaceholderPropertyShapes(model, classURI, propertiesModel, userProvider.getUser());
+        indexedResources.addAll(properties);
+
+        // Node shape based on an existing node shape
+        var propertyURIs = handleTargetNodeProperties(nodeShapeDTO.getTargetNode());
+        var referencePropertiesModel = jenaService.findResources(new ArrayList<>(propertyURIs));
+        ClassMapper.mapReferencePropertyShapes(model, classURI,
+                referencePropertiesModel);
+
+        jenaService.putDataModelToCore(modelURI, model);
+
+        openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE,
+                indexedResources.stream()
+                        .map(p -> ResourceMapper.mapToIndexResource(model, p))
+                        .toList());
+    }
+
+    Model handleCreateClassOrNodeShape(String modelURI, String prefix, BaseDTO dto) {
+        if(jenaService.doesResourceExistInGraph(modelURI, modelURI + "#" + dto.getIdentifier())){
             throw new MappingError("Class already exists");
         }
         var model = jenaService.getDataModel(modelURI);
@@ -78,30 +119,29 @@ public class ClassController {
             throw new ResourceNotFoundException(modelURI);
         }
         check(authorizationManager.hasRightToModel(prefix, model));
+        checkDataModelType(model.getResource(modelURI), dto);
 
-        terminologyService.resolveConcept(classDTO.getSubject());
-
-        var indexedResources = new ArrayList<String>();
-        var classURI = ClassMapper.createClassAndMapToModel(modelURI, model, classDTO, userProvider.getUser());
-        indexedResources.add(classURI);
-
-        if (MapperUtils.isApplicationProfile(model.getResource(modelURI))) {
-            var propertiesModel = jenaService.findResources(classDTO.getProperties());
-            var properties = ClassMapper.mapPlaceholderPropertyShapes(model, classURI, propertiesModel, userProvider.getUser());
-            indexedResources.addAll(properties);
-        }
-        jenaService.putDataModelToCore(modelURI, model);
-
-        openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE,
-                indexedResources.stream()
-                .map(p -> ResourceMapper.mapToIndexResource(model, p))
-                .toList());
+        terminologyService.resolveConcept(dto.getSubject());
+        return model;
     }
+
 
     @Operation(summary = "Update a class in a model")
     @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
-    @PutMapping(value = "/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/ontology/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public void updateClass(@PathVariable String prefix, @PathVariable String classIdentifier, @RequestBody @ValidClass(updateClass = true) ClassDTO classDTO){
+        handleUpdateClassOrNodeShape(prefix, classIdentifier, classDTO);
+    }
+
+    @Operation(summary = "Update a node shape in a model")
+    @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
+    @PutMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    public void updateNodeShape(@PathVariable String prefix, @PathVariable String nodeShapeIdentifier,
+                                @RequestBody @ValidNodeShape(updateNodeShape = true) NodeShapeDTO nodeShapeDTO){
+        handleUpdateClassOrNodeShape(prefix, nodeShapeIdentifier, nodeShapeDTO);
+    }
+
+    void handleUpdateClassOrNodeShape(String prefix, String classIdentifier, BaseDTO dto) {
         logger.info("Updating class {}", classIdentifier);
 
         var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
@@ -111,12 +151,19 @@ public class ClassController {
         }
 
         var model = jenaService.getDataModel(graph);
+
+        checkDataModelType(model.getResource(graph), dto);
         check(authorizationManager.hasRightToModel(prefix, model));
 
         var classResource = model.getResource(classURI);
 
-        terminologyService.resolveConcept(classDTO.getSubject());
-        ClassMapper.mapToUpdateClass(model, graph, classResource, classDTO, userProvider.getUser());
+        terminologyService.resolveConcept(dto.getSubject());
+
+        if (MapperUtils.isOntology(model.getResource(graph))) {
+            ClassMapper.mapToUpdateOntologyClass(model, graph, classResource, (ClassDTO) dto, userProvider.getUser());
+        } else {
+            ClassMapper.mapToUpdateNodeShape(model, graph, classResource, (NodeShapeDTO) dto, userProvider.getUser());
+        }
         jenaService.putDataModelToCore(graph, model);
 
         var indexClass = ResourceMapper.mapToIndexResource(model, classURI);
@@ -125,8 +172,19 @@ public class ClassController {
 
     @Operation(summary = "Get a class from a data model")
     @ApiResponse(responseCode = "200", description = "Class found successfully")
-    @GetMapping(value = "/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/ontology/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ClassInfoDTO getClass(@PathVariable String prefix, @PathVariable String classIdentifier){
+        return (ClassInfoDTO) handleGetClassOrNodeShape(prefix, classIdentifier);
+    }
+
+    @Operation(summary = "Add a class to a model")
+    @ApiResponse(responseCode = "200", description = "Node shape found successfully")
+    @GetMapping(value = "/profile/{prefix}/{shapeIdentifier}", produces = APPLICATION_JSON_VALUE)
+    public NodeShapeInfoDTO getNodeShape(@PathVariable String prefix, @PathVariable String shapeIdentifier){
+        return (NodeShapeInfoDTO) handleGetClassOrNodeShape(prefix, shapeIdentifier);
+    }
+
+    private ResourceInfoBaseDTO handleGetClassOrNodeShape(String prefix, String classIdentifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var classURI = modelURI + "#" + classIdentifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
@@ -140,25 +198,40 @@ public class ClassController {
 
         var orgModel = jenaService.getOrganizations();
         var userMapper = hasRightToModel ? groupManagementService.mapUser() : null;
-        var dto = ClassMapper.mapToClassDTO(model, modelURI, classIdentifier, orgModel,
-                hasRightToModel, userMapper);
 
+        ResourceInfoBaseDTO dto;
         if (MapperUtils.isOntology(model.getResource(modelURI))) {
             var classResources = jenaService.constructWithQuery(ClassMapper.getClassResourcesQuery(classURI, false));
-            ClassMapper.addClassResourcesToDTO(classResources, dto);
+            dto = ClassMapper.mapToClassDTO(model, modelURI, classIdentifier, orgModel,
+                hasRightToModel, userMapper);
+            ClassMapper.addClassResourcesToDTO(classResources, (ClassInfoDTO) dto);
         } else {
-            ClassMapper.addNodeShapeResourcesToDTO(model, dto);
+            dto = ClassMapper.mapToNodeShapeDTO(model, modelURI, classIdentifier, orgModel,
+                    hasRightToModel, userMapper);
+            ClassMapper.addNodeShapeResourcesToDTO(model, (NodeShapeInfoDTO) dto);
         }
-        terminologyService.mapConceptToClass().accept(dto);
+
+        terminologyService.mapConcept().accept(dto);
         return dto;
     }
 
     @Operation(summary = "Delete a class from a data model")
     @ApiResponse(responseCode = "200", description = "Class deleted successfully")
-    @DeleteMapping(value = "/{prefix}/{classIdentifier}")
+    @DeleteMapping(value = "/ontology/{prefix}/{classIdentifier}")
     public void deleteClass(@PathVariable String prefix, @PathVariable String classIdentifier){
+        handleDeleteClassOrNodeShape(prefix, classIdentifier);
+    }
+
+    @Operation(summary = "Delete a class from a data model")
+    @ApiResponse(responseCode = "200", description = "Class deleted successfully")
+    @DeleteMapping(value = "/profile/{prefix}/{classIdentifier}")
+    public void deleteNodeShape(@PathVariable String prefix, @PathVariable String classIdentifier){
+        handleDeleteClassOrNodeShape(prefix, classIdentifier);
+    }
+
+    void handleDeleteClassOrNodeShape(String prefix, String identifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var classURI  = modelURI + "#" + classIdentifier;
+        var classURI  = modelURI + "#" + identifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
             throw new ResourceNotFoundException(classURI);
         }
@@ -187,7 +260,7 @@ public class ClassController {
         return dto;
     }
 
-    @Operation(summary = "Get all node shapes with given targetClass")
+    @Operation(summary = "Get all node shapes based on given targetClass")
     @ApiResponse(responseCode = "200", description = "List of node shapes fetched successfully")
     @GetMapping(value = "/nodeshapes", produces = APPLICATION_JSON_VALUE)
     public List<IndexResource> getNodeShapes(@RequestParam String targetClass) throws IOException {
@@ -197,5 +270,39 @@ public class ClassController {
         return searchIndexService
                 .searchInternalResources(request, userProvider.getUser())
                 .getResponseObjects();
+    }
+
+    private Set<String> handleTargetNodeProperties(String targetNode) {
+        var propertyShapes = new HashSet<String>();
+        var handledNodeShapes = new HashSet<String>();
+
+        // collect recursively all property shape uris from target node
+        while (targetNode != null) {
+            if (handledNodeShapes.contains(targetNode)) {
+                throw new MappingError("Circular dependency, cannot add sh:node reference");
+            }
+            handledNodeShapes.add(targetNode);
+
+            var nodeModel = jenaService.findResources(List.of(targetNode));
+            var nodeResource = nodeModel.getResource(targetNode);
+
+            propertyShapes.addAll(nodeResource.listProperties(SH.property)
+                    .mapWith((var stmt) -> stmt.getResource().getURI())
+                    .toList());
+
+            if (!nodeResource.hasProperty(SH.node)) {
+                break;
+            }
+            targetNode = nodeResource.getProperty(SH.node).getObject().toString();
+        }
+        return propertyShapes;
+    }
+
+    private void checkDataModelType(Resource modelResource, BaseDTO dto) {
+        if (dto instanceof NodeShapeDTO && MapperUtils.isOntology(modelResource)) {
+            throw new MappingError("Cannot add node shape to ontology");
+        } else if (dto instanceof ClassDTO && MapperUtils.isApplicationProfile(modelResource)) {
+            throw new MappingError("Cannot add ontology class to application profile");
+        }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -115,7 +115,7 @@ public class ResourceController {
         var hasRightToModel = authorizationManager.hasRightToModel(prefix, model);
 
         var resourceInfoDTO = ResourceMapper.mapToResourceInfoDTO(model, graphUri, resourceIdentifier, orgModel, hasRightToModel, groupManagementService.mapUser());
-        terminologyService.mapConceptToResource().accept(resourceInfoDTO);
+        terminologyService.mapConcept().accept(resourceInfoDTO);
         return resourceInfoDTO;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -193,7 +193,7 @@ public class ModelMapper {
      * @param model  Model
      * @return Data Model DTO
      */
-    public DataModelInfoDTO mapToDataModelDTO(String prefix, Model model, Consumer<ResourceInfoBaseDTO> userMapper) {
+    public DataModelInfoDTO mapToDataModelDTO(String prefix, Model model, Consumer<ResourceCommonDTO> userMapper) {
 
         var datamodelDTO = new DataModelInfoDTO();
         datamodelDTO.setPrefix(prefix);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -40,7 +40,7 @@ public class ResourceMapper {
         var langs = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
         MapperUtils.addLocalizedProperty(langs, dto.getLabel(), resourceResource, RDFS.label, model);
         //Note
-        MapperUtils.addLocalizedProperty(langs, dto.getNote(), resourceResource, SKOS.note, model);
+        MapperUtils.addLocalizedProperty(langs, dto.getNote(), resourceResource, RDFS.comment, model);
         MapperUtils.addOptionalStringProperty(resourceResource, SKOS.editorialNote, dto.getEditorialNote());
         MapperUtils.addOptionalUriProperty(resourceResource, DCTerms.subject, dto.getSubject());
 
@@ -80,7 +80,7 @@ public class ResourceMapper {
         }
 
         MapperUtils.updateLocalizedProperty(languages, dto.getLabel(), resource, RDFS.label, model);
-        MapperUtils.updateLocalizedProperty(languages, dto.getNote(), resource, SKOS.note, model);
+        MapperUtils.updateLocalizedProperty(languages, dto.getNote(), resource, RDFS.comment, model);
         MapperUtils.updateStringProperty(resource, SKOS.editorialNote, dto.getEditorialNote());
         MapperUtils.updateUriProperty(resource, DCTerms.subject, dto.getSubject());
 
@@ -134,7 +134,7 @@ public class ResourceMapper {
         indexResource.setModified(resource.getProperty(DCTerms.modified).getString());
         indexResource.setCreated(resource.getProperty(DCTerms.created).getString());
         indexResource.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
-        var note = MapperUtils.localizedPropertyToMap(resource, SKOS.note);
+        var note = MapperUtils.localizedPropertyToMap(resource, RDFS.comment);
         if(!note.isEmpty()){
             indexResource.setNote(note);
         }
@@ -162,7 +162,7 @@ public class ResourceMapper {
 
     public static ResourceInfoDTO mapToResourceInfoDTO(Model model, String modelUri,
                                                        String resourceIdentifier, Model orgModel,
-                                                       boolean hasRightToModel, Consumer<ResourceInfoBaseDTO> userMapper) {
+                                                       boolean hasRightToModel, Consumer<ResourceCommonDTO> userMapper) {
         var dto = new ResourceInfoDTO();
         var resourceUri = modelUri + "#" + resourceIdentifier;
         var resourceResource = model.getResource(resourceUri);
@@ -187,7 +187,7 @@ public class ResourceMapper {
             dto.setSubject(conceptDTO);
         }
         dto.setIdentifier(resourceResource.getLocalName());
-        dto.setNote(MapperUtils.localizedPropertyToMap(resourceResource, SKOS.note));
+        dto.setNote(MapperUtils.localizedPropertyToMap(resourceResource, RDFS.comment));
         if (hasRightToModel) {
             dto.setEditorialNote(MapperUtils.propertyToString(resourceResource, SKOS.editorialNote));
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
@@ -181,7 +181,7 @@ public class OpenSearchIndexer {
         SparqlUtils.addConstructProperty(GRAPH_VARIABLE, constructBuilder, DCTerms.created, "?created");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, Iow.contentModified, "?contentModified");
         SparqlUtils.addConstructProperty(GRAPH_VARIABLE, constructBuilder, RDFS.isDefinedBy, "?isDefinedBy");
-        SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, SKOS.note, "?note");
+        SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, RDFS.comment, "?note");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, RDFS.subClassOf, "?subClassOf");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, RDFS.subPropertyOf, "?subPropertyOf");
         SparqlUtils.addConstructOptional(GRAPH_VARIABLE, constructBuilder, OWL.equivalentClass, "?equivalentClass");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/FrontendService.java
@@ -2,7 +2,6 @@ package fi.vm.yti.datamodel.api.v2.service;
 
 import static fi.vm.yti.datamodel.api.v2.dto.ModelConstants.*;
 
-import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
 import fi.vm.yti.datamodel.api.v2.mapper.OrganizationMapper;
@@ -24,7 +23,11 @@ public class FrontendService {
         var organizations = jenaService.getOrganizations();
         var dtos = OrganizationMapper.mapToListOrganizationDTO(organizations);
 
-        sortByLabel(sortLanguage, dtos);
+        dtos.sort((a, b) -> {
+            var labelA = a.getLabel().getOrDefault(sortLanguage, a.getLabel().get(DEFAULT_LANGUAGE));
+            var labelB = b.getLabel().getOrDefault(sortLanguage, b.getLabel().get(DEFAULT_LANGUAGE));
+            return labelA.compareTo(labelB);
+        });
 
         return includeChildOrganizations ? dtos : dtos.stream()
                 .filter(dto -> dto.getParentOrganization() == null)
@@ -35,16 +38,12 @@ public class FrontendService {
         var serviceCategories = jenaService.getServiceCategories();
         var dtos = ServiceCategoryMapper.mapToListServiceCategoryDTO(serviceCategories);
 
-        sortByLabel(sortLanguage, dtos);
-
-        return dtos;
-    }
-
-    private void sortByLabel(@NotNull String sortLanguage, List<? extends BaseDTO> dtos) {
         dtos.sort((a, b) -> {
             var labelA = a.getLabel().getOrDefault(sortLanguage, a.getLabel().get(DEFAULT_LANGUAGE));
             var labelB = b.getLabel().getOrDefault(sortLanguage, b.getLabel().get(DEFAULT_LANGUAGE));
             return labelA.compareTo(labelB);
         });
+
+        return dtos;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
@@ -4,7 +4,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.datamodel.api.v2.dto.GroupManagementOrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.GroupManagementUserDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ResourceInfoBaseDTO;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceCommonDTO;
 import fi.vm.yti.security.YtiUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ public class GroupManagementService {
         // TODO:
     }
 
-    public Consumer<ResourceInfoBaseDTO> mapUser() {
+    public Consumer<ResourceCommonDTO> mapUser() {
         // TODO: fetch users and set them to cache
         return (var dto) -> {
             if (dto.getCreator().getId() == null || dto.getModifier().getId() == null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -1,9 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
-import fi.vm.yti.datamodel.api.v2.dto.ClassInfoDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ConceptDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ResourceInfoDTO;
-import fi.vm.yti.datamodel.api.v2.dto.TerminologyNodeDTO;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResolvingException;
 import fi.vm.yti.datamodel.api.v2.mapper.TerminologyMapper;
 import org.slf4j.Logger;
@@ -119,11 +116,7 @@ public class TerminologyService {
         jenaService.putTerminologyToConcepts(terminologyURI, terminologyModel);
     }
 
-    public Consumer<ClassInfoDTO> mapConceptToClass() {
-        return (var dto) -> dto.setSubject(getMappedConceptDTO(dto.getSubject()));
-    }
-
-    public Consumer<ResourceInfoDTO> mapConceptToResource() {
+    public Consumer<ResourceInfoBaseDTO> mapConcept() {
         return (var dto) -> dto.setSubject(getMappedConceptDTO(dto.getSubject()));
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
+import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
 import jakarta.validation.ConstraintValidatorContext;
 import java.lang.annotation.Annotation;
 
@@ -37,4 +38,59 @@ public abstract class BaseValidator implements Annotation{
     public void setConstraintViolationAdded(boolean constraintViolationAdded) {
         this.constraintViolationAdded = constraintViolationAdded;
     }
+
+
+    public void checkLabel(ConstraintValidatorContext context, BaseDTO dto, boolean updateClass){
+        var labels = dto.getLabel();
+        if(!updateClass && (labels == null || labels.isEmpty() || labels.values().stream().allMatch(String::isBlank))){
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "label");
+        }else if(labels != null){
+            labels.forEach((lang, value) -> {
+                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
+                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "label");
+                }
+            });
+        }
+    }
+
+    public void checkEditorialNote(ConstraintValidatorContext context, BaseDTO dto){
+        var editorialNote = dto.getEditorialNote();
+        if(editorialNote != null && editorialNote.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
+            addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_AREA_MAX_LENGTH, "editorialNote");
+        }
+    }
+
+    public void checkNote(ConstraintValidatorContext context, BaseDTO dto) {
+        var notes = dto.getNote();
+        if(notes != null){
+            notes.forEach((lang, value) -> {
+                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
+                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "note");
+                }
+            });
+        }
+    }
+
+    public void checkStatus(ConstraintValidatorContext context, BaseDTO dto, boolean updateClass){
+        var status = dto.getStatus();
+        //Status has to be defined when creating
+        if(!updateClass && status == null){
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "status");
+        }
+    }
+
+    public void checkSubject(ConstraintValidatorContext context, BaseDTO dto){
+        var subject = dto.getSubject();
+        //TODO check if subject is found in one of the terminologies added to datamodel
+    }
+
+    public void checkIdentifier(ConstraintValidatorContext context, BaseDTO dto, boolean updateClass){
+        var identifier = dto.getIdentifier();
+        if(!updateClass && (identifier == null || identifier.isBlank())){
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "identifier");
+        }else if(updateClass && identifier != null){
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
+        }
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
@@ -24,55 +24,16 @@ public class ClassValidator extends BaseValidator implements
     public boolean isValid(ClassDTO classDTO, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
 
-        checkLabel(context, classDTO);
+        checkLabel(context, classDTO, updateClass);
         checkEditorialNote(context, classDTO);
         checkNote(context, classDTO);
-        checkStatus(context, classDTO);
+        checkStatus(context, classDTO, updateClass);
         checkEquivalentClass(context, classDTO);
         checkSubClassOf(context, classDTO);
         checkSubject(context, classDTO);
-        checkIdentifier(context, classDTO);
+        checkIdentifier(context, classDTO, updateClass);
 
         return !isConstraintViolationAdded();
-    }
-
-    private void checkLabel(ConstraintValidatorContext context, ClassDTO classDTO){
-        var labels = classDTO.getLabel();
-        if(!updateClass && (labels == null || labels.isEmpty() || labels.values().stream().allMatch(String::isBlank))){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "label");
-        }else if(labels != null){
-            labels.forEach((lang, value) -> {
-                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "label");
-                }
-            });
-        }
-    }
-
-    private void checkEditorialNote(ConstraintValidatorContext context, ClassDTO classDTO){
-        var editorialNote = classDTO.getEditorialNote();
-        if(editorialNote != null && editorialNote.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
-            addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_AREA_MAX_LENGTH, "editorialNote");
-        }
-    }
-
-    private void checkNote(ConstraintValidatorContext context, ClassDTO classDTO) {
-        var notes = classDTO.getNote();
-        if(notes != null){
-            notes.forEach((lang, value) -> {
-                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "note");
-                }
-            });
-        }
-    }
-
-    private void checkStatus(ConstraintValidatorContext context, ClassDTO classDTO){
-        var status = classDTO.getStatus();
-        //Status has to be defined when creating
-        if(!updateClass && status == null){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "status");
-        }
     }
 
     private void checkEquivalentClass(ConstraintValidatorContext context, ClassDTO classDTO){
@@ -103,17 +64,4 @@ public class ClassValidator extends BaseValidator implements
         }
     }
 
-    private void checkSubject(ConstraintValidatorContext context, ClassDTO classDTO){
-        var subject = classDTO.getSubject();
-        //TODO check if subject is found in one of the terminologies added to datamodel
-    }
-
-    private void checkIdentifier(ConstraintValidatorContext context, ClassDTO classDTO){
-        var identifier = classDTO.getIdentifier();
-        if(!updateClass && (identifier == null || identifier.isBlank())){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "identifier");
-        }else if(updateClass && identifier != null){
-            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
-        }
-    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
@@ -1,0 +1,63 @@
+package fi.vm.yti.datamodel.api.v2.validator;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.NodeShapeDTO;
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDFS;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.topbraid.shacl.vocabulary.SH;
+
+import java.util.List;
+
+public class NodeShapeValidator extends BaseValidator implements
+        ConstraintValidator<ValidNodeShape, NodeShapeDTO> {
+
+    @Autowired
+    private JenaService jenaService;
+
+    boolean updateNodeShape;
+
+    @Override
+    public void initialize(ValidNodeShape constraintAnnotation) {
+        updateNodeShape = constraintAnnotation.updateNodeShape();
+    }
+
+    @Override
+    public boolean isValid(NodeShapeDTO nodeShapeDTO, ConstraintValidatorContext context) {
+        setConstraintViolationAdded(false);
+
+        checkLabel(context, nodeShapeDTO, updateNodeShape);
+        checkEditorialNote(context, nodeShapeDTO);
+        checkNote(context, nodeShapeDTO);
+        checkStatus(context, nodeShapeDTO, updateNodeShape);
+        checkSubject(context, nodeShapeDTO);
+        checkIdentifier(context, nodeShapeDTO, updateNodeShape);
+        checkTargetClass(context, nodeShapeDTO);
+        checkTargetNode(context, nodeShapeDTO);
+
+        return !isConstraintViolationAdded();
+    }
+
+    private void checkTargetClass(ConstraintValidatorContext context, NodeShapeDTO nodeShapeDTO){
+        var targetClass = nodeShapeDTO.getTargetClass();
+        if(targetClass != null && !targetClass.isBlank()){
+            var checkImports = !targetClass.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
+            if(!jenaService.checkIfResourceIsOneOfTypes(targetClass, List.of(RDFS.Class, OWL.Class), checkImports)){
+                addConstraintViolation(context, "not-class-or-doesnt-exist", "targetClass");
+            }
+        }
+    }
+
+    private void checkTargetNode(ConstraintValidatorContext context, NodeShapeDTO nodeShapeDTO){
+        var targetNode = nodeShapeDTO.getTargetNode();
+        if(targetNode != null && !targetNode.isBlank()){
+            var checkImports = !targetNode.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
+            if(!jenaService.checkIfResourceIsOneOfTypes(targetNode, List.of(SH.NodeShape), checkImports)){
+                addConstraintViolation(context, "not-node-shape-or-doesnt-exist", "targetNode");
+            }
+        }
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
@@ -27,13 +27,13 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
     public boolean isValid(ResourceDTO value, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
 
-        checkLabel(context, value);
+        checkLabel(context, value, updateProperty);
         checkEditorialNote(context, value);
-        checkStatus(context, value);
+        checkStatus(context, value, updateProperty);
         checkNote(context, value);
         checkEquivalentProperty(context, value);
         checkSubPropertyOf(context, value);
-        checkIdentifier(context, value);
+        checkIdentifier(context, value, updateProperty);
         checkType(context, value);
         checkDomain(context, value);
         checkRange(context, value);
@@ -46,46 +46,6 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "type");
         }else if (updateProperty && resourceDTO.getType() != null){
             addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "type");
-        }
-    }
-
-    private void checkLabel(ConstraintValidatorContext context, ResourceDTO resourceDTO){
-        var labels = resourceDTO.getLabel();
-        if(!updateProperty && (labels == null || labels.isEmpty() || labels.values().stream().allMatch(String::isBlank))){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "label");
-        }else if(labels != null){
-            labels.forEach((lang, value) -> {
-                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "label");
-                }
-            });
-        }
-    }
-
-    private void checkEditorialNote(ConstraintValidatorContext context, ResourceDTO resourceDTO){
-        var editorialNote = resourceDTO.getEditorialNote();
-        if(editorialNote != null && editorialNote.length() > ValidationConstants.TEXT_AREA_MAX_LENGTH){
-            addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_AREA_MAX_LENGTH, "editorialNote");
-        }
-    }
-
-
-    private void checkStatus(ConstraintValidatorContext context, ResourceDTO resourceDTO){
-        var status = resourceDTO.getStatus();
-        //Status has to be defined when creating
-        if(!updateProperty && status == null){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "status");
-        }
-    }
-
-    private void checkNote(ConstraintValidatorContext context, ResourceDTO resourceDTO) {
-        var notes = resourceDTO.getNote();
-        if(notes != null){
-            notes.forEach((lang, value) -> {
-                if(value.length() > ValidationConstants.TEXT_FIELD_MAX_LENGTH){
-                    addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT + ValidationConstants.TEXT_FIELD_MAX_LENGTH, "note");
-                }
-            });
         }
     }
 
@@ -114,15 +74,6 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
                     addConstraintViolation(context, "resource-not-found-in-resolved-namespace", "subClassOf");
                 }
             });
-        }
-    }
-
-    private void checkIdentifier(ConstraintValidatorContext context, ResourceDTO resourceDTO){
-        var identifier = resourceDTO.getIdentifier();
-        if(!updateProperty && (identifier == null || identifier.isBlank())){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "identifier");
-        }else if(updateProperty && identifier != null){
-            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidNodeShape.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidNodeShape.java
@@ -1,0 +1,28 @@
+package fi.vm.yti.datamodel.api.v2.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NodeShapeValidator.class)
+public @interface ValidNodeShape {
+
+    String message() default "Invalid data";
+
+    Class<?>[] groups() default {};
+
+    boolean updateNodeShape() default false;
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -36,7 +36,7 @@ class ClassMapperTest {
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
 
-        ClassMapper.createClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
+        ClassMapper.createOntologyClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
         Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
@@ -59,7 +59,7 @@ class ClassMapperTest {
         assertEquals("TestClass", classResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
         assertEquals("comment", classResource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals("test note", classResource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("test note", classResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, classResource.listProperties(RDFS.subClassOf).toList().size());
         assertEquals("https://www.example.com/ns/ext#SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
@@ -79,7 +79,7 @@ class ClassMapperTest {
         dto.setStatus(Status.VALID);
         dto.setIdentifier("Identifier");
 
-        ClassMapper.createClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
+        ClassMapper.createOntologyClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
         Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Identifier");
@@ -145,7 +145,7 @@ class ClassMapperTest {
     void testMapToClassDTOAuthenticatedUser() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        Consumer<ResourceInfoBaseDTO> userMapper = (ResourceInfoBaseDTO dto) -> {
+        Consumer<ResourceCommonDTO> userMapper = (var dto) -> {
             var creator = new UserDTO("123");
             var modifier = new UserDTO("123");
             creator.setName("creator fake-user");
@@ -186,9 +186,9 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
 
-        ClassMapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
+        ClassMapper.mapToUpdateOntologyClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
 
         assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -200,9 +200,9 @@ class ClassMapperTest {
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(1, resource.listProperties(SKOS.note).toList().size());
-        assertEquals("new note", resource.getProperty(SKOS.note).getLiteral().getString());
-        assertEquals("fi", resource.getProperty(SKOS.note).getLiteral().getLanguage());
+        assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
+        assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
     }
@@ -225,9 +225,9 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
 
-        ClassMapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
+        ClassMapper.mapToUpdateOntologyClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
 
         assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -239,7 +239,7 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
     }
 
     @Test
@@ -259,16 +259,16 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
 
-        ClassMapper.mapToUpdateClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
+        ClassMapper.mapToUpdateOntologyClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
 
         assertNull(resource.getProperty(DCTerms.subject));
         assertNull(resource.getProperty(OWL.equivalentClass));
         //OWl thing is default value if all subClassOf is emptied
         assertEquals(OWL.Thing, resource.getProperty(RDFS.subClassOf).getResource());
         assertNull(resource.getProperty(SKOS.editorialNote));
-        assertNull(resource.getProperty(SKOS.note));
+        assertNull(resource.getProperty(RDFS.comment));
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -67,7 +67,7 @@ class ResourceMapperTest {
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
         assertEquals("comment", resourceResource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals("test note", resourceResource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals("https://www.example.com/ns/ext#SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
@@ -118,7 +118,7 @@ class ResourceMapperTest {
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
         assertEquals("comment", resourceResource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals("test note", resourceResource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topObjectProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
@@ -164,7 +164,7 @@ class ResourceMapperTest {
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
         assertEquals("comment", resourceResource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals("test note", resourceResource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topDataProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
@@ -213,7 +213,7 @@ class ResourceMapperTest {
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
 
         assertEquals("comment", resourceResource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals("test note", resourceResource.getProperty(SKOS.note).getLiteral().getString());
+        assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals("https://www.example.com/ns/ext#SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
@@ -455,7 +455,7 @@ class ResourceMapperTest {
     void mapToResourceInfoAuthenticatedUser() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        Consumer<ResourceInfoBaseDTO> userMapper = (var dto) -> {
+        Consumer<ResourceCommonDTO> userMapper = (var dto) -> {
             var creator = new UserDTO("123");
             var modifier = new UserDTO("123");
             creator.setName("creator fake-user");
@@ -497,7 +497,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
 
@@ -514,9 +514,9 @@ class ResourceMapperTest {
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(1, resource.listProperties(SKOS.note).toList().size());
-        assertEquals("new note", resource.getProperty(SKOS.note).getLiteral().getString());
-        assertEquals("fi", resource.getProperty(SKOS.note).getLiteral().getLanguage());
+        assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
+        assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
@@ -549,7 +549,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(SKOS.note).toList().size());
+        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
 
@@ -565,9 +565,9 @@ class ResourceMapperTest {
         assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(1, resource.listProperties(SKOS.note).toList().size());
-        assertEquals("new note", resource.getProperty(SKOS.note).getLiteral().getString());
-        assertEquals("fi", resource.getProperty(SKOS.note).getLiteral().getLanguage());
+        assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
+        assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
+        assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DatamodelTest.java
@@ -78,7 +78,7 @@ class DatamodelTest {
     private AuthenticatedUserProvider userProvider;
 
     @Mock
-    Consumer<ResourceInfoBaseDTO> consumer;
+    Consumer<ResourceCommonDTO> consumer;
 
     @Autowired
     private Datamodel datamodel;

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -68,8 +68,8 @@ class ResourceControllerTest {
     @Autowired
     private ResourceController resourceController;
 
-    private final Consumer<ResourceInfoBaseDTO> userMapper = (var dto) -> {};
-    private final Consumer<ResourceInfoDTO> conceptMapper = (var dto) -> {};
+    private final Consumer<ResourceCommonDTO> userMapper = (var dto) -> {};
+    private final Consumer<ResourceInfoBaseDTO> conceptMapper = (var dto) -> {};
 
     private static final YtiUser USER = EndpointUtils.mockUser;
 
@@ -84,7 +84,7 @@ class ResourceControllerTest {
         when(authorizationManager.hasRightToModel(any(), any())).thenReturn(true);
         when(userProvider.getUser()).thenReturn(USER);
         when(groupManagementService.mapUser()).thenReturn(userMapper);
-        when(terminologyService.mapConceptToResource()).thenReturn(conceptMapper);
+        when(terminologyService.mapConcept()).thenReturn(conceptMapper);
     }
 
     @Test

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -44,7 +44,7 @@ test:TestClass  rdf:type     owl:Class ;
         owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test#EqClass> ;
         owl:versionInfo      "VALID" ;
         skos:editorialNote   "comment visible for admin" ;
-        skos:note         "test note fi"@fi, "test note en"@en ;
+        rdfs:comment         "test note fi"@fi, "test note en"@en ;
         iow:creator           "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" .
 
@@ -59,7 +59,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
-        skos:note               "test note fi"@fi, "test note en"@en ;
+        rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;
@@ -76,7 +76,7 @@ test:TestAssociation  rdf:type     owl:ObjectProperty ;
         owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
-        skos:note               "test note fi"@fi, "test note en"@en ;
+        rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -43,7 +43,7 @@ test:TestClass  rdf:type     sh:NodeShape ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
         owl:versionInfo      "VALID" ;
         skos:editorialNote   "comment visible for admin" ;
-        sh:description       "test technical description fi"@fi, "test technical description en"@en ;
+        rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target#Class> .


### PR DESCRIPTION
- Add separate endpoints for saving class and nodeshape
```
Create:
PUT /class/ontology/model_prefix
PUT /class/profile/model_prefix

Edit:
PUT /class/ontology/model_prefix/class_id
PUT /class/profile/model_prefix/class_id

Get:
GET /class/ontology/model_prefix/class_id
GET /class/profile/model_prefix/class_id

Delete:
DELETE /class/ontology/model_prefix/class_id
DELETE /class/profile/model_prefix/class_id
```

- Created base dto class for holding common information for classes, nodeshapes, attributes and property shapes
- Created separate validators for classes and nodeshapse. Move some common validation methods to BaseValidator
- Created separate mapping methods for classes and nodeshapes in ClassMapper

UI changes: https://github.com/VRK-YTI/yti-terminology-ui/pull/410