### PR TITLE
YTI-2609 Index external classes 

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -195,10 +195,15 @@ public class ResourceMapper {
 
         var dataModel = dataModels.get(resource.getIsDefinedBy());
         var dataModelInfo = new DatamodelInfo();
-        dataModelInfo.setModelType(dataModel.getType());
-        dataModelInfo.setStatus(dataModel.getStatus());
-        dataModelInfo.setLabel(dataModel.getLabel());
-        dataModelInfo.setGroups(dataModel.getIsPartOf());
+        if (dataModel != null) {
+            dataModelInfo.setModelType(dataModel.getType());
+            dataModelInfo.setStatus(dataModel.getStatus());
+            dataModelInfo.setLabel(dataModel.getLabel());
+            dataModelInfo.setGroups(dataModel.getIsPartOf());
+            dataModelInfo.setUri(resource.getIsDefinedBy());
+        } else {
+            dataModelInfo.setUri(resource.getIsDefinedBy());
+        }
         indexResource.setDataModelInfo(dataModelInfo);
 
         if (resource.getSubject() != null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/DatamodelInfo.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/DatamodelInfo.java
@@ -11,6 +11,7 @@ public class DatamodelInfo {
     private List<String> groups;
     private Status status;
     private ModelType modelType;
+    private String uri;
 
     public Map<String, String> getLabel() {
         return label;
@@ -42,5 +43,13 @@ public class DatamodelInfo {
 
     public void setModelType(ModelType modelType) {
         this.modelType = modelType;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -46,7 +46,9 @@ public class ResourceQueryFactory {
 
         // intersect allowed data model lists
         List<String> isDefinedByCondition = getIsDefinedByCondition(fromNamespaces, restrictedDataModels);
-        must.add(QueryFactoryUtils.termsQuery("isDefinedBy", isDefinedByCondition));
+        if (!isDefinedByCondition.isEmpty()) {
+            must.add(QueryFactoryUtils.termsQuery("isDefinedBy", isDefinedByCondition));
+        }
 
         var types = request.getResourceTypes();
         if(types != null && !types.isEmpty()){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -1,5 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RiotException;
@@ -7,15 +9,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
 public class NamespaceResolver {
 
     private final Logger logger = LoggerFactory.getLogger(NamespaceResolver.class);
 
     private final JenaService jenaService;
+    private final OpenSearchIndexer indexer;
 
-    public NamespaceResolver(JenaService jenaService) {
+    public NamespaceResolver(JenaService jenaService, OpenSearchIndexer indexer) {
         this.jenaService = jenaService;
+        this.indexer = indexer;
     }
 
     /**
@@ -30,6 +36,13 @@ public class NamespaceResolver {
             //if namespace contained any triplets we can put the statements into fuseki
             if(model.size() > 0){
                 jenaService.putNamespaceToImports(namespace, model);
+                var indexResources = model.listSubjects()
+                        .mapWith(resource -> ResourceMapper.mapExternalToIndexResource(model, resource))
+                        .toList()
+                        .stream().filter(Objects::nonNull)
+                        .toList();
+                logger.info("Namespace {} resolved, add {} items to index", namespace, indexResources.size());
+                indexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_EXTERNAL, indexResources);
                 return true;
             }
         } catch (RiotException ex){

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -667,6 +667,46 @@ class ResourceMapperTest {
         assertEquals("Testisanasto", concept.getTerminologyLabel().get("fi"));
     }
 
+    @Test
+    void testMapExternalIndexClasses() {
+        var model = MapperTestUtils.getModelFromFile("/external_resources.ttl");
+
+        var resource1 = model.getResource("http://www.w3.org/ns/oa#describing");
+        var resource2 = model.getResource("http://www.w3.org/ns/oa#Motivation");
+
+        var indexResource1 = ResourceMapper.mapExternalToIndexResource(model, resource1);
+        var indexResource2 = ResourceMapper.mapExternalToIndexResource(model, resource2);
+
+        assertNotNull(indexResource1);
+        assertNotNull(indexResource2);
+
+        assertEquals(ResourceType.CLASS, indexResource1.getResourceType());
+        assertEquals(ResourceType.CLASS, indexResource2.getResourceType());
+
+        assertEquals("http://www.w3.org/ns/oa#describing", indexResource1.getId());
+        assertEquals("describing", indexResource1.getIdentifier());
+        assertEquals("http://www.w3.org/ns/oa#", indexResource1.getNamespace());
+        assertEquals("http://www.w3.org/ns/oa#", indexResource1.getIsDefinedBy());
+        assertEquals("Label describing", indexResource1.getLabel().get("en"));
+        assertEquals("Test comment describing", indexResource1.getNote().get("en"));
+    }
+
+    @Test
+    void testMapExternalIndexResources() {
+        var model = MapperTestUtils.getModelFromFile("/external_resources.ttl");
+        var resource1 = model.getResource("http://www.w3.org/ns/oa#exact");
+        var resource2 = model.getResource("http://www.w3.org/ns/oa#hasEndSelector");
+
+        var indexResource1 = ResourceMapper.mapExternalToIndexResource(model, resource1);
+        var indexResource2 = ResourceMapper.mapExternalToIndexResource(model, resource2);
+
+        assertNotNull(indexResource1);
+        assertNotNull(indexResource2);
+
+        assertEquals(ResourceType.ATTRIBUTE, indexResource1.getResourceType());
+        assertEquals(ResourceType.ASSOCIATION, indexResource2.getResourceType());
+    }
+
     private Model getOrgModel(){
         var model = ModelFactory.createDefaultModel();
               model.createResource("urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -33,8 +33,8 @@ class ResourceQueryFactoryTest {
         request.setTargetClass("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
-        var groupNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/groupNs");
-        var addedNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/addedNs");
+        var groupNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/groupNs", "http://uri.suomi.fi/datamodel/ns/addedNs");
+        var addedNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/addedNs", "http://external-data.com/test");
 
         var allowedIncompleteDatamodels = Set.of("http://uri.suomi.fi/datamodel/ns/test");
 

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -31,12 +31,10 @@
         },
         {
           "terms": {
-            "isDefinedBy": ["http://uri.suomi.fi/datamodel/ns/addedNs"]
-          }
-        },
-        {
-          "terms": {
-            "isDefinedBy": ["http://uri.suomi.fi/datamodel/ns/groupNs"]
+            "isDefinedBy": [
+              "http://uri.suomi.fi/datamodel/ns/addedNs",
+              "http://external-data.com/test"
+            ]
           }
         }
       ],

--- a/src/test/resources/external_resources.ttl
+++ b/src/test/resources/external_resources.ttl
@@ -1,0 +1,29 @@
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+oa:exact a rdf:Property ;
+    rdfs:label "exact" ;
+    rdfs:comment "Test comment exact" ;
+    rdfs:isDefinedBy oa: ;
+    rdfs:range xsd:string .
+
+oa:hasEndSelector a rdf:Property ;
+    rdfs:label "hasEndSelector" ;
+    rdfs:comment "Test comment hasEndSelector" ;
+    rdfs:domain oa:RangeSelector ;
+    rdfs:isDefinedBy oa: ;
+    rdfs:range oa:Selector .
+
+oa:describing a oa:Motivation ;
+    rdfs:label "Label describing" ;
+    rdfs:comment "Test comment describing" ;
+    rdfs:isDefinedBy oa: .
+
+oa:Motivation a rdfs:Class ;
+    rdfs:label "Motivation" ;
+    rdfs:comment "Test comment Motivation" ;
+    rdfs:isDefinedBy oa: ;
+    rdfs:subClassOf skos:Concept .


### PR DESCRIPTION
- create new index for external resources and init it while application starts
- external resources are indexed after resolving
- include this index to search if there are external namespaces added to the query
- index resource mapping logic from jena model -> IndexResource object
- refactor isDefinedBy query
