### PR TITLE
YTI-2425 Data model endpoints for profile and library, validation fixes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelDTO.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 public class DataModelDTO {
 
-    private ModelType type;
     private String prefix;
     private Status status;
     private Map<String, String> label = Map.of();
@@ -23,14 +22,6 @@ public class DataModelDTO {
     private Set<String> codeLists = Set.of();
     private String contact;
     private Map<String, String> documentation = Map.of();
-
-    public ModelType getType() {
-        return type;
-    }
-
-    public void setType(ModelType type) {
-        this.type = type;
-    }
 
     public String getPrefix() {
         return prefix;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -72,7 +72,7 @@ public class ClassController {
 
     @Operation(summary = "Add a class to a model")
     @ApiResponse(responseCode = "200", description = "Class added to model successfully")
-    @PutMapping(value = "/ontology/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/library/{prefix}", consumes = APPLICATION_JSON_VALUE)
     public void createClass(@PathVariable String prefix, @RequestBody @ValidClass ClassDTO classDTO){
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateClassOrNodeShape(modelURI, prefix, classDTO);
@@ -124,7 +124,7 @@ public class ClassController {
 
     @Operation(summary = "Update a class in a model")
     @ApiResponse(responseCode =  "200", description = "Class updated in model successfully")
-    @PutMapping(value = "/ontology/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/library/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public void updateClass(@PathVariable String prefix, @PathVariable String classIdentifier, @RequestBody @ValidClass(updateClass = true) ClassDTO classDTO){
         handleUpdateClassOrNodeShape(prefix, classIdentifier, classDTO);
     }
@@ -168,7 +168,7 @@ public class ClassController {
 
     @Operation(summary = "Get a class from a data model")
     @ApiResponse(responseCode = "200", description = "Class found successfully")
-    @GetMapping(value = "/ontology/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/library/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ClassInfoDTO getClass(@PathVariable String prefix, @PathVariable String classIdentifier){
         return (ClassInfoDTO) handleGetClassOrNodeShape(prefix, classIdentifier);
     }
@@ -219,7 +219,7 @@ public class ClassController {
 
     @Operation(summary = "Delete a class from a data model")
     @ApiResponse(responseCode = "200", description = "Class deleted successfully")
-    @DeleteMapping(value = "/ontology/{prefix}/{classIdentifier}")
+    @DeleteMapping(value = "/library/{prefix}/{classIdentifier}")
     public void deleteClass(@PathVariable String prefix, @PathVariable String classIdentifier){
         handleDeleteClassOrNodeShape(prefix, classIdentifier);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Datamodel.java
@@ -4,6 +4,7 @@ import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
 import fi.vm.yti.datamodel.api.v2.dto.DataModelInfoDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
@@ -67,17 +68,13 @@ public class Datamodel {
         this.groupManagementService = groupManagementService;
     }
 
-    @Operation(summary = "Create a new model")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
-    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PutMapping(produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void createModel(@ValidDatamodel @RequestBody DataModelDTO modelDTO) {
+    private void createModel(DataModelDTO modelDTO, ModelType modelType) {
         logger.info("Create model {}", modelDTO);
         check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
 
         terminologyService.resolveTerminology(modelDTO.getTerminologies());
         codelistService.resolveCodelistScheme(modelDTO.getCodeLists());
-        var jenaModel = mapper.mapToJenaModel(modelDTO, userProvider.getUser());
+        var jenaModel = mapper.mapToJenaModel(modelDTO, modelType, userProvider.getUser());
 
         jenaService.putDataModelToCore(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);
 
@@ -85,12 +82,41 @@ public class Datamodel {
         openSearchIndexer.createModelToIndex(indexModel);
     }
 
-    @Operation(summary = "Modify model")
+    @Operation(summary = "Create a new library")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new core model")
+    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @PutMapping(path = "/library", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public void createLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY) @RequestBody DataModelDTO modelDTO) {
+        createModel(modelDTO, ModelType.LIBRARY);
+    }
+
+    @Operation(summary = "Create a new application profile")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new application profile")
+    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @PutMapping(path = "/profile", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public void createProfile(@ValidDatamodel(modelType = ModelType.PROFILE) @RequestBody DataModelDTO modelDTO) {
+        createModel(modelDTO, ModelType.PROFILE);
+    }
+
+    @Operation(summary = "Modify library")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PostMapping(path = "/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void updateModel(@ValidDatamodel(updateModel = true) @RequestBody DataModelDTO modelDTO,
-                            @PathVariable String prefix) {
+    @PostMapping(path = "/library/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public void updateLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY, updateModel = true) @RequestBody DataModelDTO modelDTO,
+                              @PathVariable String prefix) {
+        updateModel(modelDTO, prefix);
+    }
+
+    @Operation(summary = "Modify application profile")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
+    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @PostMapping(path = "/profile/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public void updateProfile(@ValidDatamodel(modelType = ModelType.PROFILE, updateModel = true) @RequestBody DataModelDTO modelDTO,
+                              @PathVariable String prefix) {
+        updateModel(modelDTO, prefix);
+    }
+
+    public void updateModel(DataModelDTO modelDTO, String prefix) {
         logger.info("Updating model {}", modelDTO);
 
         var oldModel = jenaService.getDataModel(ModelConstants.SUOMI_FI_NAMESPACE + prefix);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -55,7 +55,7 @@ public class ResourceController {
 
     @Operation(summary = "Add a resource (attribute or association) to a model")
     @ApiResponse(responseCode = "200", description = "Resource added to model successfully")
-    @PutMapping(value = "/ontology/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/library/{prefix}", consumes = APPLICATION_JSON_VALUE)
     public void createResource(@PathVariable String prefix, @RequestBody @ValidResource ResourceDTO dto){
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateResourceOrPropertyShape(prefix, dto);
@@ -81,7 +81,7 @@ public class ResourceController {
 
     @Operation(summary = "Update a resource in a model")
     @ApiResponse(responseCode = "200", description = "Resource updated to model successfully")
-    @PutMapping(value = "/ontology/{prefix}/{resourceIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/library/{prefix}/{resourceIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public void updateResource(@PathVariable String prefix, @PathVariable String resourceIdentifier,
                                @RequestBody @ValidResource(updateProperty = true) ResourceDTO dto){
         handleUpdateResourceOrPropertyShape(prefix, resourceIdentifier, dto);
@@ -97,7 +97,7 @@ public class ResourceController {
 
     @Operation(summary = "Find an attribute or association from a model")
     @ApiResponse(responseCode = "200", description = "Attribute or association found")
-    @GetMapping(value = "/ontology/{prefix}/{resourceIdentifier}", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/library/{prefix}/{resourceIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ResourceInfoDTO getResource(@PathVariable String prefix, @PathVariable String resourceIdentifier){
         return (ResourceInfoDTO) handleGetResourceOrPropertyShape(prefix, resourceIdentifier);
     }
@@ -132,7 +132,7 @@ public class ResourceController {
 
     @Operation(summary = "Delete a resource from a data model")
     @ApiResponse(responseCode = "200", description = "Resource deleted successfully")
-    @DeleteMapping(value = "/ontology/{prefix}/{resourceIdentifier}")
+    @DeleteMapping(value = "/library/{prefix}/{resourceIdentifier}")
     public void deleteResource(@PathVariable String prefix, @PathVariable String resourceIdentifier){
         handleDeleteResourceOrPropertyShape(prefix, resourceIdentifier);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -36,13 +36,13 @@ public class ModelMapper {
      * @param modelDTO Data Model DTO
      * @return Model
      */
-    public Model mapToJenaModel(DataModelDTO modelDTO, YtiUser user) {
+    public Model mapToJenaModel(DataModelDTO modelDTO, ModelType modelType, YtiUser user) {
         log.info("Mapping DatamodelDTO to Jena Model");
         var model = ModelFactory.createDefaultModel();
         var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix();
         // TODO: type of application profile?
         model.setNsPrefixes(ModelConstants.PREFIXES);
-        Resource type = modelDTO.getType().equals(ModelType.LIBRARY)
+        Resource type = modelType.equals(ModelType.LIBRARY)
                 ? OWL.Ontology
                 : DCAP.DCAP;
 
@@ -81,7 +81,7 @@ public class ModelMapper {
 
         modelDTO.getTerminologies().forEach(terminology -> MapperUtils.addOptionalUriProperty(modelResource, DCTerms.references, terminology));
 
-        if(modelDTO.getType().equals(ModelType.PROFILE)) {
+        if(modelType.equals(ModelType.PROFILE)) {
             modelDTO.getCodeLists().forEach(codeList -> MapperUtils.addOptionalUriProperty(modelResource, Iow.codeLists, codeList));
         }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -17,16 +17,17 @@ public class DataModelValidator extends BaseValidator implements
     private JenaService jenaService;
 
     boolean updateModel;
+    ModelType modelType;
 
     @Override
     public void initialize(ValidDatamodel constraintAnnotation) {
         updateModel = constraintAnnotation.updateModel();
+        modelType = constraintAnnotation.modelType();
     }
 
     @Override
     public boolean isValid(DataModelDTO dataModel, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
-        checkModelType(context, dataModel);
         checkPrefix(context, dataModel);
         checkStatus(context, dataModel.getStatus());
         checkLanguages(context, dataModel);
@@ -42,7 +43,7 @@ public class DataModelValidator extends BaseValidator implements
 
 
         checkTerminologies(context, dataModel);
-        checkCodeLists(context, dataModel);
+        checkCodeLists(context, dataModel, modelType);
         return !isConstraintViolationAdded();
     }
 
@@ -63,21 +64,6 @@ public class DataModelValidator extends BaseValidator implements
         }
     }
 
-
-    /**
-     * Check if model type is valid, if updating ModelType cannot be set
-     * @param context Constraint validator context
-     * @param dataModel DataModel
-     */
-    private void checkModelType(ConstraintValidatorContext context, DataModelDTO dataModel) {
-        var modelType = dataModel.getType();
-        if(updateModel && modelType != null){
-            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "type");
-        }else if(!updateModel && modelType == null){
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "type");
-        }
-    }
-
     /**
      * Check if languages are valid
      * @param context Constraint validator context
@@ -85,6 +71,12 @@ public class DataModelValidator extends BaseValidator implements
      */
     private void checkLanguages(ConstraintValidatorContext context, DataModelDTO dataModel){
         var languages = dataModel.getLanguages();
+
+        if (languages.isEmpty()) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "languages");
+            return;
+        }
+
         languages.forEach(language -> {
             //Matches RFC-4646
             if(!language.matches("^[a-z]{2,3}(?:-[A-Z]{2,3}(?:-[a-zA-Z]{4})?)?$")){
@@ -143,7 +135,7 @@ public class DataModelValidator extends BaseValidator implements
     private void checkOrganizations(ConstraintValidatorContext context, DataModelDTO dataModel){
         var organizations = dataModel.getOrganizations();
         var existingOrgs = jenaService.getOrganizations();
-        if(!updateModel && organizations.isEmpty()){
+        if(organizations.isEmpty()){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "organization");
             return;
         }
@@ -163,7 +155,7 @@ public class DataModelValidator extends BaseValidator implements
     private void checkGroups(ConstraintValidatorContext context, DataModelDTO dataModel){
         var groups = dataModel.getGroups();
         var existingGroups = jenaService.getServiceCategories();
-        if(!updateModel && groups.isEmpty()){
+        if(groups.isEmpty()){
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "groups");
             return;
         }
@@ -249,8 +241,8 @@ public class DataModelValidator extends BaseValidator implements
         }
     }
 
-    private void checkCodeLists(ConstraintValidatorContext context, DataModelDTO dataModel) {
-        if(!updateModel && (dataModel.getType() != null && dataModel.getType().equals(ModelType.LIBRARY)) && !dataModel.getCodeLists().isEmpty()){
+    private void checkCodeLists(ConstraintValidatorContext context, DataModelDTO dataModel, ModelType modelType) {
+        if(modelType.equals(ModelType.LIBRARY) && !dataModel.getCodeLists().isEmpty()){
             addConstraintViolation(context, "library-not-supported", "codeLists");
         }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidDatamodel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidDatamodel.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
@@ -23,5 +24,6 @@ public @interface ValidDatamodel {
     Class<?>[] groups() default {};
 
     boolean updateModel() default false;
+    ModelType modelType();
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -130,9 +130,8 @@ class ModelMapperTest {
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
     }
 
-    @ParameterizedTest
-    @EnumSource(ModelType.class)
-    void testMapToUpdateJenaModel(ModelType modelType) {
+    @Test
+    void testMapToUpdateJenaModel() {
         var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
 
         when(jenaService.getDataModel("test")).thenReturn(m);
@@ -168,10 +167,6 @@ class ModelMapperTest {
         externalDTO.setPrefix("ext");
 
         dto.setExternalNamespaces(Set.of(externalDTO));
-
-        if (modelType.equals(ModelType.PROFILE)) {
-            dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test"));
-        }
 
         //unchanged values
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
@@ -227,12 +222,6 @@ class ModelMapperTest {
                 hello
                 
                 new test""", MapperUtils.localizedPropertyToMap(modelResource, Iow.documentation).get("fi"));
-
-        if (modelType.equals(ModelType.PROFILE)) {
-            assertEquals("http://uri.suomi.fi/codelist/test", MapperUtils.propertyToString(modelResource, Iow.codeLists));
-        } else {
-            assertNull(MapperUtils.propertyToString(modelResource, Iow.codeLists));
-        }
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -7,15 +7,14 @@ import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
 import fi.vm.yti.security.YtiUser;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -55,8 +54,9 @@ class ModelMapperTest {
         when(jenaService.getOrganizations()).thenReturn(mockOrgs);
     }
 
-    @Test
-    void testMapToJenaModel() {
+    @ParameterizedTest
+    @EnumSource(ModelType.class)
+    void testMapToJenaModel(ModelType modelType) {
         var mockModel = ModelFactory.createDefaultModel();
         mockModel.createResource("http://uri.suomi.fi/datamodel/ns/newint")
                         .addProperty(RDF.type, DCAP.DCAP)
@@ -66,7 +66,6 @@ class ModelMapperTest {
         UUID organizationId = UUID.randomUUID();
         YtiUser mockUser = EndpointUtils.mockUser;
 
-        //TODO: should we have 2 separate tests for ModelType.LIBRARY and ModelType.PROFILE?
         DataModelDTO dto = new DataModelDTO();
         dto.setPrefix("test");
         dto.setLabel(Map.of(
@@ -79,10 +78,11 @@ class ModelMapperTest {
         dto.setGroups(Set.of("P11"));
         dto.setLanguages(Set.of("fi", "sv"));
         dto.setOrganizations(Set.of(organizationId));
-        dto.setType(ModelType.PROFILE);
         dto.setInternalNamespaces(Set.of("http://uri.suomi.fi/datamodel/ns/newint"));
         dto.setContact("test@localhost");
-        dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test/testcodelist"));
+        if (modelType.equals(ModelType.PROFILE)) {
+            dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test/testcodelist"));
+        }
         dto.setTerminologies(Set.of("http://uri.suomi.fi/terminology/test"));
         dto.setDocumentation(Map.of("fi","""
                 test documentation
@@ -95,7 +95,7 @@ class ModelMapperTest {
         externalDTO.setPrefix("ext");
         dto.setExternalNamespaces(Set.of(externalDTO));
 
-        Model model = mapper.mapToJenaModel(dto, mockUser);
+        Model model = mapper.mapToJenaModel(dto, modelType, mockUser);
 
         Resource modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
         Resource groupResource = model.getResource("http://urn.fi/URN:NBN:fi:uuid:au:ptvl:v1105");
@@ -114,7 +114,12 @@ class ModelMapperTest {
 
         assertEquals(mockUser.getId().toString(), MapperUtils.propertyToString(modelResource, Iow.creator));
         assertEquals(mockUser.getId().toString(), MapperUtils.propertyToString(modelResource, Iow.modifier));
-        assertEquals("http://uri.suomi.fi/codelist/test/testcodelist", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+
+        if (modelType.equals(ModelType.PROFILE)) {
+            assertEquals("http://uri.suomi.fi/codelist/test/testcodelist", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+        } else {
+            assertNull(MapperUtils.propertyToString(modelResource, Iow.codeLists));
+        }
         assertEquals("http://uri.suomi.fi/terminology/test", MapperUtils.propertyToString(modelResource, DCTerms.references));
         assertEquals("""
                 test documentation
@@ -125,9 +130,9 @@ class ModelMapperTest {
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
     }
 
-    @Test
-    void testMapToUpdateJenaModel() {
-        //TODO: should we have 2 separate tests for ModelType.LIBRARY and ModelType.PROFILE?
+    @ParameterizedTest
+    @EnumSource(ModelType.class)
+    void testMapToUpdateJenaModel(ModelType modelType) {
         var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
 
         when(jenaService.getDataModel("test")).thenReturn(m);
@@ -163,6 +168,10 @@ class ModelMapperTest {
         externalDTO.setPrefix("ext");
 
         dto.setExternalNamespaces(Set.of(externalDTO));
+
+        if (modelType.equals(ModelType.PROFILE)) {
+            dto.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test"));
+        }
 
         //unchanged values
         Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
@@ -218,6 +227,12 @@ class ModelMapperTest {
                 hello
                 
                 new test""", MapperUtils.localizedPropertyToMap(modelResource, Iow.documentation).get("fi"));
+
+        if (modelType.equals(ModelType.PROFILE)) {
+            assertEquals("http://uri.suomi.fi/codelist/test", MapperUtils.propertyToString(modelResource, Iow.codeLists));
+        } else {
+            assertNull(MapperUtils.propertyToString(modelResource, Iow.codeLists));
+        }
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -112,7 +112,7 @@ class ClassControllerTest {
             resourceMapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             classMapper.when(() -> ClassMapper.createOntologyClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class))).thenReturn("test");
             this.mvc
-                    .perform(put("/v2/class/ontology/test")
+                    .perform(put("/v2/class/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                     .andExpect(status().isOk());
@@ -145,7 +145,7 @@ class ClassControllerTest {
             resourceMapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             classMapper.when(() -> ClassMapper.createOntologyClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class))).thenReturn("test");
             this.mvc
-                    .perform(put("/v2/class/ontology/test")
+                    .perform(put("/v2/class/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                     .andExpect(status().isOk());
@@ -168,7 +168,7 @@ class ClassControllerTest {
         doThrow(ResourceNotFoundException.class).when(jenaService).getDataModel(anyString());
 
         this.mvc
-                .perform(put("/v2/class/ontology/test")
+                .perform(put("/v2/class/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isNotFound());
@@ -178,7 +178,7 @@ class ClassControllerTest {
     @MethodSource("provideCreateClassDTOInvalidData")
     void shouldInvalidate(ClassDTO classDTO) throws Exception {
         this.mvc
-                .perform(put("/v2/class/ontology/test")
+                .perform(put("/v2/class/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isBadRequest());
@@ -230,7 +230,7 @@ class ClassControllerTest {
             //mockito will use our mocked static even though we do not call when(). so nothing is needed here
 
             this.mvc
-                    .perform(put("/v2/class/ontology/test/class")
+                    .perform(put("/v2/class/library/test/class")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                     .andExpect(status().isOk());
@@ -255,7 +255,7 @@ class ClassControllerTest {
         when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(false);
 
         this.mvc
-                .perform(put("/v2/class/ontology/test/class")
+                .perform(put("/v2/class/library/test/class")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isNotFound());
@@ -265,7 +265,7 @@ class ClassControllerTest {
     @MethodSource("provideUpdateClassDTOInvalidData")
     void shouldInvalidateUpdate(ClassDTO classDTO) throws Exception{
         this.mvc
-                .perform(put("/v2/class/ontology/test/class")
+                .perform(put("/v2/class/library/test/class")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isBadRequest());
@@ -293,14 +293,14 @@ class ClassControllerTest {
         try(var mapper = mockStatic(ClassMapper.class)) {
             mapper.when(() -> ClassMapper.mapToClassDTO(any(Model.class), anyString(), anyString(), any(Model.class), anyBoolean(), eq(userMapper)))
                     .thenReturn(new ClassInfoDTO());
-            mvc.perform(get("/v2/class/ontology/test/TestClass"))
+            mvc.perform(get("/v2/class/library/test/TestClass"))
                     .andExpect(status().isOk());
         }
     }
 
     @Test
     void shouldResourceNotExistGet() throws Exception {
-        mvc.perform(get("/v2/class/ontology/test/class"))
+        mvc.perform(get("/v2/class/library/test/class"))
                 .andExpect(status().isNotFound());
     }
 
@@ -308,7 +308,7 @@ class ClassControllerTest {
     void shouldModelNotExistGet() throws Exception {
         when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
         doThrow(ResourceNotFoundException.class).when(jenaService).getDataModel(anyString());
-        mvc.perform(get("/v2/class/ontology/test/class"))
+        mvc.perform(get("/v2/class/library/test/class"))
                 .andExpect(status().isNotFound());
     }
 
@@ -319,7 +319,7 @@ class ClassControllerTest {
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
 
-        mvc.perform(delete("/v2/class/ontology/test/class"))
+        mvc.perform(delete("/v2/class/library/test/class"))
                 .andExpect(status().isOk());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -331,7 +331,7 @@ class ClassControllerTest {
 
     @Test
     void shouldFailToFindClassDelete() throws Exception {
-        mvc.perform(delete("/v2/class/ontology/test/class"))
+        mvc.perform(delete("/v2/class/library/test/class"))
                 .andExpect(status().isNotFound());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -345,7 +345,7 @@ class ClassControllerTest {
         when(jenaService.getDataModel(anyString())).thenReturn(mock(Model.class));
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(false);
 
-        mvc.perform(delete("/v2/class/ontology/test/class"))
+        mvc.perform(delete("/v2/class/library/test/class"))
                 .andExpect(status().isUnauthorized());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -105,7 +105,7 @@ class ResourceControllerTest {
             mapper.when(() -> ResourceMapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class), any(YtiUser.class))).thenReturn("test");
             mapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             this.mvc
-                    .perform(put("/v2/resource/ontology/test")
+                    .perform(put("/v2/resource/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                     .andExpect(status().isOk());
@@ -139,7 +139,7 @@ class ResourceControllerTest {
             mapper.when(() -> ResourceMapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class), any(YtiUser.class))).thenReturn("test");
             mapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             this.mvc
-                    .perform(put("/v2/resource/ontology/test")
+                    .perform(put("/v2/resource/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                     .andExpect(status().isOk());
@@ -170,7 +170,7 @@ class ResourceControllerTest {
 
         //finding models from jena is not mocked so it should return null and return 404 not found
         this.mvc
-                .perform(put("/v2/resource/ontology/test")
+                .perform(put("/v2/resource/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isNotFound());
@@ -178,13 +178,13 @@ class ResourceControllerTest {
         when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
 
         this.mvc
-                .perform(put("/v2/resource/ontology/test/resource")
+                .perform(put("/v2/resource/library/test/resource")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(updateDTO)))
                 .andExpect(status().isNotFound());
 
         this.mvc
-                .perform(get("/v2/resource/ontology/test/resource")
+                .perform(get("/v2/resource/library/test/resource")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isNotFound());
@@ -198,7 +198,7 @@ class ResourceControllerTest {
 
         //finding models from jena is not mocked so it should return null and return 404 not found
         this.mvc
-                .perform(put("/v2/resource/ontology/test")
+                .perform(put("/v2/resource/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isBadRequest())
@@ -209,7 +209,7 @@ class ResourceControllerTest {
     @MethodSource("provideCreateResourceDTOInvalidData")
     void shouldInvalidate(ResourceDTO resourceDTO) throws Exception {
         this.mvc
-                .perform(put("/v2/resource/ontology/test")
+                .perform(put("/v2/resource/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isBadRequest());
@@ -268,7 +268,7 @@ class ResourceControllerTest {
         when(jenaService.getDataModel(anyString())).thenReturn(m);
         when(jenaService.doesResourceExistInGraph(anyString(), anyString())).thenReturn(true);
         this.mvc
-                .perform(put("/v2/resource/ontology/test/TestAttribute")
+                .perform(put("/v2/resource/library/test/TestAttribute")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isOk());
@@ -287,7 +287,7 @@ class ResourceControllerTest {
         when(jenaService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList(), anyBoolean())).thenReturn(true);
 
         this.mvc
-                .perform(put("/v2/resource/ontology/test/resource")
+                .perform(put("/v2/resource/library/test/resource")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isNotFound());
@@ -297,7 +297,7 @@ class ResourceControllerTest {
     @MethodSource("provideUpdateResourceDTOInvalidData")
     void shouldInvalidateUpdate(ResourceDTO resourceDTO) throws Exception{
         this.mvc
-                .perform(put("/v2/resource/ontology/test/resource")
+                .perform(put("/v2/resource/library/test/resource")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isBadRequest());
@@ -314,7 +314,7 @@ class ResourceControllerTest {
         try(var mapper = mockStatic(ResourceMapper.class)) {
             mapper.when(() -> ResourceMapper.mapToResourceInfoDTO(any(Model.class), anyString(), anyString(), any(Model.class), anyBoolean(), eq(userMapper)))
                     .thenReturn(new ResourceInfoDTO());
-            mvc.perform(get("/v2/resource/ontology/test/TestAttribute"))
+            mvc.perform(get("/v2/resource/library/test/TestAttribute"))
                     .andExpect(status().isOk());
             verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(jenaService).getDataModel(anyString());
@@ -326,7 +326,7 @@ class ResourceControllerTest {
 
     @Test
     void shouldNotFindResourceGet() throws Exception {
-        mvc.perform(get("/v2/resource/ontology/test/resource"))
+        mvc.perform(get("/v2/resource/library/test/resource"))
                 .andExpect(status().isNotFound());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -339,7 +339,7 @@ class ResourceControllerTest {
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
 
-        mvc.perform(delete("/v2/resource/ontology/test/resource"))
+        mvc.perform(delete("/v2/resource/library/test/resource"))
                 .andExpect(status().isOk());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -351,7 +351,7 @@ class ResourceControllerTest {
 
     @Test
     void shouldFailToFindResourceDelete() throws Exception {
-        mvc.perform(delete("/v2/resource/ontology/test/resource"))
+        mvc.perform(delete("/v2/resource/library/test/resource"))
                 .andExpect(status().isNotFound());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -365,7 +365,7 @@ class ResourceControllerTest {
         when(jenaService.getDataModel(anyString())).thenReturn(mock(Model.class));
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(false);
 
-        mvc.perform(delete("/v2/resource/ontology/test/resource"))
+        mvc.perform(delete("/v2/resource/library/test/resource"))
                 .andExpect(status().isUnauthorized());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());


### PR DESCRIPTION
- Changed paths /ontology -> /library as also application profiles might be ontologies
- Add separate endpoint for creating and updating application profile and library. Thus, we can add validation based on model type. ModelType is no longer provided in the payload
- Add mapping tests for both library and profile