### PR TITLE
YTI-2624 include additional resources to search

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -9,6 +9,7 @@ import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.service.GroupManagementService;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
@@ -294,12 +295,12 @@ public class ClassController {
     @Operation(summary = "Get all node shapes based on given targetClass")
     @ApiResponse(responseCode = "200", description = "List of node shapes fetched successfully")
     @GetMapping(value = "/nodeshapes", produces = APPLICATION_JSON_VALUE)
-    public List<IndexResource> getNodeShapes(@RequestParam String targetClass) throws IOException {
+    public List<IndexResourceInfo> getNodeShapes(@RequestParam String targetClass) throws IOException {
         var request = new ResourceSearchRequest();
         request.setStatus(Set.of(Status.VALID, Status.DRAFT));
         request.setTargetClass(targetClass);
         return searchIndexService
-                .searchInternalResources(request, userProvider.getUser())
+                .searchInternalResourcesWithInfo(request, userProvider.getUser())
                 .getResponseObjects();
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -13,6 +13,7 @@ public class ResourceSearchRequest extends BaseSearchRequest{
     private Set<ResourceType> resourceTypes;
     private ModelType limitToModelType;
     private String targetClass;
+    private Set<String> additionalResources;
 
     public String getLimitToDataModel() {
         return limitToDataModel;
@@ -60,5 +61,13 @@ public class ResourceSearchRequest extends BaseSearchRequest{
 
     public void setTargetClass(String targetClass) {
         this.targetClass = targetClass;
+    }
+
+    public Set<String> getAdditionalResources() {
+        return additionalResources;
+    }
+
+    public void setAdditionalResources(Set<String> additionalResources) {
+        this.additionalResources = additionalResources;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -9,6 +9,7 @@ import org.apache.jena.arq.querybuilder.*;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 @Service
 public class JenaService {
@@ -139,6 +141,14 @@ public class JenaService {
             return coreSparql.queryConstruct(query);
         }catch(HttpException ex){
             return null;
+        }
+    }
+
+    public void selectWithQuery(Query query, Consumer<QuerySolution> consumer){
+        try{
+            coreSparql.querySelect(query, consumer);
+        } catch(Exception ex) {
+            logger.error("Error with select query", ex);
         }
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -10,9 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.springframework.test.util.AssertionErrors.assertEquals;
 
@@ -45,6 +43,22 @@ class ResourceQueryFactoryTest {
 
         assertEquals("Page from value not matching", 1, classQuery.from());
         assertEquals("Page size value not matching", 100, classQuery.size());
+    }
+
+    @Test
+    void listAttributesInModelWithAdditionalResources() throws Exception {
+        var request = new ResourceSearchRequest();
+
+        request.setPageFrom(1);
+        request.setPageSize(100);
+        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE));
+        request.setAdditionalResources(Set.of("http://uri.suomi.fi/datamodel/ns/ext/some-property"));
+
+        var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(),
+                new ArrayList<>(), new HashSet<>());
+        String expected = OpenSearchUtils.getJsonString("/es/attributeListRequest.json");
+        JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(attributeListQuery), JSONCompareMode.LENIENT);
     }
 
     @Test

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -1,0 +1,60 @@
+{
+  "from": 1,
+  "size": 100,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "terms": {
+                  "isDefinedBy": [
+                    "http://uri.suomi.fi/datamodel/ns/test"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "id": [
+                    "http://uri.suomi.fi/datamodel/ns/ext/some-property"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "resourceType": [
+              "ATTRIBUTE"
+            ]
+          }
+        }
+      ],
+      "should": [
+        {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "status": {
+                    "value": "INCOMPLETE"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -30,10 +30,22 @@
           }
         },
         {
-          "terms": {
-            "isDefinedBy": [
-              "http://uri.suomi.fi/datamodel/ns/addedNs",
-              "http://external-data.com/test"
+          "bool": {
+            "should": [
+              {
+                "terms": {
+                  "isDefinedBy": [
+                    "http://uri.suomi.fi/datamodel/ns/addedNs",
+                    "http://external-data.com/test",
+                    "http://uri.suomi.fi/datamodel/ns/test"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "id": []
+                }
+              }
             ]
           }
         }


### PR DESCRIPTION
- Created sparql query for getting all external resources from sh:property
- Modify opensearch query that it matches resources defined in this model or external resources got from mentioned sparql query. e.g.

```
{
    "query": {
        "bool": {
            "must": [
                {
                    "bool": {
                        "should": [
                            {
                                "terms": {
                                    "isDefinedBy": [
                                        "http://uri.suomi.fi/datamodel/ns/test"
                                    ]
                                }
                            },
                            {
                                "terms": {
                                    "id": ["http://uri.suomi.fi/datamodel/ns/other/some-resource"]
                                }
                            }
                        ]
                    }
                },
                {
                    "terms": {
                        "resourceType": [
                            "ATTRIBUTE"
                        ]
                    }
                }
            ]
        }
    }
}
```

Also fixed `/v2/class/nodeshapes` endpoint to return extended information of data model and terminology (related to YTI-2591)