### PR TITLE
YTI-2636 change nodeshape references

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
@@ -1,11 +1,11 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-import java.util.List;
+import java.util.Set;
 
 public class NodeShapeDTO extends BaseDTO {
     private String targetClass;
     private String targetNode;
-    private List<String> properties;
+    private Set<String> properties;
 
     public String getTargetNode() {
         return targetNode;
@@ -15,11 +15,11 @@ public class NodeShapeDTO extends BaseDTO {
         this.targetNode = targetNode;
     }
 
-    public List<String> getProperties() {
+    public Set<String> getProperties() {
         return properties;
     }
 
-    public void setProperties(List<String> properties) {
+    public void setProperties(Set<String> properties) {
         this.properties = properties;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -22,8 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.validation.annotation.Validated;
@@ -31,10 +30,12 @@ import org.springframework.web.bind.annotation.*;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -88,27 +89,19 @@ public class ClassController {
     public void createNodeShape(@PathVariable String prefix, @RequestBody @ValidNodeShape NodeShapeDTO nodeShapeDTO){
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateClassOrNodeShape(modelURI, prefix, nodeShapeDTO);
-
-        var indexedResources = new ArrayList<String>();
         var classURI = ClassMapper.createNodeShapeAndMapToModel(modelURI, model, nodeShapeDTO, userProvider.getUser());
-        indexedResources.add(classURI);
 
-        var propertiesModel = jenaService.findResources(nodeShapeDTO.getProperties());
-        var properties = ClassMapper.mapPlaceholderPropertyShapes(model, classURI, propertiesModel, userProvider.getUser());
-        indexedResources.addAll(properties);
+        var allProperties = new HashSet<String>();
 
-        // Node shape based on an existing node shape
-        var propertyURIs = getTargetNodeProperties(nodeShapeDTO.getTargetNode());
-        var referencePropertiesModel = jenaService.findResources(new ArrayList<>(propertyURIs));
-        ClassMapper.mapReferencePropertyShapes(model, classURI,
-                referencePropertiesModel);
+        // Node shape based on an existing node shape (sh:node)
+        allProperties.addAll(getTargetNodeProperties(nodeShapeDTO.getTargetNode()));
+        // User defined properties from target class reference
+        allProperties.addAll(getNodeShapeTargetClassProperties(nodeShapeDTO, model, classURI));
 
+        ClassMapper.mapNodeShapeProperties(model, classURI, allProperties);
         jenaService.putDataModelToCore(modelURI, model);
 
-        openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE,
-                indexedResources.stream()
-                        .map(p -> ResourceMapper.mapToIndexResource(model, p))
-                        .toList());
+        openSearchIndexer.createResourceToIndex(ResourceMapper.mapToIndexResource(model, classURI));
     }
 
     Model handleCreateClassOrNodeShape(String modelURI, String prefix, BaseDTO dto) {
@@ -159,7 +152,33 @@ public class ClassController {
         if (MapperUtils.isLibrary(model.getResource(graph))) {
             ClassMapper.mapToUpdateOntologyClass(model, graph, classResource, (ClassDTO) dto, userProvider.getUser());
         } else {
-            ClassMapper.mapToUpdateNodeShape(model, graph, classResource, (NodeShapeDTO) dto, userProvider.getUser());
+            var nodeShape = (NodeShapeDTO) dto;
+
+            var oldNode = MapperUtils.propertyToString(classResource, SH.node);
+            var oldTarget = MapperUtils.propertyToString(classResource, SH.targetClass);
+
+            var nodeShapeProperties = classResource.listProperties(SH.property)
+                    .mapWith((var stmt) -> stmt.getResource().getURI())
+                    .toSet();
+
+            // TODO: how to handle existing properties from sh:node reference
+            if (oldNode == null && nodeShape.getTargetNode() != null) {
+                // add new sh:node, add properties from sh:node reference
+                nodeShapeProperties.addAll(getTargetNodeProperties(nodeShape.getTargetNode()));
+            } else if (oldNode != null && nodeShape.getTargetNode() != null && !oldNode.equals(nodeShape.getTargetNode())) {
+                // replace sh:node, remove properties inherited from old sh:node (?) and add properties from new sh:node reference
+                nodeShapeProperties.addAll(getTargetNodeProperties(nodeShape.getTargetNode()));
+            } else if (oldNode != null && nodeShape.getTargetNode() == null) {
+                // remove sh:node, remove properties old sh:node reference (?)
+            }
+
+            // add properties from new target class and create placeholders
+            if (nodeShape.getTargetClass() != null && !nodeShape.getTargetClass().equals(oldTarget)) {
+                nodeShapeProperties.addAll(getNodeShapeTargetClassProperties(nodeShape, model, classURI));
+            }
+
+            ClassMapper.mapToUpdateNodeShape(model, graph, classResource, (NodeShapeDTO) dto,
+                    nodeShapeProperties, userProvider.getUser());
         }
         jenaService.putDataModelToCore(graph, model);
 
@@ -340,7 +359,7 @@ public class ClassController {
             }
             handledNodeShapes.add(targetNode);
 
-            var nodeModel = jenaService.findResources(List.of(targetNode));
+            var nodeModel = jenaService.findResources(Set.of(targetNode));
             var nodeResource = nodeModel.getResource(targetNode);
 
             propertyShapes.addAll(nodeResource.listProperties(SH.property)
@@ -353,6 +372,43 @@ public class ClassController {
             targetNode = nodeResource.getProperty(SH.node).getObject().toString();
         }
         return propertyShapes;
+    }
+
+    private Set<String> getNodeShapeTargetClassProperties(NodeShapeDTO nodeShapeDTO, Model model, String classURI) {
+        var allProperties = new HashSet<String>();
+
+        // skip creating new resource, if there is already resource with sh:path reference to the property
+        var existingProperties = nodeShapeDTO.getProperties().stream()
+                .map(p -> {
+                    var iter = model.listStatements(new SimpleSelector(null, SH.path, ResourceFactory.createResource(p)));
+                    return iter.hasNext()
+                            ? iter.next().getSubject().getURI()
+                            : null;
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        var newProperties = jenaService.findResources(nodeShapeDTO.getProperties().stream()
+                .filter(p -> !existingProperties.contains(p))
+                .collect(Collectors.toSet()));
+
+        Predicate<String> checkFreeIdentifier =
+                (var uri) -> jenaService.doesResourceExistInGraph(model.getResource(classURI).getNameSpace(), uri);
+
+        // create new property shape resources to the model
+        var createdProperties = ClassMapper.mapPlaceholderPropertyShapes(model, classURI, newProperties,
+                userProvider.getUser(), checkFreeIdentifier);
+
+        allProperties.addAll(existingProperties);
+        allProperties.addAll(createdProperties);
+
+        // index new resources
+        openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE,
+                createdProperties.stream()
+                        .map(p -> ResourceMapper.mapToIndexResource(model, p))
+                        .toList());
+
+        return allProperties;
     }
 
     private void checkDataModelType(Resource modelResource, BaseDTO dto) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -377,7 +377,7 @@ public class ClassController {
     private Set<String> getNodeShapeTargetClassProperties(NodeShapeDTO nodeShapeDTO, Model model, String classURI) {
         var allProperties = new HashSet<String>();
 
-        // skip creating new resource, if there is already resource with sh:path reference to the property
+        // skip creating new resource if there is already resource with sh:path reference to the property
         var existingProperties = nodeShapeDTO.getProperties().stream()
                 .map(p -> {
                     var iter = model.listStatements(new SimpleSelector(null, SH.path, ResourceFactory.createResource(p)));

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -28,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -351,7 +352,7 @@ public class JenaService {
         return conceptSparql.queryConstruct(builder.build());
     }
 
-    public Model findResources(List<String> resourceURIs) {
+    public Model findResources(Set<String> resourceURIs) {
         if (resourceURIs == null || resourceURIs.isEmpty()) {
             return ModelFactory.createDefaultModel();
         }
@@ -359,10 +360,13 @@ public class JenaService {
         coreBuilder.addPrefixes(ModelConstants.PREFIXES);
         var importsBuilder = new ConstructBuilder();
         importsBuilder.addPrefixes(ModelConstants.PREFIXES);
-        for (var i = 0; i < resourceURIs.size(); i++) {
-            var pred = "?p" + i;
-            var obj = "?o" + i;
-            String uri = resourceURIs.get(i);
+
+        var iterator = resourceURIs.iterator();
+        var count = 0;
+        while (iterator.hasNext()) {
+            var pred = "?p" + count;
+            var obj = "?o" + count;
+            String uri = iterator.next();
             var resource = ResourceFactory.createResource(uri);
             if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
                 coreBuilder.addConstruct(resource, pred, obj);
@@ -371,6 +375,7 @@ public class JenaService {
                 importsBuilder.addConstruct(resource, pred, obj);
                 importsBuilder.addOptional(resource, pred, obj);
             }
+            count++;
         }
 
         var resultModel = coreSparql.queryConstruct(coreBuilder.build());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -39,7 +39,7 @@ class NodeShapeMapperTest {
 
         ClassMapper.createNodeShapeAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", model, dto, mockUser);
         ClassMapper.mapPlaceholderPropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
-                propertiesQueryResult, mockUser);
+                propertiesQueryResult, mockUser, s -> false);
 
         Resource modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
         Resource classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
@@ -111,9 +111,10 @@ class NodeShapeMapperTest {
     @Test
     void testMapReferencePropertyShapes() {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
-        var propertiesQueryResult = MapperTestUtils.getModelFromFile("/properties_result.ttl");
-        ClassMapper.mapReferencePropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
-                propertiesQueryResult);
+        // var propertiesQueryResult = MapperTestUtils.getModelFromFile("/properties_result.ttl");
+        ClassMapper.mapNodeShapeProperties(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
+                Set.of("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1", "http://uri.suomi.fi/datamodel/ns/test_lib/association-1")
+        );
 
         var classRes = model.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
@@ -154,7 +155,7 @@ class NodeShapeMapperTest {
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/target/Class", resource.getProperty(SH.targetClass).getObject().toString());
 
-        ClassMapper.mapToUpdateNodeShape(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
+        ClassMapper.mapToUpdateNodeShape(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, Set.of(), mockUser);
 
         assertEquals(SH.NodeShape, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -16,6 +16,7 @@ import org.topbraid.shacl.vocabulary.SH;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,6 +29,10 @@ class NodeShapeMapperTest {
         var propertiesQueryResult = MapperTestUtils.getModelFromFile("/properties_result.ttl");
         var mockUser = EndpointUtils.mockUser;
 
+        // assume there is a resource with identifier association-1 defined in the model
+        // suffix -1 should be added when creating new property shape resource
+        Predicate<String> freePrefixCheck = s -> s.equals("http://uri.suomi.fi/datamodel/ns/test/association-1");
+
         var dto = new NodeShapeDTO();
         dto.setIdentifier("TestClass");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
@@ -39,7 +44,7 @@ class NodeShapeMapperTest {
 
         ClassMapper.createNodeShapeAndMapToModel("http://uri.suomi.fi/datamodel/ns/test", model, dto, mockUser);
         ClassMapper.mapPlaceholderPropertyShapes(model, "http://uri.suomi.fi/datamodel/ns/test/TestClass",
-                propertiesQueryResult, mockUser, s -> false);
+                propertiesQueryResult, mockUser, freePrefixCheck);
 
         Resource modelResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test");
         Resource classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
@@ -66,7 +71,7 @@ class NodeShapeMapperTest {
 
         assertEquals(2, classResource.listProperties(SH.property).toList().size());
         var propertyShapeAttribute = model.getResource("http://uri.suomi.fi/datamodel/ns/test/attribute-1");
-        var propertyShapeAssociation = model.getResource("http://uri.suomi.fi/datamodel/ns/test/association-1");
+        var propertyShapeAssociation = model.getResource("http://uri.suomi.fi/datamodel/ns/test/association-1-1");
 
         assertNotNull(propertyShapeAttribute);
         assertNotNull(propertyShapeAssociation);


### PR DESCRIPTION
Handle changing nodeshape's sh:node and sh:targetClass references
- When sh:node reference changes, properties based on new reference, are added to the node shape. Properties of previous sh:node reference are not removed (for now)
- When creating new property shapes based on targetClass, check if there is already property shape with sh:path reference to the same attribute/association. If that kind of property shape is found, add only reference to existing one, otherwise create new resource as before.
- Also while creating property shapes for targetClass, add check that the identifier is not in use in current model. If it is in use, add suffix e.g. some-attribute-1