### PR TITLE
YTI-2668: New endpoint for copying propertyshape

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -131,9 +131,14 @@ public class ResourceController {
         }
 
 
+
         var model = jenaService.getDataModel(graphUri);
-        check(authorizationManager.hasRightToModel(prefix, model));
         var targetModel = jenaService.getDataModel(targetGraph);
+
+        if(!MapperUtils.isApplicationProfile(model.getResource(graphUri)) && !MapperUtils.isApplicationProfile(targetModel.getResource(targetGraph))){
+            throw new MappingError("Both data models have to be application profiles");
+        }
+        check(authorizationManager.hasRightToModel(prefix, model));
         check(authorizationManager.hasRightToModel(targetPrefix, targetModel));
 
         ResourceMapper.mapToCopyToLocalPropertyShape(graphUri, model, resourceIdentifier, targetModel, targetGraph, newIdentifier, userProvider.getUser());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -136,6 +136,26 @@ public class ResourceMapper {
         MapperUtils.addUpdateMetadata(resource, user);
     }
 
+    public static void mapToCopyToLocalPropertyShape(String graphUri, Model model, String resourceIdentifier, Model targetModel, String targetGraph, String targetIdentifier, YtiUser user){
+        var resource = model.getResource(graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier);
+        var newResource = targetModel.createResource(targetGraph + ModelConstants.RESOURCE_SEPARATOR + targetIdentifier);
+        resource.listProperties().forEach(prop -> {
+            var pred = prop.getPredicate();
+            var obj = prop.getObject();
+            newResource.addProperty(pred, obj);
+        }
+        );
+
+        MapperUtils.updateUriProperty(newResource, RDFS.isDefinedBy, targetGraph);
+        MapperUtils.updateLiteral(newResource, DCTerms.identifier, XSDDatatype.XSDNCName.parse(targetIdentifier));
+
+        newResource.removeAll(DCTerms.modified);
+        newResource.removeAll(DCTerms.created);
+        newResource.removeAll(Iow.modifier);
+        newResource.removeAll(Iow.creator);
+        MapperUtils.addCreationMetadata(newResource, user);
+    }
+
     public static IndexResource mapToIndexResource(Model model, String resourceUri){
         var indexResource = new IndexResource();
         var resource = model.getResource(resourceUri);


### PR DESCRIPTION
Changelog:
- New endpoint for making copy of propertyshape
- Mapper copies all properties of old one and sets metadata for new model
- unit tests