### PR TITLE
YTI-2695: restful api fixes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -20,8 +20,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -30,9 +34,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RequestMapping("v2/model")
 @Tag(name = "Model" )
 @Validated
-public class Datamodel {
+public class DataModelController {
 
-    private static final Logger logger = LoggerFactory.getLogger(Datamodel.class);
+    private static final Logger logger = LoggerFactory.getLogger(DataModelController.class);
 
     private final AuthorizationManager authorizationManager;
 
@@ -50,14 +54,14 @@ public class Datamodel {
 
     private final GroupManagementService groupManagementService;
 
-    public Datamodel(JenaService jenaService,
-                     AuthorizationManager authorizationManager,
-                     OpenSearchIndexer openSearchIndexer,
-                     ModelMapper modelMapper,
-                     TerminologyService terminologyService,
-                     CodeListService codelistService,
-                     AuthenticatedUserProvider userProvider,
-                     GroupManagementService groupManagementService) {
+    public DataModelController(JenaService jenaService,
+                               AuthorizationManager authorizationManager,
+                               OpenSearchIndexer openSearchIndexer,
+                               ModelMapper modelMapper,
+                               TerminologyService terminologyService,
+                               CodeListService codelistService,
+                               AuthenticatedUserProvider userProvider,
+                               GroupManagementService groupManagementService) {
         this.authorizationManager = authorizationManager;
         this.mapper = modelMapper;
         this.openSearchIndexer = openSearchIndexer;
@@ -68,52 +72,58 @@ public class Datamodel {
         this.groupManagementService = groupManagementService;
     }
 
-    private void createModel(DataModelDTO modelDTO, ModelType modelType) {
+    private String createModel(DataModelDTO modelDTO, ModelType modelType) {
         logger.info("Create model {}", modelDTO);
         check(authorizationManager.hasRightToAnyOrganization(modelDTO.getOrganizations()));
+        var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix();
 
         terminologyService.resolveTerminology(modelDTO.getTerminologies());
         codelistService.resolveCodelistScheme(modelDTO.getCodeLists());
         var jenaModel = mapper.mapToJenaModel(modelDTO, modelType, userProvider.getUser());
 
-        jenaService.putDataModelToCore(ModelConstants.SUOMI_FI_NAMESPACE + modelDTO.getPrefix(), jenaModel);
+        jenaService.putDataModelToCore(graphUri, jenaModel);
 
         var indexModel = mapper.mapToIndexModel(modelDTO.getPrefix(), jenaModel);
         openSearchIndexer.createModelToIndex(indexModel);
+        return graphUri;
     }
 
     @Operation(summary = "Create a new library")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new core model")
-    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PutMapping(path = "/library", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void createLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY) @RequestBody DataModelDTO modelDTO) {
-        createModel(modelDTO, ModelType.LIBRARY);
+    @ApiResponse(responseCode = "201", description = "The ID for the newly created model")
+    @PostMapping(path = "/library", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY) @RequestBody DataModelDTO modelDTO) throws URISyntaxException {
+        var uri = createModel(modelDTO, ModelType.LIBRARY);
+        return ResponseEntity.created(new URI(uri)).build();
     }
 
     @Operation(summary = "Create a new application profile")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new application profile")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PutMapping(path = "/profile", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void createProfile(@ValidDatamodel(modelType = ModelType.PROFILE) @RequestBody DataModelDTO modelDTO) {
-        createModel(modelDTO, ModelType.PROFILE);
+    @PostMapping(path = "/profile", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createProfile(@ValidDatamodel(modelType = ModelType.PROFILE) @RequestBody DataModelDTO modelDTO) throws URISyntaxException {
+        var uri = createModel(modelDTO, ModelType.PROFILE);
+        return ResponseEntity.created(new URI(uri)).build();
     }
 
     @Operation(summary = "Modify library")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PostMapping(path = "/library/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void updateLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY, updateModel = true) @RequestBody DataModelDTO modelDTO,
-                              @PathVariable String prefix) {
+    @PutMapping(path = "/library/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updateLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY, updateModel = true) @RequestBody DataModelDTO modelDTO,
+                                           @PathVariable String prefix) {
         updateModel(modelDTO, prefix);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Modify application profile")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
-    @PostMapping(path = "/profile/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    public void updateProfile(@ValidDatamodel(modelType = ModelType.PROFILE, updateModel = true) @RequestBody DataModelDTO modelDTO,
+    @PutMapping(path = "/profile/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updateProfile(@ValidDatamodel(modelType = ModelType.PROFILE, updateModel = true) @RequestBody DataModelDTO modelDTO,
                               @PathVariable String prefix) {
         updateModel(modelDTO, prefix);
+        return ResponseEntity.noContent().build();
     }
 
     public void updateModel(DataModelDTO modelDTO, String prefix) {
@@ -148,12 +158,12 @@ public class Datamodel {
 
     @Operation(summary = "Check if prefix already exists")
     @ApiResponse(responseCode = "200", description = "Boolean value indicating whether prefix")
-    @GetMapping(value = "/free-prefix/{prefix}", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{prefix}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean freePrefix(@PathVariable String prefix) {
         if (ValidationConstants.RESERVED_WORDS.contains(prefix)) {
             return false;
         }
-        return !jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
+        return jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
     }
 
     @Operation(summary = "Delete a model from fuseki")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -161,7 +161,7 @@ public class DataModelController {
     @GetMapping(value = "/{prefix}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean freePrefix(@PathVariable String prefix) {
         if (ValidationConstants.RESERVED_WORDS.contains(prefix)) {
-            return false;
+            return true;
         }
         return jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -99,7 +99,7 @@ public class DataModelController {
 
     @Operation(summary = "Create a new application profile")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new application profile")
-    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @ApiResponse(responseCode = "201", description = "The ID for the newly created model")
     @PostMapping(path = "/profile", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createProfile(@ValidDatamodel(modelType = ModelType.PROFILE) @RequestBody DataModelDTO modelDTO) throws URISyntaxException {
         var uri = createModel(modelDTO, ModelType.PROFILE);
@@ -108,7 +108,7 @@ public class DataModelController {
 
     @Operation(summary = "Modify library")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
-    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @ApiResponse(responseCode = "204", description = "The ID for the newly created model")
     @PutMapping(path = "/library/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateLibrary(@ValidDatamodel(modelType = ModelType.LIBRARY, updateModel = true) @RequestBody DataModelDTO modelDTO,
                                            @PathVariable String prefix) {
@@ -118,7 +118,7 @@ public class DataModelController {
 
     @Operation(summary = "Modify application profile")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new model node")
-    @ApiResponse(responseCode = "200", description = "The ID for the newly created model")
+    @ApiResponse(responseCode = "204", description = "The ID for the newly created model")
     @PutMapping(path = "/profile/{prefix}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateProfile(@ValidDatamodel(modelType = ModelType.PROFILE, updateModel = true) @RequestBody DataModelDTO modelDTO,
                               @PathVariable String prefix) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FakeableUserController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FakeableUserController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("v2/fakeableUsers")
+@RequestMapping("v2/fakeable-users")
 @Tag(name = "Admin")
 public class FakeableUserController {
     private final GroupManagementService groupManagementService;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -62,7 +63,7 @@ public class FrontendController {
     @Operation(summary = "Get organizations", description = "List of organizations sorted by name")
     @ApiResponse(responseCode = "200", description = "Organization list as JSON")
     @GetMapping(path = "/organizations", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<OrganizationDTO> getOrganizations(
+    public Collection<OrganizationDTO> getOrganizations(
             @RequestParam(value = "sortLang", required = false, defaultValue = ModelConstants.DEFAULT_LANGUAGE) String sortLang,
             @RequestParam(value = "includeChildOrganizations", required = false) boolean includeChildOrganizations) {
         logger.info("GET /organizations requested");
@@ -71,36 +72,36 @@ public class FrontendController {
 
     @Operation(summary = "Get service categories", description = "List of service categories sorted by name")
     @ApiResponse(responseCode = "200", description = "Service categories as JSON")
-    @GetMapping(path = "/serviceCategories", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<ServiceCategoryDTO> getServiceCategories(@RequestParam(value = "sortLang", required = false, defaultValue = ModelConstants.DEFAULT_LANGUAGE) String sortLang) {
+    @GetMapping(path = "/service-categories", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Collection<ServiceCategoryDTO> getServiceCategories(@RequestParam(value = "sortLang", required = false, defaultValue = ModelConstants.DEFAULT_LANGUAGE) String sortLang) {
         logger.info("GET /serviceCategories requested");
         return frontendService.getServiceCategories(sortLang);
     }
 
     @Operation(summary = "Search models")
     @ApiResponse(responseCode = "200", description = "List of data model objects")
-    @GetMapping(value = "/searchModels", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/search-models", produces = APPLICATION_JSON_VALUE)
     public SearchResponseDTO<IndexModel> getModels(ModelSearchRequest request) {
         return searchIndexService.searchModels(request, userProvider.getUser());
     }
 
     @Operation(summary = "Search resources", description = "List of resources")
     @ApiResponse(responseCode = "200", description = "List of resources as JSON")
-    @GetMapping(path = "/searchInternalResources", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/search-internal-resources", produces = APPLICATION_JSON_VALUE)
     public SearchResponseDTO<IndexResource> getInternalResources(ResourceSearchRequest request) throws IOException {
         return searchIndexService.searchInternalResources(request, userProvider.getUser());
     }
 
     @Operation(summary = "Search resources", description = "List of resources")
     @ApiResponse(responseCode = "200", description = "List of resources as JSON")
-    @GetMapping(path = "/searchInternalResourcesInfo", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/search-internal-resources-info", produces = APPLICATION_JSON_VALUE)
     public SearchResponseDTO<IndexResourceInfo> getInternalResourcesInfo(ResourceSearchRequest request) throws IOException {
         return searchIndexService.searchInternalResourcesWithInfo(request, userProvider.getUser());
     }
 
     @Operation(summary = "Get supported data types")
     @ApiResponse(responseCode = "200", description = "List of supported data types")
-    @GetMapping(path = "/dataTypes", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/data-types", produces = APPLICATION_JSON_VALUE)
     public List<String> getSupportedDataTypes() {
         return ModelConstants.SUPPORTED_DATA_TYPES;
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexController.java
@@ -4,7 +4,7 @@ import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,7 +29,7 @@ public class IndexController {
 
 
     @Operation(summary = "Reindex all datamodels")
-    @GetMapping(value = "/reindex")
+    @PostMapping(value = "/reindex")
     public void reIndex(@RequestParam(required = false) String index) {
         check(authorizationManager.hasRightToDropDatabase());
         if(index == null){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -118,7 +118,7 @@ public class ResourceController {
     }
 
     @Operation(summary = "Update a property shape in a model")
-    @ApiResponse(responseCode = "200", description = "Resource updated to model successfully")
+    @ApiResponse(responseCode = "204", description = "Resource updated to model successfully")
     @PutMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updatePropertyShape(@PathVariable String prefix, @PathVariable String propertyShapeIdentifier,
                                     @RequestBody @ValidPropertyShape(updateProperty = true) PropertyShapeDTO dto){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -203,9 +203,9 @@ public class ResourceController {
     @Operation(summary = "Delete a resource from a data model")
     @ApiResponse(responseCode = "200", description = "Resource deleted successfully")
     @DeleteMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}")
-    public void deletePropertyShape(@PathVariable String prefix, @PathVariable String resourceIdentifier) {
+    public void deletePropertyShape(@PathVariable String prefix, @PathVariable String propertyShapeIdentifier) {
         // TODO: need to check node shapes' sh:property if resource is added there
-        handleDeleteResourceOrPropertyShape(prefix, resourceIdentifier);
+        handleDeleteResourceOrPropertyShape(prefix, propertyShapeIdentifier);
     }
 
     private void handleDeleteResourceOrPropertyShape(String prefix, String resourceIdentifier) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -20,8 +20,12 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -54,9 +58,9 @@ public class ResourceController {
     }
 
     @Operation(summary = "Add a attribute to a model")
-    @ApiResponse(responseCode = "200", description = "Attribute added to model successfully")
-    @PutMapping(value = "/library/{prefix}/attribute", consumes = APPLICATION_JSON_VALUE)
-    public void createAttribute(@PathVariable String prefix, @RequestBody @ValidResource(resourceType = ResourceType.ATTRIBUTE) ResourceDTO dto){
+    @ApiResponse(responseCode = "201", description = "Attribute added to model successfully")
+    @PostMapping(value = "/library/{prefix}/attribute", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createAttribute(@PathVariable String prefix, @RequestBody @ValidResource(resourceType = ResourceType.ATTRIBUTE) ResourceDTO dto) throws URISyntaxException {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateResourceOrPropertyShape(prefix, dto);
         var resourceUri = ResourceMapper.mapToResource(graphUri, model, dto, ResourceType.ATTRIBUTE, userProvider.getUser());
@@ -64,12 +68,13 @@ public class ResourceController {
         jenaService.putDataModelToCore(graphUri, model);
         var indexClass = ResourceMapper.mapToIndexResource(model, resourceUri);
         openSearchIndexer.createResourceToIndex(indexClass);
+        return ResponseEntity.created(new URI(resourceUri)).build();
     }
 
     @Operation(summary = "Add a association to a model")
-    @ApiResponse(responseCode = "200", description = "Association added to model successfully")
-    @PutMapping(value = "/library/{prefix}/association", consumes = APPLICATION_JSON_VALUE)
-    public void createAssociation(@PathVariable String prefix, @RequestBody @ValidResource(resourceType = ResourceType.ASSOCIATION) ResourceDTO dto){
+    @ApiResponse(responseCode = "201", description = "Association added to model successfully")
+    @PostMapping(value = "/library/{prefix}/association", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createAssociation(@PathVariable String prefix, @RequestBody @ValidResource(resourceType = ResourceType.ASSOCIATION) ResourceDTO dto) throws URISyntaxException {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateResourceOrPropertyShape(prefix, dto);
         var resourceUri = ResourceMapper.mapToResource(graphUri, model, dto, ResourceType.ASSOCIATION, userProvider.getUser());
@@ -77,12 +82,13 @@ public class ResourceController {
         jenaService.putDataModelToCore(graphUri, model);
         var indexClass = ResourceMapper.mapToIndexResource(model, resourceUri);
         openSearchIndexer.createResourceToIndex(indexClass);
+        return ResponseEntity.created(new URI(resourceUri)).build();
     }
 
     @Operation(summary = "Add a property shape to a profile")
-    @ApiResponse(responseCode = "200", description = "Property shape added to profile successfully")
-    @PutMapping(value = "/profile/{prefix}", consumes = APPLICATION_JSON_VALUE)
-    public void createPropertyShape(@PathVariable String prefix, @ValidPropertyShape @RequestBody PropertyShapeDTO dto) {
+    @ApiResponse(responseCode = "201", description = "Property shape added to profile successfully")
+    @PostMapping(value = "/profile/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createPropertyShape(@PathVariable String prefix, @ValidPropertyShape @RequestBody PropertyShapeDTO dto) throws URISyntaxException {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = handleCreateResourceOrPropertyShape(prefix, dto);
         var resourceURI = ResourceMapper.mapToPropertyShapeResource(modelURI, model, dto, userProvider.getUser());
@@ -90,47 +96,50 @@ public class ResourceController {
         jenaService.putDataModelToCore(modelURI, model);
         var indexClass = ResourceMapper.mapToIndexResource(model, resourceURI);
         openSearchIndexer.createResourceToIndex(indexClass);
+        return ResponseEntity.created(new URI(resourceURI)).build();
     }
 
     @Operation(summary = "Update a resource in a model")
-    @ApiResponse(responseCode = "200", description = "Resource updated to model successfully")
+    @ApiResponse(responseCode = "204", description = "Resource updated to model successfully")
     @PutMapping(value = "/library/{prefix}/attribute/{resourceIdentifier}", consumes = APPLICATION_JSON_VALUE)
-    public void updateAttribute(@PathVariable String prefix, @PathVariable String resourceIdentifier,
+    public ResponseEntity<Void> updateAttribute(@PathVariable String prefix, @PathVariable String resourceIdentifier,
                                @RequestBody @ValidResource(resourceType = ResourceType.ATTRIBUTE, updateProperty = true) ResourceDTO dto){
         handleUpdateResourceOrPropertyShape(prefix, resourceIdentifier, dto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Update a resource in a model")
-    @ApiResponse(responseCode = "200", description = "Resource updated to model successfully")
+    @ApiResponse(responseCode = "204", description = "Resource updated to model successfully")
     @PutMapping(value = "/library/{prefix}/association/{resourceIdentifier}", consumes = APPLICATION_JSON_VALUE)
-    public void updateAssociation(@PathVariable String prefix, @PathVariable String resourceIdentifier,
+    public ResponseEntity<Void> updateAssociation(@PathVariable String prefix, @PathVariable String resourceIdentifier,
                                @RequestBody @ValidResource(resourceType = ResourceType.ASSOCIATION, updateProperty = true) ResourceDTO dto){
         handleUpdateResourceOrPropertyShape(prefix, resourceIdentifier, dto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Update a property shape in a model")
     @ApiResponse(responseCode = "200", description = "Resource updated to model successfully")
-    @PutMapping(value = "/profile/{prefix}/{resourceIdentifier}", consumes = APPLICATION_JSON_VALUE)
-    public void updatePropertyShape(@PathVariable String prefix, @PathVariable String resourceIdentifier,
+    @PutMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updatePropertyShape(@PathVariable String prefix, @PathVariable String propertyShapeIdentifier,
                                     @RequestBody @ValidPropertyShape(updateProperty = true) PropertyShapeDTO dto){
-        handleUpdateResourceOrPropertyShape(prefix, resourceIdentifier, dto);
+        handleUpdateResourceOrPropertyShape(prefix, propertyShapeIdentifier, dto);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Create a local copy of a property shape")
-    @ApiResponse(responseCode = "200", description = "Property shape copied successfully")
-    @PostMapping(value ="/profile/{prefix}/{resourceIdentifier}")
-    public void copyPropertyShape(@PathVariable String prefix, @PathVariable String resourceIdentifier, @RequestParam String targetPrefix, @RequestParam String newIdentifier) {
+    @ApiResponse(responseCode = "204", description = "Property shape copied successfully")
+    @PostMapping(value ="/profile/{prefix}/{propertyShapeIdentifier}")
+    public ResponseEntity<String> copyPropertyShape(@PathVariable String prefix, @PathVariable String propertyShapeIdentifier, @RequestParam String targetPrefix, @RequestParam String newIdentifier) throws URISyntaxException {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var targetGraph = ModelConstants.SUOMI_FI_NAMESPACE + targetPrefix;
+        var targetResource = targetGraph + ModelConstants.RESOURCE_SEPARATOR + newIdentifier;
 
-        if(!jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier)){
-            throw new ResourceNotFoundException("Resource does not exist");
+        if(!jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + propertyShapeIdentifier)){
+            throw new ResourceNotFoundException(propertyShapeIdentifier);
         }
-        if(jenaService.doesResourceExistInGraph(targetGraph, targetGraph + ModelConstants.RESOURCE_SEPARATOR + newIdentifier)){
+        if(jenaService.doesResourceExistInGraph(targetGraph, targetResource)){
             throw new MappingError("Identifier in use");
         }
-
-
 
         var model = jenaService.getDataModel(graphUri);
         var targetModel = jenaService.getDataModel(targetGraph);
@@ -141,11 +150,12 @@ public class ResourceController {
         check(authorizationManager.hasRightToModel(prefix, model));
         check(authorizationManager.hasRightToModel(targetPrefix, targetModel));
 
-        ResourceMapper.mapToCopyToLocalPropertyShape(graphUri, model, resourceIdentifier, targetModel, targetGraph, newIdentifier, userProvider.getUser());
+        ResourceMapper.mapToCopyToLocalPropertyShape(graphUri, model, propertyShapeIdentifier, targetModel, targetGraph, newIdentifier, userProvider.getUser());
 
         jenaService.putDataModelToCore(targetGraph, targetModel);
         var indexResource = ResourceMapper.mapToIndexResource(targetModel, targetGraph + ModelConstants.RESOURCE_SEPARATOR + newIdentifier);
         openSearchIndexer.createResourceToIndex(indexResource);
+        return ResponseEntity.created(new URI(targetResource)).build();
     }
 
     @Operation(summary = "Find an attribute or association from a model")
@@ -157,9 +167,9 @@ public class ResourceController {
 
     @Operation(summary = "Find a property shape from a profile")
     @ApiResponse(responseCode = "200", description = "Property shape found")
-    @GetMapping(value = "/profile/{prefix}/{identifier}", produces = APPLICATION_JSON_VALUE)
-    public PropertyShapeInfoDTO getPropertyShape(@PathVariable String prefix, @PathVariable String identifier){
-        return (PropertyShapeInfoDTO) handleGetResourceOrPropertyShape(prefix, identifier);
+    @GetMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}", produces = APPLICATION_JSON_VALUE)
+    public PropertyShapeInfoDTO getPropertyShape(@PathVariable String prefix, @PathVariable String propertyShapeIdentifier){
+        return (PropertyShapeInfoDTO) handleGetResourceOrPropertyShape(prefix, propertyShapeIdentifier);
     }
 
     @Operation(summary = "Get an external resource from imports")
@@ -177,10 +187,10 @@ public class ResourceController {
 
     @Operation(summary = "Check if identifier for resource already exists")
     @ApiResponse(responseCode = "200", description = "Boolean value indicating whether prefix")
-    @GetMapping(value = "/{prefix}/free-identifier/{identifier}", produces = APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{prefix}/{identifier}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean freeIdentifier(@PathVariable String prefix, @PathVariable String identifier) {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        return !jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier);
+        return jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier);
     }
 
     @Operation(summary = "Delete a resource from a data model")
@@ -192,7 +202,7 @@ public class ResourceController {
 
     @Operation(summary = "Delete a resource from a data model")
     @ApiResponse(responseCode = "200", description = "Resource deleted successfully")
-    @DeleteMapping(value = "/profile/{prefix}/{resourceIdentifier}")
+    @DeleteMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}")
     public void deletePropertyShape(@PathVariable String prefix, @PathVariable String resourceIdentifier) {
         // TODO: need to check node shapes' sh:property if resource is added there
         handleDeleteResourceOrPropertyShape(prefix, resourceIdentifier);
@@ -227,7 +237,7 @@ public class ResourceController {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
 
         if(!jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier)){
-            throw new ResourceNotFoundException("Resource does not exist");
+            throw new ResourceNotFoundException(identifier);
         }
 
         var model = jenaService.getDataModel(graphUri);
@@ -251,7 +261,7 @@ public class ResourceController {
     private ResourceInfoBaseDTO handleGetResourceOrPropertyShape(String prefix, String identifier) {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         if(!jenaService.doesResourceExistInGraph(graphUri,graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier)){
-            throw new ResourceNotFoundException("Resource does not exist");
+            throw new ResourceNotFoundException(identifier);
         }
 
         var model = jenaService.getDataModel(graphUri);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -401,7 +401,7 @@ class ClassControllerTest {
                 .perform(get("/v2/class/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("false")));
+                .andExpect(content().string(containsString("true")));
     }
 
     @Test
@@ -412,7 +412,7 @@ class ClassControllerTest {
                 .perform(get("/v2/class/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("true")));
+                .andExpect(content().string(containsString("false")));
     }
 
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -112,10 +112,10 @@ class ClassControllerTest {
             resourceMapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             classMapper.when(() -> ClassMapper.createOntologyClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class))).thenReturn("test");
             this.mvc
-                    .perform(put("/v2/class/library/test")
+                    .perform(post("/v2/class/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
 
             //Check that functions are called
             verify(this.jenaService, times(2)).doesResolvedNamespaceExist(anyString());
@@ -145,10 +145,10 @@ class ClassControllerTest {
             resourceMapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             classMapper.when(() -> ClassMapper.createOntologyClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class))).thenReturn("test");
             this.mvc
-                    .perform(put("/v2/class/library/test")
+                    .perform(post("/v2/class/library/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
 
             //Check that functions are called
             verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -168,7 +168,7 @@ class ClassControllerTest {
         doThrow(ResourceNotFoundException.class).when(jenaService).getDataModel(anyString());
 
         this.mvc
-                .perform(put("/v2/class/library/test")
+                .perform(post("/v2/class/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isNotFound());
@@ -178,7 +178,7 @@ class ClassControllerTest {
     @MethodSource("provideCreateClassDTOInvalidData")
     void shouldInvalidate(ClassDTO classDTO) throws Exception {
         this.mvc
-                .perform(put("/v2/class/library/test")
+                .perform(post("/v2/class/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(classDTO)))
                 .andExpect(status().isBadRequest());
@@ -233,7 +233,7 @@ class ClassControllerTest {
                     .perform(put("/v2/class/library/test/class")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(classDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             //Check that functions are called
             verify(this.jenaService, times(2)).doesResolvedNamespaceExist(anyString());
@@ -371,10 +371,10 @@ class ClassControllerTest {
             classMapper.when(() -> ClassMapper.mapPlaceholderPropertyShapes(any(Model.class), anyString(), any(Model.class), any(YtiUser.class), any(Predicate.class)))
                     .thenReturn(new ArrayList<>());
             this.mvc
-                    .perform(put("/v2/class/profile/test")
+                    .perform(post("/v2/class/profile/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(nodeShapeDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
 
             verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(this.jenaService).getDataModel(anyString());
@@ -398,7 +398,7 @@ class ClassControllerTest {
         when(jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + "Resource")).thenReturn(true);
 
         this.mvc
-                .perform(get("/v2/class/test/free-identifier/Resource")
+                .perform(get("/v2/class/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("false")));
@@ -409,7 +409,7 @@ class ClassControllerTest {
         when(jenaService.doesDataModelExist(anyString())).thenReturn(false);
 
         this.mvc
-                .perform(get("/v2/class/test/free-identifier/Resource")
+                .perform(get("/v2/class/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("true")));

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -47,9 +47,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "spring.cloud.config.import-check.enabled=false"
 })
-@WebMvcTest(controllers =Datamodel.class)
+@WebMvcTest(controllers = DataModelController.class)
 @ActiveProfiles("junit")
-class DatamodelTest {
+class DataModelControllerTest {
 
     @Autowired
     private MockMvc mvc;
@@ -82,7 +82,7 @@ class DatamodelTest {
     Consumer<ResourceCommonDTO> consumer;
 
     @Autowired
-    private Datamodel datamodel;
+    private DataModelController dataModelController;
 
     private static final UUID RANDOM_ORG = UUID.randomUUID();
     private static final YtiUser USER = EndpointUtils.mockUser;
@@ -90,7 +90,7 @@ class DatamodelTest {
     @BeforeEach
     public void setup() {
         this.mvc = MockMvcBuilders
-                .standaloneSetup(this.datamodel)
+                .standaloneSetup(this.dataModelController)
                 .setControllerAdvice(new ExceptionHandlerAdvice())
                 .build();
 
@@ -116,10 +116,10 @@ class DatamodelTest {
         when(modelMapper.mapToIndexModel("test", model)).thenReturn(indexmodel);
 
         this.mvc
-                .perform(put("/v2/model/library")
+                .perform(post("/v2/model/library")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dataModelDTO)))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         //Check that functions are called
         verify(this.modelMapper)
@@ -151,10 +151,10 @@ class DatamodelTest {
         when(modelMapper.mapToIndexModel("test", model)).thenReturn(indexmodel);
 
         this.mvc
-                .perform(post("/v2/model/library/test")
+                .perform(put("/v2/model/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dataModelDTO)))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         //Check that functions are called
         verify(this.modelMapper)
@@ -212,7 +212,7 @@ class DatamodelTest {
         when(jenaService.getServiceCategories()).thenReturn(mockModel);
 
         this.mvc
-                .perform(put("/v2/model/profile")
+                .perform(post("/v2/model/profile")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dataModelDTO)))
                 .andExpect(status().isBadRequest());
@@ -231,7 +231,7 @@ class DatamodelTest {
         // code lists are not allowed in libraries
         dataModelDTO.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test"));
         this.mvc
-                .perform(put("/v2/model/library")
+                .perform(post("/v2/model/library")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dataModelDTO)))
                 .andExpect(status().isBadRequest());
@@ -247,15 +247,15 @@ class DatamodelTest {
         when(jenaService.getServiceCategories()).thenReturn(mockModel);
 
         this.mvc
-                .perform(put("/v2/model/library")
+                .perform(post("/v2/model/library")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(createDatamodelDTO(false))))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         when(jenaService.doesDataModelExist(anyString())).thenReturn(true);
 
         this.mvc
-                .perform(put("/v2/model/library")
+                .perform(post("/v2/model/library")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(createDatamodelDTO(false))))
                 .andExpect(status().isBadRequest())
@@ -273,7 +273,7 @@ class DatamodelTest {
         when(jenaService.getServiceCategories()).thenReturn(mockModel);
 
         this.mvc
-                .perform(post("/v2/model/library/test")
+                .perform(put("/v2/model/library/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dataModelDTO)))
                 .andExpect(status().isBadRequest());
@@ -285,7 +285,7 @@ class DatamodelTest {
         when(jenaService.doesDataModelExist(ModelConstants.SUOMI_FI_NAMESPACE + "test")).thenReturn(true);
 
         this.mvc
-                .perform(get("/v2/model/free-prefix/" + prefix)
+                .perform(get("/v2/model/{prefix}/exists", prefix)
                     .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("false")));
@@ -296,7 +296,7 @@ class DatamodelTest {
         when(jenaService.doesDataModelExist(anyString())).thenReturn(false);
 
         this.mvc
-                .perform(get("/v2/model/free-prefix/xyz")
+                .perform(get("/v2/model/xyz/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("true")));

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -288,7 +288,7 @@ class DataModelControllerTest {
                 .perform(get("/v2/model/{prefix}/exists", prefix)
                     .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("false")));
+                .andExpect(content().string(containsString("true")));
     }
 
     @Test
@@ -299,7 +299,7 @@ class DataModelControllerTest {
                 .perform(get("/v2/model/xyz/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("true")));
+                .andExpect(content().string(containsString("false")));
     }
 
     /**

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendControllerTest.java
@@ -65,7 +65,7 @@ class FrontendControllerTest {
 
     @Test
     void searchInternalResourcesTest() throws Exception {
-        this.mvc.perform(get("/v2/frontend/searchInternalResources")
+        this.mvc.perform(get("/v2/frontend/search-internal-resources")
                             .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(new ResourceSearchRequest())))
                         .andExpect(status().isOk());
@@ -75,7 +75,7 @@ class FrontendControllerTest {
 
     @Test
     void searchInternalResourcesInfoTest() throws Exception {
-        this.mvc.perform(get("/v2/frontend/searchInternalResourcesInfo")
+        this.mvc.perform(get("/v2/frontend/search-internal-resources-info")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(new ResourceSearchRequest())))
                 .andExpect(status().isOk());
@@ -85,7 +85,7 @@ class FrontendControllerTest {
 
     @Test
     void searchModelsTest() throws Exception {
-        this.mvc.perform(get("/v2/frontend/searchModels")
+        this.mvc.perform(get("/v2/frontend/search-models")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(new ModelSearchRequest())))
                 .andExpect(status().isOk());
@@ -94,12 +94,12 @@ class FrontendControllerTest {
 
     @Test
     void getServiceCategories() throws Exception {
-        this.mvc.perform(get("/v2/frontend/serviceCategories")
+        this.mvc.perform(get("/v2/frontend/service-categories")
                         .contentType("application/json"))
                 .andExpect(status().isOk());
         verify(frontendService).getServiceCategories("fi");
 
-        this.mvc.perform(get("/v2/frontend/serviceCategories")
+        this.mvc.perform(get("/v2/frontend/service-categories")
                         .param("sortLang", "en")
                         .contentType("application/json"))
                 .andExpect(status().isOk());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/IndexControllerTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = {
@@ -49,7 +49,7 @@ class IndexControllerTest {
     @Test
     void shouldReIndex() throws Exception {
         this.mvc
-            .perform(get("/v2/index/reindex"))
+            .perform(post("/v2/index/reindex"))
             .andExpect(status().isOk());
 
         verify(this.openSearchIndexer).reindex();
@@ -58,19 +58,19 @@ class IndexControllerTest {
     @Test
     void shouldReIndexParameter() throws Exception {
         this.mvc
-                .perform(get("/v2/index/reindex")
+                .perform(post("/v2/index/reindex")
                         .param("index", "models_v2"))
                 .andExpect(status().isOk());
         verify(openSearchIndexer).initModelIndex();
 
         this.mvc
-                .perform(get("/v2/index/reindex")
+                .perform(post("/v2/index/reindex")
                         .param("index", "resources_v2"))
                 .andExpect(status().isOk());
         verify(openSearchIndexer).initResourceIndex();
 
         this.mvc
-                .perform(get("/v2/index/reindex")
+                .perform(post("/v2/index/reindex")
                         .param("index", "external_v2"))
                 .andExpect(status().isOk());
         verify(openSearchIndexer).initExternalResourceIndex();
@@ -79,7 +79,7 @@ class IndexControllerTest {
     @Test
     void reindexThrowOnInvalidParamater() throws Exception{
         this.mvc
-                .perform(get("/v2/index/reindex")
+                .perform(post("/v2/index/reindex")
                         .param("index", "invalid"))
                 .andExpect(status().isBadRequest());
         verifyNoInteractions(openSearchIndexer);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -533,7 +533,7 @@ class ResourceControllerTest {
                 .perform(get("/v2/resource/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("false")));
+                .andExpect(content().string(containsString("true")));
     }
 
     @Test
@@ -544,7 +544,7 @@ class ResourceControllerTest {
                 .perform(get("/v2/resource/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("true")));
+                .andExpect(content().string(containsString("false")));
     }
 
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -109,10 +109,10 @@ class ResourceControllerTest {
             mapper.when(() -> ResourceMapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class), any(ResourceType.class), any(YtiUser.class))).thenReturn("test");
             mapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             this.mvc
-                    .perform(put("/v2/resource/library/test/{resourceType}", resourceType)
+                    .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
             verify(this.jenaService, times(2)).doesResolvedNamespaceExist(anyString());
             verify(this.jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(this.jenaService).getDataModel(anyString());
@@ -147,10 +147,10 @@ class ResourceControllerTest {
             mapper.when(() -> ResourceMapper.mapToResource(anyString(), any(Model.class), any(ResourceDTO.class), any(ResourceType.class), any(YtiUser.class))).thenReturn("test");
             mapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class), anyString())).thenReturn(new IndexResource());
             this.mvc
-                    .perform(put("/v2/resource/library/test/{resourceType}", resourceType)
+                    .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
 
             //Check that functions are called
             verify(this.jenaService).doesResourceExistInGraph(anyString(), anyString());
@@ -179,7 +179,7 @@ class ResourceControllerTest {
 
         //finding models from jena is not mocked so it should return null and return 404 not found
         this.mvc
-                .perform(put("/v2/resource/library/test/{resourceType}", resourceType)
+                .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isNotFound());
@@ -208,7 +208,7 @@ class ResourceControllerTest {
 
         //finding models from jena is not mocked so it should return null and return 404 not found
         this.mvc
-                .perform(put("/v2/resource/library/test/{resourceType}", resourceType)
+                .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isBadRequest())
@@ -219,7 +219,7 @@ class ResourceControllerTest {
     @MethodSource("provideCreateResourceDTOInvalidData")
     void shouldInvalidate(String resourceType, ResourceDTO resourceDTO) throws Exception {
         this.mvc
-                .perform(put("/v2/resource/library/test/{resourceType}", resourceType)
+                .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
                 .andExpect(status().isBadRequest());
@@ -282,7 +282,7 @@ class ResourceControllerTest {
                 .perform(put("/v2/resource/library/test/{resourceType}/TestA{resourceType}", resourceType, resourceType.substring(1))
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         verify(jenaService).doesResourceExistInGraph(anyString(), anyString());
         verify(jenaService).getDataModel(anyString());
@@ -402,10 +402,10 @@ class ResourceControllerTest {
             mapper.when(() -> ResourceMapper.mapToIndexResource(any(Model.class),
                     anyString())).thenReturn(new IndexResource());
             this.mvc
-                    .perform(put("/v2/resource/profile/test")
+                    .perform(post("/v2/resource/profile/test")
                             .contentType("application/json")
                             .content(EndpointUtils.convertObjectToJsonString(dto)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
             verify(this.jenaService).doesResourceExistInGraph(anyString(), anyString());
             verify(this.jenaService).getDataModel(anyString());
             verify(jenaService, times(2)).checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"),
@@ -442,7 +442,7 @@ class ResourceControllerTest {
                             .contentType("application/json")
                             .param("targetPrefix", "newtest")
                             .param("newIdentifier", "newid"))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
 
             verify(jenaService, times(2)).doesResourceExistInGraph(anyString(), anyString());
             verify(jenaService, times(2)).getDataModel(anyString());
@@ -517,7 +517,7 @@ class ResourceControllerTest {
     @MethodSource("provideCreatePropertyShapeDTOInvalidData")
     void shouldInvalidatePropertyShape(PropertyShapeDTO dto) throws Exception {
         this.mvc
-                .perform(put("/v2/resource/profile/test")
+                .perform(post("/v2/resource/profile/test")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dto)))
                 .andExpect(status().isBadRequest());
@@ -530,7 +530,7 @@ class ResourceControllerTest {
         when(jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + "Resource")).thenReturn(true);
 
         this.mvc
-                .perform(get("/v2/resource/test/free-identifier/Resource")
+                .perform(get("/v2/resource/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("false")));
@@ -541,7 +541,7 @@ class ResourceControllerTest {
         when(jenaService.doesDataModelExist(anyString())).thenReturn(false);
 
         this.mvc
-                .perform(get("/v2/resource/test/free-identifier/Resource")
+                .perform(get("/v2/resource/test/Resource/exists")
                         .contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("true")));


### PR DESCRIPTION
Changelog:
- Creating new models and resources are now POST and return 201 with the URI
- Modifying is PUT and return 204
- All camelCase endpoints to kebab-case
- Reordered some endpoint text to make more sense
- Rename Datamodel to DatamodelController
- Free prefix are now exists and they are completely reversed now
- Changed some property names so they are uniform
- Fixed all unit tests
