### PR TITLE
YTI-2628: resolve external namespaces

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/Application.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/Application.java
@@ -36,6 +36,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class Application {
 
     public static void main(String[] args) {
+        System.setProperty("jdk.httpclient.redirects.retrylimit", "15");
         SpringApplication.run(Application.class, args);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
@@ -68,7 +68,7 @@ public class StartUpListener {
     private void initOpenSearchIndices() {
         try {
             openSearchConnector.waitForESNodes();
-            openSearchIndexer.reindex();
+            openSearchIndexer.initIndexes();
         } catch (Exception e) {
             logger.warn("OpenSearch initialization failed!", e);
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static fi.vm.yti.security.AuthorizationException.check;
@@ -29,9 +30,17 @@ public class IndexController {
 
     @Operation(summary = "Reindex all datamodels")
     @GetMapping(value = "/reindex")
-    public void reIndex() {
+    public void reIndex(@RequestParam(required = false) String index) {
         check(authorizationManager.hasRightToDropDatabase());
-
-        indexer.reindex();
+        if(index == null){
+            indexer.reindex();
+            return;
+        }
+        switch (index){
+            case OpenSearchIndexer.OPEN_SEARCH_INDEX_EXTERNAL -> indexer.initExternalResourceIndex();
+            case OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL -> indexer.initModelIndex();
+            case OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE -> indexer.initResourceIndex();
+            default -> throw new IllegalArgumentException("Given value not allowed");
+        }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -1,11 +1,40 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 public class NamespaceService {
 
+    private final NamespaceResolver namespaceResolver;
+
+    @Autowired
+    public NamespaceService(NamespaceResolver namespaceResolver) {
+        this.namespaceResolver = namespaceResolver;
+    }
+
+    private static final Map<String, String> DEFAULT_NAMESPACES = Map.ofEntries(
+            Map.entry("oa", "http://www.w3.org/ns/oa#"),
+            Map.entry("dcterms", "http://purl.org/dc/terms/"),
+            Map.entry("skos", "http://www.w3.org/2004/02/skos/core#"),
+            Map.entry("skosxl", "http://www.w3.org/2008/05/skos-xl#"),
+            Map.entry("owl", "http://www.w3.org/2002/07/owl#"),
+            Map.entry("prov", "http://www.w3.org/ns/prov#"),
+            Map.entry("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+            Map.entry("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+            //Map.entry("xsd", "http://www.w3.org/2001/XMLSchema#"), UNRESOLVABLE
+            Map.entry("rr", "http://www.w3.org/ns/r2rml#"),
+            Map.entry("ordl", "http://www.w3.org/ns/odrl/2/"),
+            Map.entry("dcat", "http://www.w3.org/ns/dcat#"),
+            Map.entry("dc", "http://purl.org/dc/elements/1.1/"),
+            Map.entry("sd", "http://www.w3.org/ns/sparql-service-description#"),
+            Map.entry("sh", "http://www.w3.org/ns/shacl#"),
+            Map.entry("shsh", "http://www.w3.org/ns/shacl-shacl")
+    );
+
     public void resolveDefaultNamespaces() {
-        // TODO: resolve default name
+        DEFAULT_NAMESPACES.forEach((prefix, uri) -> namespaceResolver.resolveNamespace(uri));
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
@@ -3,7 +3,6 @@ package fi.vm.yti.datamodel.api.v2.validator;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.Ordered;
@@ -85,6 +84,13 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     protected ResponseEntity<Object> handleNotFoundException(ResourceNotFoundException ex) {
         var apiError = new ApiError(NOT_FOUND);
+        apiError.setMessage(ex.getMessage());
+        return buildResponseEntity(apiError);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+        var apiError = new ApiError(BAD_REQUEST);
         apiError.setMessage(ex.getMessage());
         return buildResponseEntity(apiError);
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
@@ -58,4 +58,34 @@ class IndexControllerTest {
 
         verify(this.openSearchIndexer).reindex();
     }
+
+    @Test
+    void shouldReIndexParameter() throws Exception {
+        this.mvc
+                .perform(get("/v2/index/reindex")
+                        .param("index", "models_v2"))
+                .andExpect(status().isOk());
+        verify(openSearchIndexer).initModelIndex();
+
+        this.mvc
+                .perform(get("/v2/index/reindex")
+                        .param("index", "resources_v2"))
+                .andExpect(status().isOk());
+        verify(openSearchIndexer).initResourceIndex();
+
+        this.mvc
+                .perform(get("/v2/index/reindex")
+                        .param("index", "external_v2"))
+                .andExpect(status().isOk());
+        verify(openSearchIndexer).initExternalResourceIndex();
+    }
+
+    @Test
+    void reindexThrowOnInvalidParamater() throws Exception{
+        this.mvc
+                .perform(get("/v2/index/reindex")
+                        .param("index", "invalid"))
+                .andExpect(status().isBadRequest());
+        verifyNoInteractions(openSearchIndexer);
+    }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
@@ -2,7 +2,6 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
-import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,9 +35,6 @@ class IndexControllerTest {
 
     @Autowired
     private IndexController indexController;
-
-    @MockBean
-    private JenaService jenaService;
 
     @BeforeEach
     public void setup() {


### PR DESCRIPTION
Changelog:
- Added resolving of external namespaces
- Refactored namespace resolver to work with more content types
- Added JVM setting to Application.java to allow for more redirects using the HttpClient
  - This was blocking some namespaces from resolving due to having more than the default 5
- Resource mapper can now check for inverseOf for type and can check literal range if it is using unionOf
- Indexer does not index external resources on startup anymore (so that external resources are not indexed twice)
- More options on reindexing through API