### PR TITLE
YTI-2578 map search modal data

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -6,6 +6,7 @@ import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.*;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
 import fi.vm.yti.security.AuthenticatedUserProvider;
@@ -80,6 +81,13 @@ public class FrontendController {
     @GetMapping(path = "/searchInternalResources", produces = APPLICATION_JSON_VALUE)
     public SearchResponseDTO<IndexResource> getInternalResources(ResourceSearchRequest request) throws IOException {
         return searchIndexService.searchInternalResources(request, userProvider.getUser());
+    }
+
+    @Operation(summary = "Search resources", description = "List of resources")
+    @ApiResponse(responseCode = "200", description = "List of resources as JSON")
+    @GetMapping(path = "/searchInternalResourcesInfo", produces = APPLICATION_JSON_VALUE)
+    public SearchResponseDTO<IndexResourceInfo> getInternalResourcesInfo(ResourceSearchRequest request) throws IOException {
+        return searchIndexService.searchInternalResourcesWithInfo(request, userProvider.getUser());
     }
 
     @Operation(summary = "Get supported data types")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/ConceptInfo.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/ConceptInfo.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.datamodel.api.v2.opensearch.index;
+
+import java.util.Map;
+
+public class ConceptInfo {
+    private String conceptURI;
+    private Map<String, String> conceptLabel;
+    private Map<String, String> terminologyLabel;
+
+    public String getConceptURI() {
+        return conceptURI;
+    }
+
+    public void setConceptURI(String conceptURI) {
+        this.conceptURI = conceptURI;
+    }
+
+    public Map<String, String> getConceptLabel() {
+        return conceptLabel;
+    }
+
+    public void setConceptLabel(Map<String, String> conceptLabel) {
+        this.conceptLabel = conceptLabel;
+    }
+
+    public Map<String, String> getTerminologyLabel() {
+        return terminologyLabel;
+    }
+
+    public void setTerminologyLabel(Map<String, String> terminologyLabel) {
+        this.terminologyLabel = terminologyLabel;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/DatamodelInfo.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/DatamodelInfo.java
@@ -1,0 +1,46 @@
+package fi.vm.yti.datamodel.api.v2.opensearch.index;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+
+import java.util.List;
+import java.util.Map;
+
+public class DatamodelInfo {
+    private Map<String, String> label;
+    private List<String> groups;
+    private Status status;
+    private ModelType modelType;
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public ModelType getModelType() {
+        return modelType;
+    }
+
+    public void setModelType(ModelType modelType) {
+        this.modelType = modelType;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResourceInfo.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResourceInfo.java
@@ -1,0 +1,62 @@
+package fi.vm.yti.datamodel.api.v2.opensearch.index;
+
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
+
+import java.util.Map;
+
+public class IndexResourceInfo extends IndexBase {
+    private Map<String, String> note;
+    private ResourceType resourceType;
+    private String namespace;
+    private String identifier;
+    private ConceptInfo conceptInfo;
+    private DatamodelInfo dataModelInfo;
+
+    public Map<String, String> getNote() {
+        return note;
+    }
+
+    public void setNote(Map<String, String> note) {
+        this.note = note;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(ResourceType resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public ConceptInfo getConceptInfo() {
+        return conceptInfo;
+    }
+
+    public void setConceptInfo(ConceptInfo conceptInfo) {
+        this.conceptInfo = conceptInfo;
+    }
+
+    public DatamodelInfo getDataModelInfo() {
+        return dataModelInfo;
+    }
+
+    public void setDataModelInfo(DatamodelInfo dataModelInfo) {
+        this.dataModelInfo = dataModelInfo;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -4,6 +4,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
+import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
 import org.apache.jena.arq.querybuilder.*;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.graph.NodeFactory;
@@ -329,6 +330,14 @@ public class JenaService {
             .addWhere(res, OWL.versionInfo, status)
             .addWhere(inScheme, RDFS.label, terminologyLabel);
 
+        return conceptSparql.queryConstruct(builder.build());
+    }
+
+    public Model getAllConcepts() {
+        var builder = new ConstructBuilder().addPrefixes(ModelConstants.PREFIXES);
+        SparqlUtils.addConstructProperty("?concept", builder, SKOS.prefLabel, "?label");
+        SparqlUtils.addConstructProperty("?concept", builder, SKOS.inScheme, "?terminology");
+        SparqlUtils.addConstructProperty("?terminology", builder, RDFS.label, "?terminologyLabel");
         return conceptSparql.queryConstruct(builder.build());
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -59,7 +59,7 @@ public abstract class BaseValidator implements Annotation{
     public void checkNote(ConstraintValidatorContext context, BaseDTO dto) {
         var notes = dto.getNote();
         if(notes != null){
-            notes.forEach((lang, value) -> checkCommonTextField(context, value, "note"));
+            notes.forEach((lang, value) -> checkCommonTextArea(context, value, "note"));
         }
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
@@ -71,6 +71,16 @@ class FrontendControllerTest {
     }
 
     @Test
+    void searchInternalResourcesInfoTest() throws Exception {
+        this.mvc.perform(get("/v2/frontend/searchInternalResourcesInfo")
+                        .contentType("application/json")
+                        .content(EndpointUtils.convertObjectToJsonString(new ResourceSearchRequest())))
+                .andExpect(status().isOk());
+        verify(searchIndexService).searchInternalResourcesWithInfo(any(ResourceSearchRequest.class), any(YtiUser.class));
+    }
+
+
+    @Test
     void searchModelsTest() throws Exception {
         this.mvc.perform(get("/v2/frontend/searchModels")
                         .contentType("application/json")

--- a/src/test/resources/all_concepts.ttl
+++ b/src/test/resources/all_concepts.ttl
@@ -1,0 +1,17 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<http://uri.suomi.fi/terminology/dd0e10ed/concept-1>
+        skos:inScheme   <http://uri.suomi.fi/terminology/dd0e10ed/> ;
+        skos:prefLabel  "concept"@en , "käsite"@fi .
+
+<http://uri.suomi.fi/terminology/dd0e10ed/>
+        rdfs:label  "Testisanasto"@fi , "Test terminology"@en .
+


### PR DESCRIPTION
In some cases data model and concept data is needed to display search results. Add new endpoint, which returns enriched data. Search functionalities are not changed.

Fix also checking note's length (allow 5000 characters)