### PR TITLE
Feature yti 2602 separator migration task

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
@@ -5,15 +5,18 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.service.NamespaceService;
+import fi.vm.yti.migration.MigrationConfig;
+import fi.vm.yti.migration.MigrationInitializer;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import jakarta.annotation.PostConstruct;
-
 @Component
+@ImportAutoConfiguration(MigrationConfig.class)
 public class StartUpListener {
 
     private static final Logger logger = LoggerFactory.getLogger(StartUpListener.class);
@@ -29,7 +32,8 @@ public class StartUpListener {
                     OpenSearchConnector openSearchConnector,
                     OpenSearchIndexer openSearchIndexer,
                     JenaService jenaService,
-                    NamespaceService namespaceService) {
+                    NamespaceService namespaceService,
+                    MigrationInitializer migrationInitializer) {
         this.groupManagementService = groupManagementService;
         this.openSearchConnector = openSearchConnector;
         this.openSearchIndexer = openSearchIndexer;

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/FusekiSchemaVersionAccessor.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/FusekiSchemaVersionAccessor.java
@@ -1,12 +1,11 @@
 package fi.vm.yti.datamodel.api.migration;
 
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.migration.InitializationException;
+import fi.vm.yti.migration.SchemaVersionAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import fi.vm.yti.migration.InitializationException;
-import fi.vm.yti.migration.SchemaVersionAccessor;
 
 @Service
 public class FusekiSchemaVersionAccessor implements SchemaVersionAccessor {
@@ -20,7 +19,7 @@ public class FusekiSchemaVersionAccessor implements SchemaVersionAccessor {
 
     @Override
     public boolean isInitialized() throws InitializationException {
-        return true; // graphManager.isVersionGraphInitialized();
+        return jenaService.isVersionGraphInitialized();
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V1_Initial.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V1_Initial.java
@@ -1,11 +1,10 @@
 package fi.vm.yti.datamodel.api.migration.task;
 
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.migration.MigrationTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
-import fi.vm.yti.migration.MigrationTask;
 
 @Component
 public class V1_Initial implements MigrationTask {
@@ -19,8 +18,9 @@ public class V1_Initial implements MigrationTask {
 
     @Override
     public void migrate() {
-        /* TODO: migrations
-        logger.debug("Creating default graph and service categories");
+
+        logger.info("v1");
+        /*
         graphManager.createDefaultGraph();
         graphManager.initServiceCategories();
 

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V2_Separator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V2_Separator.java
@@ -60,5 +60,23 @@ public class V2_Separator implements MigrationTask {
         """;
         jenaService.sendUpdateStringQuery(xmlNamespaceUpdateQuery);
 
+        var updateSubjectQuery = """
+            DELETE{
+             GRAPH ?g {
+              ?subject ?predicate ?object
+             }
+            }INSERT{
+             GRAPH ?g {
+              ?replaced ?predicate ?object
+             }
+            }WHERE{
+              GRAPH ?g {
+               ?subject ?predicate ?object
+               FILTER(REGEX(STR(?subject), "http://uri.suomi.fi/datamodel/ns/[a-zA-Z0-9]+#", "i"))
+                BIND(IRI(REPLACE(str(?subject), "#", "/", "i")) as ?replaced)
+              }
+            }
+        """;
+        jenaService.sendUpdateStringQuery(updateSubjectQuery);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V2_Separator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V2_Separator.java
@@ -1,0 +1,64 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.migration.MigrationTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V2_Separator implements MigrationTask {
+
+    private static final Logger logger = LoggerFactory.getLogger(V2_Separator.class);
+
+    private final JenaService jenaService;
+
+    public V2_Separator(JenaService jenaService) {
+        this.jenaService = jenaService;
+    }
+
+    @Override
+    public void migrate() {
+        logger.debug("Sending separator update");
+        var query = """
+            DELETE{
+             GRAPH ?g {
+              ?subject ?predicate ?object
+             }
+            }INSERT{
+             GRAPH ?g {
+              ?subject ?predicate ?replaced
+             }
+            }WHERE{
+              GRAPH ?g {
+               ?subject ?predicate ?object
+               FILTER(REGEX(STR(?object), "http://uri.suomi.fi/datamodel/ns/[a-zA-Z0-9]+#", "i"))
+               FILTER NOT EXISTS { ?subject <http://purl.org/ws-mmi-dc/terms/preferredXMLNamespaceName> ?object }
+                BIND(IRI(REPLACE(str(?object), "#", "/", "i")) as ?replaced)
+              }
+            }
+        """;
+        jenaService.sendUpdateStringQuery(query);
+
+        var xmlNamespaceUpdateQuery = """
+            DELETE{
+             GRAPH ?g {
+              ?subject ?predicate ?object
+             }
+            }INSERT{
+             GRAPH ?g {
+              ?subject ?predicate ?replaced
+             }
+            }WHERE{
+              GRAPH ?g {
+               ?subject ?predicate ?object
+               FILTER(REGEX(STR(?object), "http://uri.suomi.fi/datamodel/ns/[a-zA-Z0-9]+#", "i"))
+               FILTER EXISTS { ?subject <http://purl.org/ws-mmi-dc/terms/preferredXMLNamespaceName> ?object }
+               BIND(REPLACE(str(?object), "#", "/", "i") as ?replaced)
+             }
+            }
+        """;
+        jenaService.sendUpdateStringQuery(xmlNamespaceUpdateQuery);
+
+    }
+}


### PR DESCRIPTION
Changelog:
- Added migration support
- New migration task for changing separator for resources
  - This migration task is done under the assumption that the data in the database is using the new v2 models
  - V1 task was left open for creating a task to update production data to the new v2 models, so it may not be run in test and dev environments where task V2 was already run

NOTE: Before installation #133  should be merged as well