### PR TITLE
YTI-2627 fetch resolved namespaces

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -8,6 +8,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
+import fi.vm.yti.datamodel.api.v2.service.NamespaceService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -36,14 +38,17 @@ public class FrontendController {
     private final SearchIndexService searchIndexService;
     private final FrontendService frontendService;
     private final AuthenticatedUserProvider userProvider;
+    private final NamespaceService namespaceService;
 
     @Autowired
     public FrontendController(SearchIndexService searchIndexService,
                               FrontendService frontendService,
-                              AuthenticatedUserProvider userProvider) {
+                              AuthenticatedUserProvider userProvider,
+                              NamespaceService namespaceService) {
         this.searchIndexService = searchIndexService;
         this.frontendService = frontendService;
         this.userProvider = userProvider;
+        this.namespaceService = namespaceService;
     }
 
     @Operation(summary = "Get counts", description = "List counts of data model grouped by different search results")
@@ -98,5 +103,12 @@ public class FrontendController {
     @GetMapping(path = "/dataTypes", produces = APPLICATION_JSON_VALUE)
     public List<String> getSupportedDataTypes() {
         return ModelConstants.SUPPORTED_DATA_TYPES;
+    }
+
+    @Operation(summary = "Get resolved external namespaces")
+    @ApiResponse(responseCode = "200", description = "List of resolved namespaces")
+    @GetMapping(path = "/namespaces", produces = APPLICATION_JSON_VALUE)
+    public Set<String> getResolvedNamespaces() {
+        return namespaceService.getResolvedNamespaces();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/repository/BaseRepository.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/repository/BaseRepository.java
@@ -1,0 +1,82 @@
+package fi.vm.yti.datamodel.api.v2.repository;
+
+import org.apache.jena.arq.querybuilder.AskBuilder;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.update.UpdateRequest;
+
+import java.util.function.Consumer;
+
+public class BaseRepository {
+
+    RDFConnection read;
+    RDFConnection write;
+    RDFConnection sparql;
+    RDFConnection update;
+
+    protected BaseRepository(RDFConnection read, RDFConnection write) {
+        this.read = read;
+        this.write = write;
+    }
+
+    protected BaseRepository(RDFConnection read, RDFConnection write, RDFConnection sparql) {
+        this.read = read;
+        this.write = write;
+        this.sparql = sparql;
+    }
+
+    protected BaseRepository(RDFConnection read, RDFConnection write, RDFConnection sparql, RDFConnection update) {
+        this.read = read;
+        this.write = write;
+        this.sparql = sparql;
+        this.update = update;
+    }
+
+    public Model fetch(String graph) {
+        return read.fetch(graph);
+    }
+
+    public void put(String graph, Model model) {
+        write.put(graph, model);
+    }
+
+    public boolean graphExists(String graph) {
+        var askBuilder = new AskBuilder()
+                .addGraph(NodeFactory.createURI(graph), "?s", "?p", "?o");
+        return this.queryAsk(askBuilder.build());
+    }
+
+    public boolean resourceExistsInGraph(String graph, String resource) {
+        var askBuilder = new AskBuilder()
+                .addGraph(NodeFactory.createURI(graph),
+                        NodeFactory.createURI(resource), "?p", "?o");
+        return this.queryAsk(askBuilder.build());
+    }
+
+    public Model queryConstruct(Query query) {
+        return sparql.queryConstruct(query);
+    }
+
+    public void querySelect(Query query, Consumer<QuerySolution> consumer) {
+        sparql.querySelect(query, consumer);
+    }
+
+    public void querySelect(String query, Consumer<QuerySolution> consumer) {
+        sparql.querySelect(query, consumer);
+    }
+
+    public boolean queryAsk(Query query) {
+        return sparql.queryAsk(query);
+    }
+
+    public void queryUpdate(String query) {
+        update.update(query);
+    }
+
+    public void queryUpdate(UpdateRequest query) {
+        update.update(query);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/repository/BaseRepository.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/repository/BaseRepository.java
@@ -10,7 +10,7 @@ import org.apache.jena.update.UpdateRequest;
 
 import java.util.function.Consumer;
 
-public class BaseRepository {
+public abstract class BaseRepository {
 
     RDFConnection read;
     RDFConnection write;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/repository/ImportsRepository.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/repository/ImportsRepository.java
@@ -1,0 +1,17 @@
+package fi.vm.yti.datamodel.api.v2.repository;
+
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ImportsRepository extends BaseRepository {
+
+    public ImportsRepository(@Value(("${endpoint}")) String endpoint) {
+        super(
+                RDFConnection.connect(endpoint + "/imports/get"),
+                RDFConnection.connect(endpoint + "/imports/data"),
+                RDFConnection.connect(endpoint + "/imports/sparql")
+        );
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -1,21 +1,27 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import fi.vm.yti.datamodel.api.v2.repository.ImportsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 public class NamespaceService {
 
     private final NamespaceResolver namespaceResolver;
+    private final ImportsRepository importsRepository;
+
     @Value("${namespaces.resolveDefault:false}")
     private boolean resolveDefault;
 
     @Autowired
-    public NamespaceService(NamespaceResolver namespaceResolver) {
+    public NamespaceService(NamespaceResolver namespaceResolver, ImportsRepository importsRepository) {
         this.namespaceResolver = namespaceResolver;
+        this.importsRepository = importsRepository;
     }
 
     private static final Map<String, String> DEFAULT_NAMESPACES = Map.ofEntries(
@@ -41,5 +47,17 @@ public class NamespaceService {
         if(resolveDefault){
             DEFAULT_NAMESPACES.forEach((prefix, uri) -> namespaceResolver.resolveNamespace(uri));
         }
+    }
+
+    public Set<String> getResolvedNamespaces() {
+        String query = """
+                SELECT ?g WHERE {
+                  GRAPH ?g {}
+                }
+                """;
+        var result = new HashSet<String>();
+        importsRepository.querySelect(query, (var row) -> result.add(row.get("g").toString()));
+
+        return result;
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
@@ -4,6 +4,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;
+import fi.vm.yti.datamodel.api.v2.service.NamespaceService;
 import fi.vm.yti.datamodel.api.v2.service.SearchIndexService;
 import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
 import fi.vm.yti.security.AuthenticatedUserProvider;
@@ -41,7 +42,8 @@ class FrontendControllerTest {
     FrontendService frontendService;
     @MockBean
     AuthenticatedUserProvider userProvider;
-
+    @MockBean
+    NamespaceService namespaceService;
 
     @BeforeEach
     void init () {
@@ -122,6 +124,14 @@ class FrontendControllerTest {
                         .contentType("application/json"))
                 .andExpect(status().isOk());
         verify(frontendService).getOrganizations(anyString(), eq(true));
+    }
+
+    @Test
+    void getNamespacesTest() throws Exception {
+        this.mvc.perform(get("/v2/frontend/namespaces")
+                        .contentType("application/json"))
+                .andExpect(status().isOk());
+        verify(namespaceService).getResolvedNamespaces();
     }
 
 }


### PR DESCRIPTION
- Add endpoint for fetching resolved namespaces

Refactor JenaService (in this PR only form imports dataset)
- Create on repository class per dataset in Fuseki, e.g. ImportsRepository, CoreRepository etc.
- Create BaseRepository with basic actions for saving and fetching data from Fuseki
- Future goal: move specific methods, e.g. getServiceCategories, from JenaService to some more appropriate service class. Create repository classes for all other datasets. 