### PR TITLE
YTI-2591 Add deactivation endpoint

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -272,8 +272,8 @@ public class ClassController {
                 .getResponseObjects();
     }
 
-    @Operation(summary = "Get all node shapes based on given targetClass")
-    @ApiResponse(responseCode = "200", description = "List of node shapes fetched successfully")
+    @Operation(summary = "Toggles deactivation of a single property shape")
+    @ApiResponse(responseCode = "200", description = "Deactivation has changes successfully")
     @PutMapping(value = "/toggleDeactivate/{prefix}", produces = APPLICATION_JSON_VALUE)
     public void deactivatePropertyShape(@PathVariable String prefix, @RequestParam String propertyUri) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
@@ -282,7 +282,7 @@ public class ClassController {
             throw new ResourceNotFoundException(modelURI);
         }
         check(authorizationManager.hasRightToModel(prefix, model));
-        ClassMapper.mapDeactivatedProperty(model, propertyUri);
+        ClassMapper.toggleAndMapDeactivatedProperty(model, propertyUri);
         jenaService.putDataModelToCore(modelURI, model);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -272,6 +272,20 @@ public class ClassController {
                 .getResponseObjects();
     }
 
+    @Operation(summary = "Get all node shapes based on given targetClass")
+    @ApiResponse(responseCode = "200", description = "List of node shapes fetched successfully")
+    @PutMapping(value = "/toggleDeactivate/{prefix}", produces = APPLICATION_JSON_VALUE)
+    public void deactivatePropertyShape(@PathVariable String prefix, @RequestParam String propertyUri) {
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = jenaService.getDataModel(modelURI);
+        if(model == null) {
+            throw new ResourceNotFoundException(modelURI);
+        }
+        check(authorizationManager.hasRightToModel(prefix, model));
+        ClassMapper.mapDeactivatedProperty(model, propertyUri);
+        jenaService.putDataModelToCore(modelURI, model);
+    }
+
     private Set<String> handleTargetNodeProperties(String targetNode) {
         var propertyShapes = new HashSet<String>();
         var handledNodeShapes = new HashSet<String>();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -384,4 +384,13 @@ public class ClassMapper {
         dto.setAssociations(associations);
     }
 
+    public static void mapDeactivatedProperty(Model model, String propertyURI) {
+        var resource = model.getResource(propertyURI);
+        if (resource.hasProperty(SH.deactivated)) {
+            resource.removeAll(SH.deactivated);
+        } else {
+            resource.addLiteral(SH.deactivated, true);
+        }
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -384,7 +384,7 @@ public class ClassMapper {
         dto.setAssociations(associations);
     }
 
-    public static void mapDeactivatedProperty(Model model, String propertyURI) {
+    public static void toggleAndMapDeactivatedProperty(Model model, String propertyURI) {
         var resource = model.getResource(propertyURI);
         if (resource.hasProperty(SH.deactivated)) {
             resource.removeAll(SH.deactivated);

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -171,4 +171,21 @@ class NodeShapeMapperTest {
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
     }
 
+    @Test
+    void testMapDeactivatedPropertyShape() {
+        var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
+
+        var propertyShape1 = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestPropertyShape");
+        var propertyShape2 = m.getResource("http://uri.suomi.fi/datamodel/ns/test#DeactivatedPropertyShape");
+
+        assertFalse(propertyShape1.hasProperty(SH.deactivated));
+        assertTrue(propertyShape2.getProperty(SH.deactivated).getObject().asLiteral().getBoolean());
+
+        ClassMapper.toggleAndMapDeactivatedProperty(m, "http://uri.suomi.fi/datamodel/ns/test#TestPropertyShape");
+        ClassMapper.toggleAndMapDeactivatedProperty(m, "http://uri.suomi.fi/datamodel/ns/test#DeactivatedPropertyShape");
+
+        assertTrue(propertyShape1.getProperty(SH.deactivated).getObject().asLiteral().getBoolean());
+        assertFalse(propertyShape2.hasProperty(SH.deactivated));
+    }
+
 }

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -47,3 +47,14 @@ test:TestClass  rdf:type     sh:NodeShape ;
         iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target#Class> .
+
+test:TestPropertyShape  rdf:type  sh:PropertyShape ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
+        rdfs:label           "test property shape"@fi .
+
+test:DeactivatedPropertyShape  rdf:type  sh:PropertyShape ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        dcterms:identifier   "DeactivatedPropertyShape"^^xsd:NCName ;
+        sh:deactivated       true ;
+        rdfs:label           "deactivated property shape"@fi .


### PR DESCRIPTION
Endpoint for toggling `sh:deactivated` property

```
PUT /datamodel-api/v2/class/toggleDeactivate/{prefix}?propertyUri=http://uri.suomi.fi/datamodel/ns/test%23SomeProperty
```