### PR TITLE
YTI-2567 Single property missing features

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -97,7 +97,7 @@ public class ClassController {
         indexedResources.addAll(properties);
 
         // Node shape based on an existing node shape
-        var propertyURIs = handleTargetNodeProperties(nodeShapeDTO.getTargetNode());
+        var propertyURIs = getTargetNodeProperties(nodeShapeDTO.getTargetNode());
         var referencePropertiesModel = jenaService.findResources(new ArrayList<>(propertyURIs));
         ClassMapper.mapReferencePropertyShapes(model, classURI,
                 referencePropertiesModel);
@@ -121,7 +121,6 @@ public class ClassController {
         terminologyService.resolveConcept(dto.getSubject());
         return model;
     }
-
 
     @Operation(summary = "Update a class in a model")
     @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
@@ -202,7 +201,8 @@ public class ClassController {
         } else {
             dto = ClassMapper.mapToNodeShapeDTO(model, modelURI, classIdentifier, orgModel,
                     hasRightToModel, userMapper);
-            ClassMapper.addNodeShapeResourcesToDTO(model, (NodeShapeInfoDTO) dto);
+            var nodeShapeResources = jenaService.constructWithQuery(ClassMapper.getNodeShapeResourcesQuery(classURI));
+            ClassMapper.addNodeShapeResourcesToDTO(model, nodeShapeResources, (NodeShapeInfoDTO) dto);
         }
 
         terminologyService.mapConcept().accept(dto);
@@ -223,9 +223,41 @@ public class ClassController {
         handleDeleteClassOrNodeShape(prefix, classIdentifier);
     }
 
+    @Operation(summary = "Add property reference to node shape")
+    @ApiResponse(responseCode = "200", description = "Property reference deleted successfully")
+    @PutMapping(value = "/profile/{prefix}/{identifier}/add-property")
+    public void addNodeShapePropertyReference(@PathVariable String prefix, @PathVariable String identifier,
+                                                 @RequestParam String uri) {
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = jenaService.getDataModel(modelURI);
+        var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + identifier;
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        var classResource = model.getResource(classURI);
+        var existingProperties = getTargetNodeProperties(MapperUtils.propertyToString(classResource, SH.node));
+        ClassMapper.mapAppendNodeShapeProperty(classResource, uri, existingProperties);
+        jenaService.putDataModelToCore(modelURI, model);
+    }
+
+    @Operation(summary = "Delete property reference from node shape")
+    @ApiResponse(responseCode = "200", description = "Property reference deleted successfully")
+    @DeleteMapping(value = "/profile/{prefix}/{identifier}/delete-property")
+    public void deleteNodeShapePropertyReference(@PathVariable String prefix, @PathVariable String identifier,
+                                                 @RequestParam String uri) {
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = jenaService.getDataModel(modelURI);
+        var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + identifier;
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        var classResource = model.getResource(classURI);
+        var existingProperties = getTargetNodeProperties(MapperUtils.propertyToString(classResource, SH.node));
+        ClassMapper.mapRemoveNodeShapeProperty(model, classResource, uri, existingProperties);
+        jenaService.putDataModelToCore(modelURI, model);
+    }
+
     void handleDeleteClassOrNodeShape(String prefix, String identifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        var classURI  = modelURI + ModelConstants.RESOURCE_SEPARATOR + identifier;
+        var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + identifier;
         if(!jenaService.doesResourceExistInGraph(modelURI , classURI)){
             throw new ResourceNotFoundException(classURI);
         }
@@ -263,9 +295,19 @@ public class ClassController {
                 .getResponseObjects();
     }
 
+    @Operation(summary = "Get all node shapes properties based on sh:node reference")
+    @ApiResponse(responseCode = "200", description = "List of node shape's properties fetched successfully")
+    @GetMapping(value = "/nodeshape/properties", produces = APPLICATION_JSON_VALUE)
+    public List<IndexResource> getNodeShapeProperties(@RequestParam String nodeURI) throws IOException {
+        var propertyURIs = getTargetNodeProperties(nodeURI);
+        return searchIndexService
+                .findResourcesByURI(propertyURIs)
+                .getResponseObjects();
+    }
+
     @Operation(summary = "Toggles deactivation of a single property shape")
     @ApiResponse(responseCode = "200", description = "Deactivation has changes successfully")
-    @PutMapping(value = "/toggleDeactivate/{prefix}", produces = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/toggle-deactivate/{prefix}", produces = APPLICATION_JSON_VALUE)
     public void deactivatePropertyShape(@PathVariable String prefix, @RequestParam String propertyUri) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = jenaService.getDataModel(modelURI);
@@ -278,7 +320,7 @@ public class ClassController {
         jenaService.putDataModelToCore(modelURI, model);
     }
 
-    private Set<String> handleTargetNodeProperties(String targetNode) {
+    private Set<String> getTargetNodeProperties(String targetNode) {
         var propertyShapes = new HashSet<String>();
         var handledNodeShapes = new HashSet<String>();
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -210,6 +210,11 @@ public class MapperUtils {
         }
     }
 
+    public static void addLiteral(Resource resource, Property property, Object value) {
+        if (value != null) {
+            resource.addLiteral(property, value);
+        }
+    }
     public static void updateLiteral(Resource resource, Property property, Object value){
         if (value != null) {
             resource.removeAll(property);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -66,10 +66,10 @@ public class ResourceMapper {
         MapperUtils.addOptionalStringProperty(resource, SH.defaultValue, dto.getDefaultValue());
         MapperUtils.addOptionalStringProperty(resource, SH.hasValue, dto.getHasValue());
         MapperUtils.addOptionalStringProperty(resource, SH.datatype, dto.getDataType());
-        resource.addLiteral(SH.minCount, dto.getMinCount());
-        resource.addLiteral(SH.maxCount, dto.getMaxCount());
-        resource.addLiteral(SH.minLength, dto.getMinLength());
-        resource.addLiteral(SH.maxLength, dto.getMaxLength());
+        MapperUtils.addLiteral(resource, SH.minCount, dto.getMinCount());
+        MapperUtils.addLiteral(resource, SH.maxCount, dto.getMaxCount());
+        MapperUtils.addLiteral(resource, SH.minLength, dto.getMinLength());
+        MapperUtils.addLiteral(resource, SH.maxLength, dto.getMaxLength());
 
         MapperUtils.addCreationMetadata(resource, user);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -86,4 +86,15 @@ public class ResourceQueryFactory {
         return sr;
     }
 
+    public static SearchRequest createFindResourcesByURIQuery(Set<String> resourceURIs) {
+        return new SearchRequest.Builder()
+                .index(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE)
+                .query(QueryBuilders
+                        .bool()
+                        .must(QueryFactoryUtils.termsQuery("id", resourceURIs))
+                        .build()
+                        ._toQuery())
+                .build();
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
@@ -155,6 +155,17 @@ public class SearchIndexService {
         return result;
     }
 
+    public SearchResponseDTO<IndexResource> findResourcesByURI(Set<String> resourceURIs) throws IOException {
+        var response = client.search(ResourceQueryFactory.createFindResourcesByURIQuery(resourceURIs), IndexResource.class);
+        var result = new SearchResponseDTO<IndexResource>();
+        result.setResponseObjects(response.hits().hits().stream()
+                .map(Hit::source)
+                .toList()
+        );
+        result.setTotalHitCount(response.hits().total().value());
+        return result;
+    }
+
     private void getNamespacesFromModel(String modelUri, List<String> namespaces){
         var model = jenaService.getDataModel(modelUri);
         var resource = model.getResource(modelUri);

--- a/src/test/resources/property_shapes_result.ttl
+++ b/src/test/resources/property_shapes_result.ttl
@@ -1,0 +1,39 @@
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<http://uri.suomi.fi/datamodel/ns/test_profile/ps-1>
+        rdf:type            sh:PropertyShape , owl:DatatypeProperty ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_profile> ;
+        rdfs:label          "Property shape attribute"@fi ;
+        dcterms:identifier  "ps-1"^^xsd:NCName ;
+        owl:versionInfo     "VALID" .
+
+<http://uri.suomi.fi/datamodel/ns/TestPropertyShape>
+        rdf:type             sh:PropertyShape , owl:DatatypeProperty ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
+        dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
+        dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        rdfs:label           "test property shape"@fi ;
+        owl:versionInfo      "DRAFT" ;
+        sh:defaultValue      "foo" ;
+        sh:hasValue          "hasValue" ;
+        sh:datatype          "xsd:integer" ;
+        sh:in                "bar" , "foo" ;
+        sh:maxCount          10 ;
+        sh:maxLength         100 ;
+        sh:minCount          1 ;
+        sh:minLength         2 ;
+        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .
+
+<http://uri.suomi.fi/datamodel/ns/test/DeactivatedPropertyShape>
+        rdf:type             sh:PropertyShape , owl:DatatypeProperty ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        dcterms:identifier   "DeactivatedPropertyShape"^^xsd:NCName ;
+        sh:deactivated       true ;
+        rdfs:label           "deactivated property shape"@fi .


### PR DESCRIPTION
Endpoints for adding and removing property shapes (update node shape's `SH.property`)
```
# Add
PUT /datamodel-api/v2/class/profile/{prefix}/{identifier}/add-property?uri=http://uri.suomi.fi/datamodel/ns/foo/some-property

# Delete
DELETE /datamodel-api/v2/class/profile/{prefix}/{identifier}/delete-property?uri=http://uri.suomi.fi/datamodel/ns/foo/some-property
```

Endpoint for fetching recursively properties from sh:node reference. Data fetched from OpenSearch.

```
GET /datamodel-api/nodeshape/properties?nodeURI=http://uri.suomi.fi/datamodel/ns/foo/some-class
```

Changed reference property shape handling that no placeholder resource is created, only reference with `SH.property`. Also created sparql query for fetching resources from Fuseki based on `SH.property` values

Other refactorings and fixes
- rename toggleDeactivated endpoint -> toggle-deactivated
- null checks for adding literals