### PR TITLE
YTI-2601: Changed all code to use / as separator instead of #

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
@@ -9,7 +9,7 @@ public class Iow {
         //property class
     }
 
-    public static final String URI ="http://uri.suomi.fi/datamodel/ns/iow#";
+    public static final String URI ="http://uri.suomi.fi/datamodel/ns/iow/";
 
     public static final Property contentModified = ResourceFactory.createProperty(URI, "contentModified");
     public static final Property documentation = ResourceFactory.createProperty(URI, "documentation");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -10,6 +10,7 @@ public class ModelConstants {
     }
 
     public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
+    public static final String RESOURCE_SEPARATOR = "/";
     public static final String URN_UUID = "urn:uuid:";
     public static final String DEFAULT_LANGUAGE = "fi";
     public static final List<String> USED_LANGUAGES = List.of("fi", "sv", "en");
@@ -22,7 +23,7 @@ public class ModelConstants {
             "owl", "http://www.w3.org/2002/07/owl#",
             "dcap", "http://purl.org/ws-mmi-dc/terms/",
             "xsd", "http://www.w3.org/2001/XMLSchema#",
-            "iow", "http://uri.suomi.fi/datamodel/ns/iow#",
+            "iow", "http://uri.suomi.fi/datamodel/ns/iow/",
             "skos", "http://www.w3.org/2004/02/skos/core#",
             "sh", "http://www.w3.org/ns/shacl#"
     );

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -111,7 +111,7 @@ public class ClassController {
     }
 
     Model handleCreateClassOrNodeShape(String modelURI, String prefix, BaseDTO dto) {
-        if(jenaService.doesResourceExistInGraph(modelURI, modelURI + "#" + dto.getIdentifier())){
+        if(jenaService.doesResourceExistInGraph(modelURI, modelURI + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier())){
             throw new MappingError("Class already exists");
         }
         var model = jenaService.getDataModel(modelURI);
@@ -145,8 +145,8 @@ public class ClassController {
         logger.info("Updating class {}", classIdentifier);
 
         var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var classURI = graph + "#" + classIdentifier;
-        if(!jenaService.doesResourceExistInGraph(graph, graph + "#" + classIdentifier)){
+        var classURI = graph + ModelConstants.RESOURCE_SEPARATOR + classIdentifier;
+        if(!jenaService.doesResourceExistInGraph(graph, graph + ModelConstants.RESOURCE_SEPARATOR + classIdentifier)){
             throw new ResourceNotFoundException(classIdentifier);
         }
 
@@ -186,7 +186,7 @@ public class ClassController {
 
     private ResourceInfoBaseDTO handleGetClassOrNodeShape(String prefix, String classIdentifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var classURI = modelURI + "#" + classIdentifier;
+        var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + classIdentifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
             throw new ResourceNotFoundException(classURI);
         }
@@ -231,7 +231,7 @@ public class ClassController {
 
     void handleDeleteClassOrNodeShape(String prefix, String identifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var classURI  = modelURI + "#" + identifier;
+        var classURI  = modelURI + ModelConstants.RESOURCE_SEPARATOR + identifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
             throw new ResourceNotFoundException(classURI);
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -7,7 +7,8 @@ import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.SKOS;
@@ -61,7 +62,7 @@ public class ExportController {
         }
 
         if (resource != null) {
-            var res = model.getResource(modelURI + "#" + resource);
+            var res = model.getResource(modelURI + ModelConstants.RESOURCE_SEPARATOR + resource);
             var properties = res.listProperties();
             if (!properties.hasNext()) {
                 return ResponseEntity.notFound().build();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveController.java
@@ -99,7 +99,7 @@ public class ResolveController {
                 return;
             }
 
-            var dataModelResource = dataModel.getResource(modelURI + "#" + resource);
+            var dataModelResource = dataModel.getResource(modelURI + ModelConstants.RESOURCE_SEPARATOR + resource);
 
             if (MapperUtils.hasType(dataModelResource, OWL.Class, SH.NodeShape)) {
                 redirectURL.append("/class/");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -54,7 +54,7 @@ public class ResourceController {
     @PutMapping(value = "/{prefix}", consumes = APPLICATION_JSON_VALUE)
     public void createResource(@PathVariable String prefix, @RequestBody @ValidResource ResourceDTO dto){
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        if(jenaService.doesResourceExistInGraph(graphUri, graphUri + prefix + "#" + dto.getIdentifier())){
+        if(jenaService.doesResourceExistInGraph(graphUri, graphUri + prefix + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier())){
             throw new MappingError("Already exists");
         }
 
@@ -77,7 +77,7 @@ public class ResourceController {
     public void updateResource(@PathVariable String prefix, @PathVariable String resourceIdentifier, @RequestBody @ValidResource(updateProperty = true) ResourceDTO dto){
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
 
-        if(!jenaService.doesResourceExistInGraph(graphUri, graphUri + "#" + resourceIdentifier)){
+        if(!jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier)){
             throw new ResourceNotFoundException("Resource does not exist");
         }
 
@@ -93,7 +93,7 @@ public class ResourceController {
         terminologyService.resolveConcept(dto.getSubject());
         ResourceMapper.mapToUpdateResource(graphUri, model, resourceIdentifier, dto, userProvider.getUser());
         jenaService.putDataModelToCore(graphUri, model);
-        var indexResource = ResourceMapper.mapToIndexResource(model, graphUri + "#" + resourceIdentifier);
+        var indexResource = ResourceMapper.mapToIndexResource(model, graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier);
         openSearchIndexer.updateResourceToIndex(indexResource);
     }
 
@@ -102,7 +102,7 @@ public class ResourceController {
     @GetMapping(value = "/{prefix}/{resourceIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ResourceInfoDTO getResource(@PathVariable String prefix, @PathVariable String resourceIdentifier){
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        if(!jenaService.doesResourceExistInGraph(graphUri,graphUri + "#" + resourceIdentifier)){
+        if(!jenaService.doesResourceExistInGraph(graphUri,graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier)){
             throw new ResourceNotFoundException("Resource does not exist");
         }
 
@@ -124,7 +124,7 @@ public class ResourceController {
     @DeleteMapping(value = "/{prefix}/{resourceIdentifier}")
     public void deleteResource(@PathVariable String prefix, @PathVariable String resourceIdentifier){
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var resourceUri  = modelURI + "#" + resourceIdentifier;
+        var resourceUri  = modelURI + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , resourceUri)){
             throw new ResourceNotFoundException(resourceUri);
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -33,7 +33,7 @@ public class ClassMapper {
 
     private static Resource createResourceAndMapCommonInfo(Model model, String modelURI, BaseDTO dto) {
         var modelResource = model.getResource(modelURI);
-        var classUri = modelURI + "#" + dto.getIdentifier();
+        var classUri = modelURI + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier();
         var resource = model.createResource(classUri)
                 .addProperty(OWL.versionInfo, dto.getStatus().name())
                 .addProperty(RDFS.isDefinedBy, modelResource)
@@ -256,7 +256,7 @@ public class ClassMapper {
                                              boolean hasRightToModel,
                                              Consumer<ResourceCommonDTO> userMapper){
         var dto = new ClassInfoDTO();
-        var classUri = modelUri + "#" + classIdentifier;
+        var classUri = modelUri + ModelConstants.RESOURCE_SEPARATOR + classIdentifier;
         var classResource = model.getResource(classUri);
         var modelResource = model.getResource(modelUri);
 
@@ -275,7 +275,7 @@ public class ClassMapper {
                                                      boolean hasRightToModel,
                                                      Consumer<ResourceCommonDTO> userMapper) {
         var dto = new NodeShapeInfoDTO();
-        var nodeShapeURI = modelUri + "#" + identifier;
+        var nodeShapeURI = modelUri + ModelConstants.RESOURCE_SEPARATOR + identifier;
         var nodeShapeResource = model.getResource(nodeShapeURI);
         var modelResource = model.getResource(modelUri);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -241,8 +241,8 @@ public class MapperUtils {
      * @param resourceUri Resource URI
      */
     public static void addResourceRelationship(Set<String> owlImports, Set<String> dcTermsRequires, Resource resource, Property property, String resourceUri){
-        var namespace = NodeFactory.createURI(resourceUri).getNameSpace().replace("#", "");
-        var ownNamespace = resource.getNameSpace().replace("#", "");
+        var namespace = NodeFactory.createURI(resourceUri).getNameSpace().replaceAll("/$", "");
+        var ownNamespace = resource.getNameSpace().replaceAll("/$", "");
         if(!ownNamespace.equals(namespace) &&!owlImports.contains(namespace) && !dcTermsRequires.contains(namespace)){
             throw new MappingError("Resource namespace not in owl:imports or dcterms:requires");
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -2,8 +2,8 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.service.JenaQueryException;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.security.YtiUser;
@@ -86,7 +86,7 @@ public class ModelMapper {
             modelDTO.getCodeLists().forEach(codeList -> modelResource.addProperty(Iow.codeLists, ResourceFactory.createResource(codeList)));
         }
 
-        model.setNsPrefix(modelDTO.getPrefix(), modelUri + "#");
+        model.setNsPrefix(modelDTO.getPrefix(), modelUri + "/");
 
         return model;
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -22,7 +22,7 @@ public class ResourceMapper {
 
     public static String mapToResource(String graphUri, Model model, ResourceDTO dto, YtiUser user){
         var creationDate = new XSDDateTime(Calendar.getInstance());
-        var resourceUri = graphUri + "#" + dto.getIdentifier();
+        var resourceUri = graphUri + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier();
         var resourceType = dto.getType().equals(ResourceType.ASSOCIATION) ? OWL.ObjectProperty : OWL.DatatypeProperty;
 
         var resourceResource = model.createResource(resourceUri)
@@ -72,7 +72,7 @@ public class ResourceMapper {
         var updateDate = new XSDDateTime(Calendar.getInstance());
         var modelResource = model.getResource(graphUri);
         var languages = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
-        var resource = model.getResource(graphUri + "#" + resourceIdentifier);
+        var resource = model.getResource(graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier);
 
         var type = resource.getProperty(RDF.type).getResource();
         if(type.equals(OWL.Class)){
@@ -164,7 +164,7 @@ public class ResourceMapper {
                                                        String resourceIdentifier, Model orgModel,
                                                        boolean hasRightToModel, Consumer<ResourceCommonDTO> userMapper) {
         var dto = new ResourceInfoDTO();
-        var resourceUri = modelUri + "#" + resourceIdentifier;
+        var resourceUri = modelUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier;
         var resourceResource = model.getResource(resourceUri);
         if(MapperUtils.hasType(resourceResource, OWL.ObjectProperty)){
             dto.setType(ResourceType.ASSOCIATION);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -1,7 +1,10 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.v2.dto.*;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.SimpleSelector;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
@@ -122,15 +125,9 @@ public class VisualizationMapper {
 
     private static String getReferenceIdentifier(String uri, Map<String, String> namespaces) {
         try {
-            var u = new URI(uri);
-            String fragment = u.getFragment();
-
-            if (fragment == null) {
-                LOG.warn("No fragment found from URI {}", uri);
-                return null;
-            }
-
-            String prefix = namespaces.get(uri.substring(0, uri.lastIndexOf("#")));
+            var uriPath = URI.create(uri).getPath();
+            var fragment = uriPath.substring(uriPath.lastIndexOf("/") + 1);
+            String prefix = namespaces.get(uri.substring(0, uri.lastIndexOf("/")));
 
             if (prefix == null) {
                 // referenced class in the external namespace or other model in Interoperability platform

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
@@ -16,10 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static fi.vm.yti.datamodel.api.v2.opensearch.OpenSearchUtil.logPayload;
-
+//TODO this can be made static
 @Service
 public class CountQueryFactory {
-
     public SearchRequest createModelQuery() {
         var status = QueryBuilders.bool()
                 .mustNot(QueryBuilders.term()

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -4,7 +4,7 @@ import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,8 +29,8 @@ class ClassMapperTest {
         ClassDTO dto = new ClassDTO();
         dto.setIdentifier("TestClass");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqClass"));
-        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext#SubClass"));
+        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqClass"));
+        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext/SubClass"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
@@ -39,13 +39,13 @@ class ClassMapperTest {
         ClassMapper.createOntologyClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         assertNotNull(modelResource);
         assertNotNull(classResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(1, classResource.listProperties(RDFS.label).toList().size());
         assertEquals("test label", classResource.getProperty(RDFS.label).getLiteral().getString());
@@ -62,9 +62,9 @@ class ClassMapperTest {
         assertEquals("test note", classResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, classResource.listProperties(RDFS.subClassOf).toList().size());
-        assertEquals("https://www.example.com/ns/ext#SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/SubClass", classResource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(1, classResource.listProperties(OWL.equivalentClass).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqClass", classResource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqClass", classResource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.creator).getString());
         assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.modifier).getString());
     }
@@ -82,7 +82,7 @@ class ClassMapperTest {
         ClassMapper.createOntologyClassAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Identifier");
+        Resource classResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Identifier");
 
         assertNotNull(modelResource);
         assertNotNull(classResource);
@@ -102,9 +102,9 @@ class ClassMapperTest {
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals("TestClass", dto.getIdentifier());
         assertEquals(1, dto.getEquivalentClass().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", dto.getEquivalentClass().stream().findFirst().orElse(null));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", dto.getEquivalentClass().stream().findFirst().orElse(null));
         assertEquals(1, dto.getSubClassOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", dto.getSubClassOf().stream().findFirst().orElse(null));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", dto.getSubClassOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getLabel().size());
         assertEquals("test label", dto.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
@@ -115,7 +115,7 @@ class ClassMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", dto.getUri());
     }
 
     @Test
@@ -138,7 +138,7 @@ class ClassMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", dto.getUri());
     }
 
     @Test
@@ -164,15 +164,15 @@ class ClassMapperTest {
     @Test
     void testMapToUpdateClassLibrary(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new ClassDTO();
         dto.setLabel(Map.of("fi", "new label"));
         dto.setStatus(Status.INVALID);
         dto.setNote(Map.of("fi", "new note"));
-        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int#NewEq"));
-        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext#NewSub"));
+        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
+        dto.setSubClassOf(Set.of("https://www.example.com/ns/ext/NewSub"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
 
@@ -182,8 +182,8 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
@@ -196,8 +196,8 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
-        assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
@@ -210,7 +210,7 @@ class ClassMapperTest {
     @Test
     void testMapToUpdateClassNullValuesDTO(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new ClassDTO();
@@ -221,8 +221,8 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
@@ -235,8 +235,8 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
@@ -245,7 +245,7 @@ class ClassMapperTest {
     @Test
     void testMapToUpdateClassEmptyValuesDTO(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new ClassDTO();
@@ -256,8 +256,8 @@ class ClassMapperTest {
         dto.setNote(Collections.emptyMap());
 
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
 
@@ -284,7 +284,7 @@ class ClassMapperTest {
 
         assertEquals("test label", attribute.getLabel().get("fi"));
         assertEquals("test", attribute.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#rangetest2", attribute.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/rangetest2", attribute.getUri());
         assertEquals("test", attribute.getModelId());
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -1,11 +1,11 @@
 package fi.vm.yti.datamodel.api.mapper;
 
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
 import fi.vm.yti.datamodel.api.v2.dto.NodeShapeDTO;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
-import fi.vm.yti.datamodel.api.v2.dto.Iow;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.*;
@@ -34,14 +34,14 @@ class NodeShapeMapperTest {
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
-        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target#Class");
+        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target/Class");
 
         ClassMapper.createNodeShapeAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", model, dto, mockUser);
-        ClassMapper.mapPlaceholderPropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test#TestClass",
+        ClassMapper.mapPlaceholderPropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
                 propertiesQueryResult, mockUser);
 
         Resource modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        Resource classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         assertNotNull(modelResource);
         assertNotNull(classResource);
@@ -61,11 +61,11 @@ class NodeShapeMapperTest {
         assertEquals("test note", classResource.getProperty(RDFS.comment).getLiteral().getString());
         assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.creator).getString());
         assertEquals(mockUser.getId().toString(), classResource.getProperty(Iow.modifier).getString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", classResource.getProperty(SH.targetClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target/Class", classResource.getProperty(SH.targetClass).getObject().toString());
 
         assertEquals(2, classResource.listProperties(SH.property).toList().size());
-        var propertyShapeAttribute = model.getResource("http://uri.suomi.fi/datamodel/ns/test#attribute-1");
-        var propertyShapeAssociation = model.getResource("http://uri.suomi.fi/datamodel/ns/test#association-1");
+        var propertyShapeAttribute = model.getResource("http://uri.suomi.fi/datamodel/ns/test/attribute-1");
+        var propertyShapeAssociation = model.getResource("http://uri.suomi.fi/datamodel/ns/test/association-1");
 
         assertNotNull(propertyShapeAttribute);
         assertNotNull(propertyShapeAssociation);
@@ -77,7 +77,7 @@ class NodeShapeMapperTest {
         assertTrue(MapperUtils.hasType(propertyShapeAssociation, SH.PropertyShape));
         assertTrue(MapperUtils.hasType(propertyShapeAssociation, OWL.ObjectProperty));
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1",
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1",
                 propertyShapeAttribute.getProperty(SH.path).getObject().toString());
         assertEquals(Status.DRAFT.name(), propertyShapeAttribute.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));
@@ -103,36 +103,36 @@ class NodeShapeMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", dto.getTargetClass());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target/Class", dto.getTargetClass());
     }
 
     @Test
     void testMapReferencePropertyShapes() {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
         var propertiesQueryResult = MapperTestUtils.getModelFromFile("/properties_result.ttl");
-        ClassMapper.mapReferencePropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test#TestClass",
+        ClassMapper.mapReferencePropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
                 propertiesQueryResult);
 
-        var classRes = model.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var classRes = model.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         var propertyShapes = classRes.listProperties(SH.property).toList();
-        var propertyShapeResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1");
+        var propertyShapeResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1");
 
         assertEquals(2, propertyShapes.size());
         assertTrue(propertyShapes.stream().anyMatch(
-                shape -> shape.getObject().toString().equals("http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1")));
+                shape -> shape.getObject().toString().equals("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1")));
         assertTrue(propertyShapes.stream().anyMatch(
-                shape -> shape.getObject().toString().equals("http://uri.suomi.fi/datamodel/ns/test_lib#association-1")));
+                shape -> shape.getObject().toString().equals("http://uri.suomi.fi/datamodel/ns/test_lib/association-1")));
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1", propertyShapeResource.getURI());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1", propertyShapeResource.getURI());
         assertEquals(OWL.DatatypeProperty, propertyShapeResource.getProperty(RDF.type).getObject());
     }
 
     @Test
     void testMapToUpdateClassProfile(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new NodeShapeDTO();
@@ -141,7 +141,7 @@ class NodeShapeMapperTest {
         dto.setNote(Map.of("fi", "new note"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
-        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target#NewClass");
+        dto.setTargetClass("http://uri.suomi.fi/datamodel/ns/target/NewClass");
 
         assertEquals(SH.NodeShape, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -152,7 +152,7 @@ class NodeShapeMapperTest {
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/target#Class", resource.getProperty(SH.targetClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/target/Class", resource.getProperty(SH.targetClass).getObject().toString());
 
         ClassMapper.mapToUpdateNodeShape(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -34,25 +34,25 @@ class ResourceMapperTest {
         dto.setIdentifier("Resource");
         dto.setType(ResourceType.ASSOCIATION);
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqRes"));
-        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext#SubRes"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/SubRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
         dto.setDomain("http://www.w3.org/2002/07/owl#Class");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test#RangeClass");
+        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/RangeClass");
 
         ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Resource");
+        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.ObjectProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -70,14 +70,14 @@ class ResourceMapperTest {
         assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
-        assertEquals("https://www.example.com/ns/ext#SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals(mockUser.getId().toString(), resourceResource.getProperty(Iow.creator).getObject().toString());
         assertEquals(mockUser.getId().toString(), resourceResource.getProperty(Iow.modifier).getObject().toString());
 
         assertEquals("http://www.w3.org/2002/07/owl#Class", MapperUtils.propertyToString(resourceResource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
     }
 
     @Test
@@ -88,7 +88,7 @@ class ResourceMapperTest {
         dto.setIdentifier("Resource");
         dto.setType(ResourceType.ASSOCIATION);
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqRes"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
@@ -97,13 +97,13 @@ class ResourceMapperTest {
         ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, EndpointUtils.mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Resource");
+        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.ObjectProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -123,7 +123,7 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topObjectProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
     }
 
     @Test
@@ -134,7 +134,7 @@ class ResourceMapperTest {
         dto.setIdentifier("Resource");
         dto.setType(ResourceType.ATTRIBUTE);
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqRes"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
@@ -143,13 +143,13 @@ class ResourceMapperTest {
         ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, EndpointUtils.mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Resource");
+        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.DatatypeProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -169,7 +169,7 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topDataProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
     }
 
     @Test
@@ -180,25 +180,25 @@ class ResourceMapperTest {
         dto.setIdentifier("Resource");
         dto.setType(ResourceType.ATTRIBUTE);
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#EqRes"));
-        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext#SubRes"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/SubRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
         dto.setDomain("http://www.w3.org/2002/07/owl#Class");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test#RangeClass");
+        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/RangeClass");
 
         ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, EndpointUtils.mockUser);
 
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#Resource");
+        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.DatatypeProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -216,27 +216,27 @@ class ResourceMapperTest {
         assertEquals("test note", resourceResource.getProperty(RDFS.comment).getLiteral().getString());
 
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
-        assertEquals("https://www.example.com/ns/ext#SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
 
         assertEquals("http://www.w3.org/2002/07/owl#Class", MapperUtils.propertyToString(resourceResource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
     }
 
     @Test
     void testMapToIndexResourceClass(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         assertEquals(ResourceType.CLASS, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
     }
@@ -246,19 +246,19 @@ class ResourceMapperTest {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
+        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
 
         assertEquals(ResourceType.ATTRIBUTE, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAttribute", indexClass.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test attribute", indexClass.getLabel().get("fi"));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", indexClass.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", indexClass.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
     }
 
     @Test
@@ -266,33 +266,33 @@ class ResourceMapperTest {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
+        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
 
         assertEquals(ResourceType.ASSOCIATION, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAssociation", indexClass.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test association", indexClass.getLabel().get("fi"));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", indexClass.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", indexClass.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
     }
 
     @Test
     void testMapToIndexResourceMinimalClass(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestClass");
+        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         assertEquals(ResourceType.CLASS, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestClass", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", indexClass.getId());
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexClass.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
         assertNull(indexClass.getNote());
@@ -302,14 +302,14 @@ class ResourceMapperTest {
     void testMapToIndexResourceMinimalAttribute(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
+        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
 
         assertEquals(ResourceType.ATTRIBUTE, indexResource.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", indexResource.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
         assertEquals("TestAttribute", indexResource.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexResource.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexResource.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexResource.getNamespace());
         assertEquals(1, indexResource.getLabel().size());
         assertEquals("test attribute", indexResource.getLabel().get("fi"));
         assertNull(indexResource.getNote());
@@ -319,14 +319,14 @@ class ResourceMapperTest {
     void testMapToIndexResourceMinimalAssociation(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
+        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
 
         assertEquals(ResourceType.ASSOCIATION, indexResource.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", indexResource.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
         assertEquals("TestAssociation", indexResource.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexResource.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#", indexResource.getNamespace());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexResource.getNamespace());
         assertEquals(1, indexResource.getLabel().size());
         assertEquals("test association", indexResource.getLabel().get("fi"));
         assertNull(indexResource.getNote());
@@ -344,9 +344,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAttribute", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -356,9 +356,9 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", dto.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", dto.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange());
     }
 
     @Test
@@ -373,9 +373,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAssociation", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -385,9 +385,9 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", dto.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", dto.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange());
     }
 
     @Test
@@ -410,7 +410,7 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAttribute", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", dto.getUri());
     }
 
     @Test
@@ -434,7 +434,7 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#TestAssociation", dto.getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", dto.getUri());
     }
 
 
@@ -473,19 +473,19 @@ class ResourceMapperTest {
     void mapToUpdateModelAttribute() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
         dto.setStatus(Status.INVALID);
         dto.setNote(Map.of("fi", "new note"));
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#NewEq"));
-        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext#NewSub"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
+        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
-        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test#NewRangeClass");
+        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass");
+        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass");
 
         assertEquals(OWL.DatatypeProperty, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -493,13 +493,13 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
 
 
         ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", dto, mockUser);
@@ -510,8 +510,8 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
@@ -519,25 +519,25 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
     }
 
     @Test
     void mapToUpdateModelAssociation() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
         dto.setStatus(Status.INVALID);
         dto.setNote(Map.of("fi", "new note"));
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int#NewEq"));
-        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext#NewSub"));
+        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
+        dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
-        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test#NewRangeClass");
+        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass");
+        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass");
 
         assertEquals(OWL.ObjectProperty, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -545,13 +545,13 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
 
         ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAssociation", dto, EndpointUtils.mockUser);
 
@@ -561,25 +561,25 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int#NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("https://www.example.com/ns/ext#NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
     }
 
     @Test
     void mapToUpdateAttributeEmptySubResource(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestAttribute");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
 
         //Shouldn't change if null
         ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", new ResourceDTO(), EndpointUtils.mockUser);
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
 
         var dto = new ResourceDTO();
         dto.setSubResourceOf(Set.of());
@@ -592,11 +592,11 @@ class ResourceMapperTest {
     @Test
     void mapToUpdateAssociationEmptySubResource(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test#TestAssociation");
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
 
         //Shouldn't change if null
         ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAssociation", new ResourceDTO(), EndpointUtils.mockUser);
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test#SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
 
         var dto = new ResourceDTO();
         dto.setSubResourceOf(Set.of());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResolveControllerTest.java
@@ -16,12 +16,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Map;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import static org.hamcrest.Matchers.endsWith;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.Matchers.endsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = {
         "spring.cloud.config.import-check.enabled=false"
@@ -63,9 +63,9 @@ class ResolveControllerTest {
         when(jenaService.getDataModel(anyString())).thenReturn(model);
 
         var pathMap = Map.of(
-                "http://uri.suomi.fi/datamodel/ns/test#TestClass", "/model/test/class/TestClass",
-                "http://uri.suomi.fi/datamodel/ns/test#TestAttribute", "/model/test/attribute/TestAttribute",
-                "http://uri.suomi.fi/datamodel/ns/test#TestAssociation", "/model/test/association/TestAssociation"
+                "http://uri.suomi.fi/datamodel/ns/test/TestClass", "/model/test/class/TestClass",
+                "http://uri.suomi.fi/datamodel/ns/test/TestAttribute", "/model/test/attribute/TestAttribute",
+                "http://uri.suomi.fi/datamodel/ns/test/TestAssociation", "/model/test/association/TestAssociation"
         );
         var accept = "text/html";
         for (var key : pathMap.keySet()) {
@@ -84,7 +84,7 @@ class ResolveControllerTest {
 
         var accept = "text/turtle";
         mvc.perform(get("/v2/resolve")
-                        .param("iri", "http://uri.suomi.fi/datamodel/ns/test#TestClass")
+                        .param("iri", "http://uri.suomi.fi/datamodel/ns/test/TestClass")
                         .header(HttpHeaders.ACCEPT, accept))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string(HttpHeaders.LOCATION, endsWith("/datamodel-api/v2/export/test/TestClass")));

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
@@ -3,9 +3,9 @@ package fi.vm.yti.datamodel.api.v2.opensearch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.datamodel.api.index.OpenSearchConnector;
+import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
-import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
@@ -17,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.io.IOException;
 
 import static org.mockito.Mockito.*;
 
@@ -51,7 +49,7 @@ class OpenSearchIndexerTest {
 
 
     @Test
-    void initModelIndexTest() throws IOException {
+    void initModelIndexTest() {
         var model = mock(Model.class);
         var subjects = mock(ResIterator.class);
         when(jenaService.constructWithQuery(any(Query.class))).thenReturn(model);
@@ -64,7 +62,7 @@ class OpenSearchIndexerTest {
     }
 
     @Test
-    void initResourceIndexTest() throws IOException {
+    void initResourceIndexTest() {
         var model = mock(Model.class);
         var subjects = mock(ResIterator.class);
         when(jenaService.constructWithQuery(any(Query.class))).thenReturn(model);

--- a/src/test/resources/codelist.ttl
+++ b/src/test/resources/codelist.ttl
@@ -1,7 +1,7 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
-@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
 
 <http://uri.suomi.fi/codelist/test/testcodelist>
     a               iow:CodeScheme ;

--- a/src/test/resources/create_model.json
+++ b/src/test/resources/create_model.json
@@ -7,7 +7,7 @@
       "dcterms:language": {
         "@list": ["fi", "en", "sv"]
       },
-      "preferredXMLNamespaceName": "http://uri.suomi.fi/datamodel-v2/ns/test#",
+      "preferredXMLNamespaceName": "http://uri.suomi.fi/datamodel-v2/ns/test/",
       "preferredXMLNamespacePrefix": "test",
       "label": {
         "@language": "fi",
@@ -36,7 +36,7 @@
       "@id": "http://www.w3.org/2004/02/skos/core#prefLabel"
     },
     "parentOrganization": {
-      "@id": "http://uri.suomi.fi/datamodel/ns/iow#parentOrganization"
+      "@id": "http://uri.suomi.fi/datamodel/ns/iow/parentOrganization"
     },
     "versionInfo": {
       "@id": "http://www.w3.org/2002/07/owl#versionInfo"
@@ -81,7 +81,7 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "iow": "http://uri.suomi.fi/datamodel/ns/iow#",
+    "iow": "http://uri.suomi.fi/datamodel/ns/iow/",
     "sd": "http://www.w3.org/ns/sparql-service-description#",
     "sh": "http://www.w3.org/ns/shacl#",
     "dcterms": "http://purl.org/dc/terms/",

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -1,10 +1,10 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 
@@ -36,12 +36,12 @@ dcap:preferredXMLNamespacePrefix    "extres" .
 test:TestClass  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test label"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test#SubClass> ;
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test/SubClass> ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test#EqClass> ;
+        owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test/EqClass> ;
         owl:versionInfo      "VALID" ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test note fi"@fi, "test note en"@en ;
@@ -51,34 +51,34 @@ test:TestClass  rdf:type     owl:Class ;
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label              "test attribute"@fi ;
-        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test#SubResource> ;
+        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test/SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAttribute"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
+        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test/EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;
-        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test#RangeClass> .
+        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test/DomainClass> ;
+        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test/RangeClass> .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
         rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label              "test association"@fi ;
-        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test#SubResource> ;
+        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test/SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAssociation"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test#EqResource> ;
+        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test/EqResource> ;
         owl:versionInfo         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test#DomainClass> ;
-        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test#RangeClass>
+        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test/DomainClass> ;
+        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test/RangeClass>
 

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -1,10 +1,10 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#>
@@ -46,4 +46,4 @@ test:TestClass  rdf:type     sh:NodeShape ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target#Class> .
+        sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target/Class> .

--- a/src/test/resources/models/test_datamodel_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_visualization.ttl
@@ -1,10 +1,10 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 
@@ -17,46 +17,46 @@ test:testclass1  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass1"^^xsd:NCName ;
         rdfs:label           "Label 1"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/yti-model#TestClass> .
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/yti-model/TestClass> .
 
 test:testclass2  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass2"^^xsd:NCName ;
         rdfs:label           "Label 2"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test#testclass1> .
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test/testclass1> .
 
 test:testclass3  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass3"^^xsd:NCName ;
         rdfs:label           "Label 3"@fi ;
-        rdfs:subClassOf      <https://www.example.com/ns/external#ExternalClass> .
+        rdfs:subClassOf      <https://www.example.com/ns/external/ExternalClass> .
 
 test:attribute-1  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test#testclass1> ;
+        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass1> ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
         rdfs:label          "testiattribuutti"@fi .
 
 test:association-1 rdf:type  owl:ObjectProperty ;
-        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test#testclass1> ;
+        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass1> ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label          "testiassosiaatio"@fi ;
         dcterms:identifier  "association-1"^^xsd:NCName ;
-        rdfs:range          <http://uri.suomi.fi/datamodel/ns/visu#testclass2> .
+        rdfs:range          <http://uri.suomi.fi/datamodel/ns/visu/testclass2> .
 
 test:association-2 rdf:type  owl:ObjectProperty ;
-        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test#testclass2> ;
+        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass2> ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label          "testiassosiaatio ext"@fi ;
         dcterms:identifier  "association-2"^^xsd:NCName ;
-        rdfs:range          <http://uri.suomi.fi/datamodel/ns/yti-model#SomeClass> .
+        rdfs:range          <http://uri.suomi.fi/datamodel/ns/yti-model/SomeClass> .
 
 test:association-3 rdf:type  owl:ObjectProperty ;
-        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test#testclass3> ;
+        rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass3> ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label          "testiassosiaatio ext"@fi ;
         dcterms:identifier  "association-3"^^xsd:NCName ;
-        rdfs:range          <https://www.example.com/ns/external#ExternalClass> .
+        rdfs:range          <https://www.example.com/ns/external/ExternalClass> .
 
 <https://www.example.com/ns/external>
         dcterms:type                        rdfs:Resource ;

--- a/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
+++ b/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
@@ -1,10 +1,10 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 

--- a/src/test/resources/models/test_resource_query_model.ttl
+++ b/src/test/resources/models/test_resource_query_model.ttl
@@ -1,4 +1,4 @@
-@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix dcap:  <http://purl.org/ws-mmi-dc/terms/> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
@@ -8,9 +8,9 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://uri.suomi.fi/datamodel/ns/test#rangetest2>
+<http://uri.suomi.fi/datamodel/ns/test/rangetest2>
         a                    owl:DatatypeProperty ;
         rdfs:label           "test label"@fi ;
-        rdfs:range           <http://uri.suomi.fi/datamodel/ns/testkirj#NewNewId> ;
+        rdfs:range           <http://uri.suomi.fi/datamodel/ns/testkirj/NewNewId> ;
         dcterms:identifier   "test"^^xsd:NCName ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> .

--- a/src/test/resources/organizations.ttl
+++ b/src/test/resources/organizations.ttl
@@ -6,17 +6,17 @@
 <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09>
         a                    <http://xmlns.com/foaf/0.1/Organization> ;
         dcterms:description  "kuvaus"@fi ;
-        <http://uri.suomi.fi/datamodel/ns/iow#parentOrganization> "" ;
+        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> "" ;
         skos:prefLabel       "Testiorganisaatio"@fi , "Test organization"@en  ;
         <http://xmlns.com/foaf/0.1/homepage> "http://testi.fi" .
 
 <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63>
         a               <http://xmlns.com/foaf/0.1/Organization> ;
-        <http://uri.suomi.fi/datamodel/ns/iow#parentOrganization> "" ;
+        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> "" ;
         skos:prefLabel  "Yhteentoimivuusalustan yllapito"@fi , "Interoperability platform developers"@en , "Utvecklare av interoperabilitetsplattform"@sv ;
         <http://xmlns.com/foaf/0.1/homepage> "https://yhteentoimiva.suomi.fi/" .
 
 <urn:uuid:8fab2816-03c5-48cd-9d48-b61048f435da>
         a               <http://xmlns.com/foaf/0.1/Organization> ;
-        <http://uri.suomi.fi/datamodel/ns/iow#parentOrganization> <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09> ;
+        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09> ;
         skos:prefLabel  "Test aliorganisaatio"@fi .

--- a/src/test/resources/properties_result.ttl
+++ b/src/test/resources/properties_result.ttl
@@ -1,6 +1,6 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@@ -8,14 +8,14 @@
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
-<http://uri.suomi.fi/datamodel/ns/test_lib#attribute-1>
+<http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1>
         rdf:type            owl:DatatypeProperty ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
         rdfs:label          "Attribute attribute-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
         owl:versionInfo     "VALID" .
 
-<http://uri.suomi.fi/datamodel/ns/test_lib#association-1>
+<http://uri.suomi.fi/datamodel/ns/test_lib/association-1>
         rdf:type            owl:ObjectProperty ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
         rdfs:label          "Association association-1"@fi ;

--- a/src/test/resources/service-categories.ttl
+++ b/src/test/resources/service-categories.ttl
@@ -1,5 +1,5 @@
 @prefix dcap:  <http://purl.org/ws-mmi-dc/terms/> .
-@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -1,6 +1,6 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .

--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -1,6 +1,6 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .

--- a/src/test/resources/test_datamodel_v1.ttl
+++ b/src/test/resources/test_datamodel_v1.ttl
@@ -5,12 +5,12 @@
 @prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix dcam:  <http://purl.org/dc/dcam/> .
-@prefix testaa: <http://uri.suomi.fi/datamodel/ns/testaa#> .
+@prefix testaa: <http://uri.suomi.fi/datamodel/ns/testaa/> .
 @prefix afn:   <http://jena.hpl.hp.com/ARQ/function#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix sd:    <http://www.w3.org/ns/sparql-service-description#> .
 @prefix at:    <http://publications.europa.eu/ontology/authority/> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -69,7 +69,7 @@ testaa:test-property  a     owl:DatatypeProperty ;
         dcterms:language                ( "fi" "en" ) ;
         dcterms:modified                "2018-03-20T16:21:07.067Z"^^xsd:dateTime ;
         dcterms:references              <http://uri.suomi.fi/terminology/jhs/terminological-vocabulary-1> ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/testaa#" ;
+        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/testaa/" ;
         dcap:preferredXMLNamespacePrefix
                 "testaa" ;
         owl:versionInfo                 "DRAFT" .


### PR DESCRIPTION
Changelog:
- Added separator in the ModelConstants
- Changed all code to use separator
- Separator is now `/` instead of `#`
- Changed tests to also test for `/` instead of `#`

NOTE: Before installation #132 should be merged as well