### PR TITLE
YTI-2569: Resource query not listing all resources

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
@@ -1,36 +1,29 @@
 package fi.vm.yti.datamodel.api.v2.opensearch.queries;
 
-import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountDTO;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountSearchResponse;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
-import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
-import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
-import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static fi.vm.yti.datamodel.api.v2.opensearch.OpenSearchUtil.logPayload;
-//TODO this can be made static
-@Service
 public class CountQueryFactory {
-    public SearchRequest createModelQuery() {
-        var status = QueryBuilders.bool()
-                .mustNot(QueryBuilders.term()
-                        .field("status")
-                        .value(FieldValue.of(Status.INCOMPLETE.name()))
-                        .build()._toQuery())
-                .build()._toQuery();
 
-        SearchRequest sr = new SearchRequest.Builder()
+    private CountQueryFactory(){
+        //Static class
+    }
+    public static SearchRequest createModelQuery() {
+        var sr = new SearchRequest.Builder()
                 .index(OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL)
                 .size(0)
-                .query(status)
+                .query(QueryFactoryUtils.hideIncompleteStatusQuery())
                 .aggregations("statuses", getAggregation("status"))
                 .aggregations("types", getAggregation("type"))
                 .aggregations("languages", getAggregation("language"))
@@ -45,7 +38,7 @@ public class CountQueryFactory {
         return AggregationBuilders.terms().field(fieldName).build()._toAggregation();
     }
 
-    public CountSearchResponse parseResponse(SearchResponse<?> response) {
+    public static CountSearchResponse parseResponse(SearchResponse<?> response) {
         var ret = new CountSearchResponse();
         var counts = new CountDTO(
                 getBucketValues(response, "statuses"),
@@ -59,19 +52,17 @@ public class CountQueryFactory {
     }
 
     private static Map<String, Long> getBucketValues(SearchResponse<?> response, String aggregateName) {
-        Map<String, Long> result = new HashMap<>();
         var aggregation = response.aggregations().get(aggregateName);
 
         if (aggregation == null) {
-            return result;
+            return Collections.emptyMap();
         }
-        aggregation
+        return aggregation
                 .sterms()
                 .buckets()
                 .array()
-                .forEach(bucket -> result.put(bucket.key(), bucket.docCount()));
-
-        return result;
+                .stream()
+                .collect(Collectors.toMap(StringTermsBucket::key, StringTermsBucket::docCount));
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
@@ -33,8 +33,7 @@ public class ModelQueryFactory {
             should.add(incompleteFromQuery);
         }
 
-        var incompleteStatusQuery = QueryFactoryUtils.hideIncompleteStatusQuery();
-        should.add(incompleteStatusQuery);
+        should.add(QueryFactoryUtils.hideIncompleteStatusQuery());
 
         var queryString = request.getQuery();
         if(queryString != null && !queryString.isBlank()){
@@ -49,7 +48,7 @@ public class ModelQueryFactory {
 
         var groups = request.getGroups();
         if(groups != null && !groups.isEmpty()){
-            var groupsQuery = QueryFactoryUtils.termsQuery("isPartOf", groups.stream().toList());
+            var groupsQuery = QueryFactoryUtils.termsQuery("isPartOf", groups);
             must.add(groupsQuery);
         }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
@@ -5,7 +5,7 @@ import fi.vm.yti.datamodel.api.v2.dto.Status;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.*;
 
-import java.util.List;
+import java.util.Collection;
 
 public class QueryFactoryUtils {
 
@@ -15,6 +15,7 @@ public class QueryFactoryUtils {
 
     public static final int DEFAULT_PAGE_FROM = 0;
     public static final int DEFAULT_PAGE_SIZE = 10;
+    public static final int INTERNAL_SEARCH_PAGE_SIZE = 10000;
     public static final String DEFAULT_SORT_LANG = "fi";
 
     public static int pageFrom(Integer pageFrom){
@@ -43,7 +44,7 @@ public class QueryFactoryUtils {
         return BoolQuery.of(q -> q.mustNot(termQuery))._toQuery();
     }
 
-    public static Query termsQuery(String field, List<String> values){
+    public static Query termsQuery(String field, Collection<String> values){
         return TermsQuery.of(q -> q
                 .field(field)
                 .terms(t -> t

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -29,45 +29,37 @@ public class ResourceQueryFactory {
 
 
         if(allowedDatamodels != null && !allowedDatamodels.isEmpty()){
-            var allowedDatamodelsQuery = QueryFactoryUtils.termsQuery("isDefinedBy", allowedDatamodels.stream().toList());
-            should.add(allowedDatamodelsQuery);
+            should.add(QueryFactoryUtils.termsQuery("isDefinedBy", allowedDatamodels));
         }
 
-        var removeIncompleteStatus = QueryFactoryUtils.hideIncompleteStatusQuery();
-        should.add(removeIncompleteStatus);
+        should.add(QueryFactoryUtils.hideIncompleteStatusQuery());
 
-
-        if(request.getQuery() != null){
-            var labelQuery = QueryFactoryUtils.labelQuery(request.getQuery());
-            must.add(labelQuery);
+        var query = request.getQuery();
+        if(query != null && !query.isBlank()){
+            must.add(QueryFactoryUtils.labelQuery(query));
         }
 
         var statuses = request.getStatus();
         if(statuses != null && !statuses.isEmpty()){
-            var statusQuery = QueryFactoryUtils.termsQuery("status", statuses.stream().map(Status::name).toList());
-            must.add(statusQuery);
+            must.add(QueryFactoryUtils.termsQuery("status", statuses.stream().map(Status::name).toList()));
         }
 
         if(fromNamespaces != null && !fromNamespaces.isEmpty()){
-            var fromNamespacesQuery = QueryFactoryUtils.termsQuery("isDefinedBy", fromNamespaces);
-            must.add(fromNamespacesQuery);
+            must.add(QueryFactoryUtils.termsQuery("isDefinedBy", fromNamespaces));
         }
         //TODO it would be great if we could combine these 2 terms queries.
         //Basically just need to combine the list so that it contains the intersecting strings
         if(restrictedDataModels != null && !restrictedDataModels.isEmpty()){
-            var groupRestrictedNamespacesQuery = QueryFactoryUtils.termsQuery("isDefinedBy", restrictedDataModels);
-            must.add(groupRestrictedNamespacesQuery);
+            must.add(QueryFactoryUtils.termsQuery("isDefinedBy", restrictedDataModels));
         }
 
         var types = request.getResourceTypes();
         if(types != null && !types.isEmpty()){
-            var typeQuery = QueryFactoryUtils.termsQuery("resourceType", types.stream().map(ResourceType::name).toList());
-            must.add(typeQuery);
+            must.add(QueryFactoryUtils.termsQuery("resourceType", types.stream().map(ResourceType::name).toList()));
         }
 
         if (request.getTargetClass() != null) {
-            var targetClassQuery = QueryFactoryUtils.termQuery("targetClass", request.getTargetClass());
-            must.add(targetClassQuery);
+            must.add(QueryFactoryUtils.termQuery("targetClass", request.getTargetClass()));
         }
 
         var finalQuery = QueryBuilders.bool()

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/CountQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/CountQueryFactoryTest.java
@@ -4,7 +4,6 @@ import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountSearchResponse;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.CountQueryFactory;
-
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Buckets;
@@ -22,17 +21,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CountQueryFactoryTest {
 
-    CountQueryFactory factory = new CountQueryFactory();
 
     @Test
     void testModelCounts() throws Exception {
         String expected = OpenSearchUtils.getJsonString("/es/models_count_request.json");
 
-        SearchRequest request = factory.createModelQuery();
+        SearchRequest request = CountQueryFactory.createModelQuery();
 
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(request), JSONCompareMode.LENIENT);
     }
@@ -59,7 +57,7 @@ class CountQueryFactoryTest {
                         "P21", 1L
                 )));
 
-        CountSearchResponse countSearchResponse = factory.parseResponse(response.build());
+        CountSearchResponse countSearchResponse = CountQueryFactory.parseResponse(response.build());
 
         assertEquals(8, countSearchResponse.getTotalHitCount());
         Map<String, Long> groups = countSearchResponse.getCounts().getGroups();

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -4,8 +4,8 @@ import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
 import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
-import fi.vm.yti.datamodel.api.v2.opensearch.queries.ResourceQueryFactory;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.QueryFactoryUtils;
+import fi.vm.yti.datamodel.api.v2.opensearch.queries.ResourceQueryFactory;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -30,6 +30,7 @@ class ResourceQueryFactoryTest {
         request.setPageSize(100);
         request.setStatus(Set.of(Status.DRAFT, Status.VALID));
         request.setSortLang("en");
+        request.setTargetClass("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
         var groupNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/groupNs");

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -18,6 +18,13 @@
           }
         },
         {
+          "term": {
+            "targetClass": {
+              "value": "http://uri.suomi.fi/datamodel/ns/test/TestClass"
+            }
+          }
+        },
+        {
           "terms": {
             "resourceType": ["ATTRIBUTE", "ASSOCIATION"]
           }


### PR DESCRIPTION
Changelog:
- Increased datamodel limit on internal queries to 10000 (elastic search default upper limit)
- Refactored CountQueryFactory to static
- Cleaned up other query factories a bit
- Added targetClass query  parameter to unit test