### PR TITLE
YTI-2693 visualization coordinates

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Iow.java
@@ -20,4 +20,8 @@ public class Iow {
     public static final Property codeList = ResourceFactory.createProperty(URI, "codeList");
     public static final Property CodeScheme = ResourceFactory.createProperty(URI, "CodeScheme");
     public static final Property ApplicationProfile = ResourceFactory.createProperty(URI, "ApplicationProfile");
+
+    public static final Property posX = ResourceFactory.createProperty(URI, "posX");
+    public static final Property posY = ResourceFactory.createProperty(URI, "posY");
+    public static final Property referenceTarget = ResourceFactory.createProperty(URI, "referenceTarget");
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -12,6 +12,8 @@ public class ModelConstants {
     public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
     public static final String CODELIST_NAMESPACE = "http://uri.suomi.fi/codelist/";
     public static final String TERMINOLOGY_NAMESPACE = "http://uri.suomi.fi/terminology/";
+    public static final String MODEL_POSITIONS_NAMESPACE = "http://uri.suomi.fi/datamodel/positions/";
+
     public static final String RESOURCE_SEPARATOR = "/";
     public static final String URN_UUID = "urn:uuid:";
     public static final String DEFAULT_LANGUAGE = "fi";

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PositionDataDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PositionDataDTO.java
@@ -1,0 +1,42 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Set;
+
+public class PositionDataDTO {
+    private String identifier;
+    private Double x;
+    private Double y;
+    private Set<String> referenceTargets;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Double getX() {
+        return x;
+    }
+
+    public void setX(Double x) {
+        this.x = x;
+    }
+
+    public Double getY() {
+        return y;
+    }
+
+    public void setY(Double y) {
+        this.y = y;
+    }
+
+    public Set<String> getReferenceTargets() {
+        return referenceTargets;
+    }
+
+    public void setReferenceTargets(Set<String> referenceTargets) {
+        this.referenceTargets = referenceTargets;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationAssociationDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationAssociationDTO.java
@@ -1,18 +1,14 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
-import java.util.LinkedList;
-import java.util.List;
-
 public class VisualizationAssociationDTO extends VisualizationItemDTO {
 
-    private List<String> route = new LinkedList<>();
+    private String referenceTarget;
 
-    public List<String> getRoute() {
-        return route;
+    public String getReferenceTarget() {
+        return referenceTarget;
     }
 
-    public void setRoute(List<String> route) {
-        this.route = route;
+    public void setReferenceTarget(String referenceTarget) {
+        this.referenceTarget = referenceTarget;
     }
-
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationHiddenNodeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationHiddenNodeDTO.java
@@ -1,0 +1,30 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+public class VisualizationHiddenNodeDTO {
+    private String identifier;
+    private PositionDTO position;
+    private String referenceTarget;
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public PositionDTO getPosition() {
+        return position;
+    }
+
+    public void setPosition(PositionDTO position) {
+        this.position = position;
+    }
+
+    public String getReferenceTarget() {
+        return referenceTarget;
+    }
+
+    public void setReferenceTarget(String referenceTarget) {
+        this.referenceTarget = referenceTarget;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationItemDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationItemDTO.java
@@ -38,6 +38,6 @@ public class VisualizationItemDTO {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(identifier, label);
+        return Objects.hashCode(identifier);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationResultDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/VisualizationResultDTO.java
@@ -1,0 +1,24 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Set;
+
+public class VisualizationResultDTO {
+    Set<VisualizationClassDTO> nodes;
+    Set<VisualizationHiddenNodeDTO> hiddenNodes;
+
+    public Set<VisualizationClassDTO> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(Set<VisualizationClassDTO> nodes) {
+        this.nodes = nodes;
+    }
+
+    public Set<VisualizationHiddenNodeDTO> getHiddenNodes() {
+        return hiddenNodes;
+    }
+
+    public void setHiddenNodes(Set<VisualizationHiddenNodeDTO> hiddenNodes) {
+        this.hiddenNodes = hiddenNodes;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -243,6 +243,10 @@ public class ClassController {
     @ApiResponse(responseCode = "200", description = "Boolean value indicating whether prefix")
     @GetMapping(value = "/{prefix}/{identifier}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean freeIdentifier(@PathVariable String prefix, @PathVariable String identifier) {
+        // identifiers e.g. corner-abcd1234 are reserved for visualization
+        if (identifier.startsWith("corner-")) {
+            return true;
+        }
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         return jenaService.doesResourceExistInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
@@ -1,15 +1,15 @@
 package fi.vm.yti.datamodel.api.v2.endpoint;
 
+import fi.vm.yti.datamodel.api.v2.dto.PositionDataDTO;
 import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
 import fi.vm.yti.datamodel.api.v2.service.VisualizationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -30,5 +30,13 @@ public class VisualizationController {
     @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)
     public Set<VisualizationClassDTO> getVisualizationData(@PathVariable String prefix) {
         return visualizationService.getVisualizationData(prefix);
+    }
+
+    @Operation(summary = "Saves position data for visualization components")
+    @ApiResponse(responseCode = "204", description = "Visualization data saved or updated for the model")
+    @PutMapping(value = "/{prefix}/positions")
+    public ResponseEntity<Void> savePositions(@PathVariable String prefix, @RequestBody List<PositionDataDTO> positions) {
+        visualizationService.savePositionData(prefix, positions);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -190,6 +190,8 @@ public class MapperUtils {
             return type.cast(literal.getInt());
         } else if (type.equals(Boolean.class)) {
             return type.cast(literal.getBoolean());
+        } else if (type.equals(Double.class)) {
+            return type.cast(literal.getDouble());
         }
         return null;
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -104,6 +104,19 @@ public class JenaService {
         }
     }
 
+    public Model getDataModelPositions(String prefix) {
+        var positionGraphRI = ModelConstants.MODEL_POSITIONS_NAMESPACE + prefix;
+        try {
+            return coreRead.fetch(positionGraphRI);
+        } catch (HttpException ex) {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
+                throw new ResourceNotFoundException(prefix);
+            } else {
+                throw new JenaQueryException();
+            }
+        }
+    }
+
     public void deleteDataModel(String graph) {
         logger.debug("Deleting model from core {}", graph);
         try{

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -1,8 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
-import fi.vm.yti.datamodel.api.v2.dto.DCAP;
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
+import fi.vm.yti.datamodel.api.v2.dto.*;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
 import org.apache.jena.rdf.model.*;
@@ -27,7 +26,12 @@ public class VisualizationService {
     public Set<VisualizationClassDTO> getVisualizationData(String prefix) {
         var graph = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var model = jenaService.getDataModel(graph);
-        var positions = ModelFactory.createDefaultModel();
+        Model positions;
+        try {
+            positions = jenaService.getDataModel(ModelConstants.MODEL_POSITIONS_NAMESPACE + prefix);
+        } catch(ResourceNotFoundException e) {
+            positions = ModelFactory.createDefaultModel();
+        }
 
         var modelResource = model.getResource(graph);
         var classURIs = getClassURIs(model, graph);
@@ -40,8 +44,7 @@ public class VisualizationService {
             String classURI = classURIs.next().getSubject().getURI();
             var classResource = model.getResource(classURI);
 
-            var classDTO = VisualizationMapper.mapClass(classURI, model,
-                    positions, namespaces);
+            var classDTO = VisualizationMapper.mapClass(classURI, model, namespaces);
 
             var attributesAndAssociations = getAttributesAndAssociations(model, classResource, modelResource);
             var externalPropertyURIs = new HashSet<String>();
@@ -49,34 +52,46 @@ public class VisualizationService {
                 if (!model.contains(resource, null)) {
                     externalPropertyURIs.add(resource.getURI());
                 } else {
-                    VisualizationMapper.mapResource(classDTO, resource, model, positions, namespaces);
+                    VisualizationMapper.mapResource(classDTO, resource, model, namespaces);
                 }
             }
 
             if (!externalPropertyURIs.isEmpty()) {
                 var externalResources = jenaService.findResources(externalPropertyURIs);
                 externalPropertyURIs.forEach(uri -> VisualizationMapper
-                        .mapResource(classDTO, externalResources.getResource(uri), model, positions, namespaces));
+                        .mapResource(classDTO, externalResources.getResource(uri), model, namespaces));
             }
 
             // add dummy classes for external classes
-            addExternalClasses(classDTO, positions, languages, result);
+            addExternalClasses(classDTO, languages, result);
 
             result.add(classDTO);
         }
+        VisualizationMapper.mapPositionsDataToDTOs(positions, prefix, result);
         return result;
     }
 
-    private static void addExternalClasses(VisualizationClassDTO classDTO, Model positions, Set<String> languages, HashSet<VisualizationClassDTO> result) {
+    public void savePositionData(String modelPrefix, List<PositionDataDTO> positions) {
+        String positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+
+        if (jenaService.doesDataModelExist(positionGraphURI)) {
+            jenaService.deleteDataModel(positionGraphURI);
+        }
+
+        var positionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI, positions);
+        jenaService.putDataModelToCore(positionGraphURI, positionModel);
+    }
+
+    private static void addExternalClasses(VisualizationClassDTO classDTO, Set<String> languages, HashSet<VisualizationClassDTO> result) {
         classDTO.getParentClasses().forEach(parent -> {
             if (parent.contains(":")) {
-                result.add(VisualizationMapper.mapExternalClass(parent, languages, positions));
+                result.add(VisualizationMapper.mapExternalClass(parent, languages));
             }
         });
         classDTO.getAssociations().forEach(association -> {
-            var target = ((LinkedList<String>)association.getRoute()).getLast();
+            var target = association.getReferenceTarget();
             if (target != null && target.contains(":")) {
-                result.add(VisualizationMapper.mapExternalClass(target, languages, positions));
+                result.add(VisualizationMapper.mapExternalClass(target, languages));
             }
         });
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
@@ -1,15 +1,11 @@
 package fi.vm.yti.datamodel.api.mapper;
 
-import fi.vm.yti.datamodel.api.v2.dto.VisualizationNodeShapeDTO;
-import fi.vm.yti.datamodel.api.v2.dto.VisualizationPropertyShapeAssociationDTO;
-import fi.vm.yti.datamodel.api.v2.dto.VisualizationPropertyShapeAttributeDTO;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
-import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.DCTerms;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,10 +22,9 @@ class VisualizationDataMapperTest {
 
     @Test
     void mapLibraryClassWithAttributes() {
-        var positions = ModelFactory.createDefaultModel();
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_visualization.ttl");
 
-        var classDTO = VisualizationMapper.mapClass("http://uri.suomi.fi/datamodel/ns/test/testclass1", model, positions, libraryNamespaces);
+        var classDTO = VisualizationMapper.mapClass("http://uri.suomi.fi/datamodel/ns/test/testclass1", model, libraryNamespaces);
         assertEquals("Label 1", classDTO.getLabel().get("fi"));
         assertEquals("testclass1", classDTO.getIdentifier());
         assertEquals("yti-model:TestClass", classDTO.getParentClasses().iterator().next());
@@ -37,8 +32,8 @@ class VisualizationDataMapperTest {
         var attribute = model.getResource("http://uri.suomi.fi/datamodel/ns/test/attribute-1");
         var association = model.getResource("http://uri.suomi.fi/datamodel/ns/test/association-1");
 
-        VisualizationMapper.mapResource(classDTO, attribute, model, positions, libraryNamespaces);
-        VisualizationMapper.mapResource(classDTO, association, model, positions, libraryNamespaces);
+        VisualizationMapper.mapResource(classDTO, attribute, model, libraryNamespaces);
+        VisualizationMapper.mapResource(classDTO, association, model, libraryNamespaces);
 
         assertEquals(1, classDTO.getAttributes().size());
         assertEquals(1, classDTO.getAssociations().size());
@@ -47,30 +42,28 @@ class VisualizationDataMapperTest {
         assertEquals("testiassosiaatio", classDTO.getAssociations().get(0).getLabel().get("fi"));
         assertEquals("attribute-1", classDTO.getAttributes().get(0).getIdentifier());
         assertEquals("association-1", classDTO.getAssociations().get(0).getIdentifier());
-        assertEquals("testclass2", classDTO.getAssociations().get(0).getRoute().get(0));
+        assertEquals("testclass2", classDTO.getAssociations().get(0).getReferenceTarget());
     }
 
     @Test
     void mapLibraryClassWithExternalResources() {
-        var positions = ModelFactory.createDefaultModel();
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_visualization.ttl");
 
-        var classDTO = VisualizationMapper.mapClass("http://uri.suomi.fi/datamodel/ns/test/testclass3", model, positions, libraryNamespaces);
+        var classDTO = VisualizationMapper.mapClass("http://uri.suomi.fi/datamodel/ns/test/testclass3", model, libraryNamespaces);
 
         var association = model.getResource("http://uri.suomi.fi/datamodel/ns/test/association-3");
 
-        VisualizationMapper.mapResource(classDTO, association, model, positions, libraryNamespaces);
+        VisualizationMapper.mapResource(classDTO, association, model, libraryNamespaces);
 
         assertEquals("ext:ExternalClass", classDTO.getParentClasses().iterator().next());
-        assertEquals("ext:ExternalClass", classDTO.getAssociations().get(0).getRoute().get(0));
+        assertEquals("ext:ExternalClass", classDTO.getAssociations().get(0).getReferenceTarget());
     }
 
     @Test
     void mapExternalClass() {
-        var positions = ModelFactory.createDefaultModel();
         String identifier = "ext:TestClass";
 
-        var external = VisualizationMapper.mapExternalClass(identifier, Set.of("fi", "en"), positions);
+        var external = VisualizationMapper.mapExternalClass(identifier, Set.of("fi", "en"));
 
         assertEquals(identifier, external.getIdentifier());
         assertEquals(Map.of("fi", identifier, "en", identifier), external.getLabel());
@@ -78,11 +71,10 @@ class VisualizationDataMapperTest {
 
     @Test
     void mapApplicationProfileClass() {
-        var positions = ModelFactory.createDefaultModel();
         var model = MapperTestUtils.getModelFromFile("/models/test_application_profile_visualization.ttl");
 
         var classDTO = (VisualizationNodeShapeDTO) VisualizationMapper
-                .mapClass("http://uri.suomi.fi/datamodel/ns/visuprof/person", model, positions, profileNamespaces);
+                .mapClass("http://uri.suomi.fi/datamodel/ns/visuprof/person", model,profileNamespaces);
 
         assertEquals("person", classDTO.getIdentifier());
         assertEquals("Henkilö", classDTO.getLabel().get("fi"));
@@ -91,8 +83,8 @@ class VisualizationDataMapperTest {
         var attribute = model.getResource("http://uri.suomi.fi/datamodel/ns/visuprof/age");
         var association = model.getResource("http://uri.suomi.fi/datamodel/ns/visuprof/is-address");
 
-        VisualizationMapper.mapResource(classDTO, attribute, model, positions, profileNamespaces);
-        VisualizationMapper.mapResource(classDTO, association, model, positions, profileNamespaces);
+        VisualizationMapper.mapResource(classDTO, attribute, model, profileNamespaces);
+        VisualizationMapper.mapResource(classDTO, association, model, profileNamespaces);
 
         var mappedAttribute = (VisualizationPropertyShapeAttributeDTO) classDTO.getAttributes().get(0);
         var mappedAssociation = (VisualizationPropertyShapeAssociationDTO) classDTO.getAssociations().get(0);
@@ -112,6 +104,219 @@ class VisualizationDataMapperTest {
         assertEquals("ytm:is-address", mappedAssociation.getPath());
         assertEquals(1, mappedAssociation.getMinCount());
         assertEquals(2, mappedAssociation.getMaxCount());
-        assertEquals("address", ((LinkedList<String>)mappedAssociation.getRoute()).getLast());
+        assertEquals("address", mappedAssociation.getReferenceTarget());
+    }
+
+    @Test
+    void mapPositionDataToGraph() {
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+
+        var position = new PositionDataDTO();
+        position.setIdentifier("class-1");
+        position.setX(3.0);
+        position.setY(5.0);
+        position.setReferenceTargets(Set.of("class-2"));
+
+        var positionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI, List.of(position));
+
+        var resource = positionModel.getResource(positionGraphURI + ModelConstants.RESOURCE_SEPARATOR + position.getIdentifier());
+
+        assertEquals("class-1", resource.getProperty(DCTerms.identifier).getString());
+        assertEquals(3.0, resource.getProperty(Iow.posX).getLiteral().getDouble());
+        assertEquals(5.0, resource.getProperty(Iow.posY).getLiteral().getDouble());
+        assertEquals("class-2", resource.listProperties(Iow.referenceTarget).toList().get(0).getString());
+    }
+
+    @Test
+    void mapPositionDataWithParentClasses() {
+        var modelPrefix = "test-model";
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+
+        var node1 = new PositionDataDTO();
+        node1.setIdentifier("class-1");
+        node1.setX(1.0);
+        node1.setY(2.0);
+        node1.setReferenceTargets(Set.of("class-2"));
+
+        var node2 = new PositionDataDTO();
+        node2.setIdentifier("class-2");
+        node2.setX(0.0);
+        node2.setY(10.0);
+
+        var postionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI,
+                List.of(node1, node2));
+
+        var classDTO1 = new VisualizationClassDTO();
+        classDTO1.setIdentifier("class-1");
+        classDTO1.setParentClasses(Set.of("class-2"));
+
+        var classDTO2 = new VisualizationClassDTO();
+        classDTO2.setIdentifier("class-2");
+
+        var classes = new HashSet<VisualizationClassDTO>();
+        classes.add(classDTO1);
+        classes.add(classDTO2);
+
+        VisualizationMapper.mapPositionsDataToDTOs(postionModel, modelPrefix, classes);
+
+        var c1 = findClass(classes, "class-1");
+        assertNotNull(c1);
+
+        assertEquals(2, classes.size());
+        assertEquals("class-2", c1.getParentClasses().iterator().next());
+    }
+
+    @Test
+    void mapPositionDataWithParentClassesAndHiddenNode() {
+        var modelPrefix = "test-model";
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+
+        var node1 = new PositionDataDTO();
+        node1.setIdentifier("class-1");
+        node1.setX(1.0);
+        node1.setY(2.0);
+        node1.setReferenceTargets(Set.of("corner-1"));
+
+        var node2 = new PositionDataDTO();
+        node2.setIdentifier("class-2");
+        node2.setX(0.0);
+        node2.setY(10.0);
+
+        var corner1 = new PositionDataDTO();
+        corner1.setIdentifier("corner-1");
+        corner1.setX(0.0);
+        corner1.setY(0.0);
+        corner1.setReferenceTargets(Set.of("class-2"));
+
+        var postionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI,
+                List.of(node1, node2, corner1));
+
+        var classDTO1 = new VisualizationClassDTO();
+        classDTO1.setIdentifier("class-1");
+        classDTO1.setParentClasses(Set.of("class-2"));
+
+        var classDTO2 = new VisualizationClassDTO();
+        classDTO2.setIdentifier("class-2");
+
+        var classes = new HashSet<VisualizationClassDTO>();
+        classes.add(classDTO1);
+        classes.add(classDTO2);
+
+        VisualizationMapper.mapPositionsDataToDTOs(postionModel, modelPrefix, classes);
+
+        var c1 = findClass(classes, "class-1");
+        var hidden = findClass(classes, "corner-1");
+        assertNotNull(c1);
+        assertNotNull(hidden);
+
+        assertEquals(3, classes.size());
+        assertEquals("corner-1", c1.getParentClasses().iterator().next());
+
+        assertEquals("class-2", hidden.getParentClasses().iterator().next());
+    }
+
+    @Test
+    void mapPositionDataWithParentClassesAndAssociationsAndHiddenNodes() {
+        var modelPrefix = "test-model";
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+
+        // class-1 has parent class reference to class-2 via corner-1 and corner-2
+        // class-1 has association to class-3 via corner-3
+        // class-2 has parent class reference to class-3 directly
+        var node1 = new PositionDataDTO();
+        node1.setIdentifier("class-1");
+        node1.setX(1.0);
+        node1.setY(2.0);
+        node1.setReferenceTargets(Set.of("corner-1", "corner-3"));
+
+        var node2 = new PositionDataDTO();
+        node2.setIdentifier("class-2");
+        node2.setX(0.0);
+        node2.setY(10.0);
+        node2.setReferenceTargets(Set.of("class-3"));
+
+        var node3 = new PositionDataDTO();
+        node3.setIdentifier("class-3");
+        node3.setX(20.0);
+        node3.setY(15.0);
+
+        var corner1 = new PositionDataDTO();
+        corner1.setX(6.0);
+        corner1.setY(7.0);
+        corner1.setIdentifier("corner-1");
+        corner1.setReferenceTargets(Set.of("corner-2"));
+
+        var corner2 = new PositionDataDTO();
+        corner2.setX(3.0);
+        corner2.setY(6.0);
+        corner2.setIdentifier("corner-2");
+        corner2.setReferenceTargets(Set.of("class-2"));
+
+        var corner3 = new PositionDataDTO();
+        corner3.setX(3.0);
+        corner3.setY(6.0);
+        corner3.setIdentifier("corner-3");
+        corner3.setReferenceTargets(Set.of("class-3"));
+
+        var postionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI,
+                List.of(node1, node2, node3, corner1, corner2, corner3));
+
+        var association = new VisualizationAssociationDTO();
+        association.setReferenceTarget("class-3");
+        association.setIdentifier("assoc-1");
+
+        var classDTO1 = new VisualizationClassDTO();
+        classDTO1.setIdentifier("class-1");
+        classDTO1.setParentClasses(Set.of("class-2"));
+        classDTO1.setAssociations(List.of(association));
+
+        var classDTO2 = new VisualizationClassDTO();
+        classDTO2.setIdentifier("class-2");
+        classDTO2.setParentClasses(Set.of("class-3"));
+
+        var classDTO3 = new VisualizationClassDTO();
+        classDTO3.setIdentifier("class-3");
+
+        var classes = new HashSet<VisualizationClassDTO>();
+        classes.add(classDTO1);
+        classes.add(classDTO2);
+        classes.add(classDTO3);
+
+        VisualizationMapper.mapPositionsDataToDTOs(postionModel, modelPrefix, classes);
+
+        // should contain three classes and three hidden nodes
+        assertEquals(6, classes.size());
+
+        var identifiers = classes.stream().map(VisualizationItemDTO::getIdentifier).toList();
+        assertTrue(identifiers.containsAll(List.of("class-1", "class-2", "class-3", "corner-1", "corner-2", "corner-3")));
+
+        var classItem = findClass(classes, "class-1");
+        assertNotNull(classItem);
+
+        var classItem2 = findClass(classes, "class-2");
+        assertNotNull(classItem2);
+        assertEquals("class-3", classItem2.getParentClasses().iterator().next());
+
+        assertEquals("corner-1", classItem.getParentClasses().iterator().next());
+        assertEquals(1.0, classItem.getPosition().getX());
+        assertEquals(2.0, classItem.getPosition().getY());
+
+        var cornerItem1 = findClass(classes, "corner-1");
+        assertNotNull(cornerItem1);
+        assertEquals(6.0, cornerItem1.getPosition().getX());
+        assertEquals(7.0, cornerItem1.getPosition().getY());
+        assertEquals("corner-2", cornerItem1.getParentClasses().iterator().next());
+
+        var cornerItem2 = findClass(classes, "corner-2");
+        assertNotNull(cornerItem2);
+        assertEquals("class-2", cornerItem2.getParentClasses().iterator().next());
+
+        var cornerItem3 = findClass(classes, "corner-3");
+        assertNotNull(cornerItem3);
+        assertEquals("class-3", cornerItem3.getParentClasses().iterator().next());
+    }
+
+    private static VisualizationClassDTO findClass(Set<VisualizationClassDTO> classes, String identifier) {
+        return classes.stream().filter(c -> c.getIdentifier().equals(identifier)).findFirst().orElse(null);
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -43,27 +43,31 @@ class VisualizationServiceTest {
     @Test
     void testMapVisualizationData() {
         var model = MapperTestUtils.getModelFromFile("/models/test_application_profile_visualization.ttl");
+        var positionModel = MapperTestUtils.getModelFromFile("/positions.ttl");
         var externalPropertiesModel = getExternalPropertiesResult();
 
         when(jenaService.getDataModel(anyString())).thenReturn(model);
+        when(jenaService.getDataModelPositions(anyString())).thenReturn(positionModel);
         when(jenaService.findResources(anySet())).thenReturn(externalPropertiesModel);
 
         var visualizationData = visualizationService.getVisualizationData("visuprof");
 
-        assertEquals(3, visualizationData.size());
+        assertEquals(3, visualizationData.getNodes().size());
 
-        var person = findClass(visualizationData, "person");
+        var person = findClass(visualizationData.getNodes(), "person");
         assertNotNull(person);
         assertEquals(1, person.getAssociations().size());
         assertEquals(2, person.getAttributes().size());
 
-        var address = findClass(visualizationData, "address");
+        var address = findClass(visualizationData.getNodes(), "address");
         assertNotNull(address);
         assertEquals(0, address.getAssociations().size());
         assertEquals(2, address.getAttributes().size());
 
-        var ext = findClass(visualizationData, "personprof:address");
+        var ext = findClass(visualizationData.getNodes(), "personprof:address");
         assertNotNull(ext);
+
+        assertEquals(1, visualizationData.getHiddenNodes().size());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -1,6 +1,8 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.PositionDataDTO;
 import fi.vm.yti.datamodel.api.v2.dto.VisualizationClassDTO;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -9,12 +11,15 @@ import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.topbraid.shacl.vocabulary.SH;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.*;
@@ -28,6 +33,9 @@ class VisualizationServiceTest {
 
     @MockBean
     private JenaService jenaService;
+
+    @Captor
+    private ArgumentCaptor<Model> modelCaptor;
 
     @Autowired
     private VisualizationService visualizationService;
@@ -56,6 +64,26 @@ class VisualizationServiceTest {
 
         var ext = findClass(visualizationData, "personprof:address");
         assertNotNull(ext);
+    }
+
+    @Test
+    void savePositions() {
+        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+        when(jenaService.doesDataModelExist(graphURI)).thenReturn(true);
+
+        var positionData = new PositionDataDTO();
+        positionData.setX(1.0);
+        positionData.setY(2.0);
+        positionData.setIdentifier("pos-1");
+
+        visualizationService.savePositionData("test-model", List.of(positionData));
+
+        verify(jenaService).deleteDataModel(graphURI);
+        verify(jenaService).putDataModelToCore(eq(graphURI), modelCaptor.capture());
+
+        var resourceURI = graphURI + ModelConstants.RESOURCE_SEPARATOR + positionData.getIdentifier();
+        var resource = modelCaptor.getValue().getResource(resourceURI);
+        assertEquals("pos-1", resource.getProperty(DCTerms.identifier).getString());
     }
 
     private static Model getExternalPropertiesResult() {

--- a/src/test/resources/positions.ttl
+++ b/src/test/resources/positions.ttl
@@ -1,0 +1,20 @@
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix iow:        <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix visuprof:   <http://uri.suomi.fi/datamodel/positions/visuprof/> .
+
+visuprof:person
+        dcterms:identifier      "person" ;
+        iow:posX                "1.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+        iow:posY                "2.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+        iow:referenceTarget     "corner-1" .
+
+visuprof:address
+        dcterms:identifier      "address" ;
+        iow:posX                "10.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+        iow:posY                "20.0"^^<http://www.w3.org/2001/XMLSchema#double> .
+
+visuprof:corner-1
+        dcterms:identifier      "corner-1" ;
+        iow:posX                "6.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+        iow:posY                "7.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+        iow:referenceTarget     "address" .


### PR DESCRIPTION
- New endpoint for saving coordinates PUT /datamodel-api/v2/visualization/{prefix}/positions. Old positions are removed if exists
- Changed response type of getting visualization data: separated visible and hidden nodes
- Map positions to VisualizationClass objects
- Determine path between nodes and create hidden nodes (with position, identifier and references) as needed
- Add validation rule for classes and nodeshapes, that identifier cannot start with `corner-`

Saving positions for two nodes (class-1 and class-2) connected via two hidden nodes (corner-1 and corner-2)

```
[
    {
        "identifier": "class-1",
        "x": 0.0,
        "y": 10.0,
        "referenceTargets": [
            "corner-1"
        ]
    },
    {
        "identifier": "class-2",
        "x": 10.0,
        "y": 20.0,
        "referenceTargets": []
    },
    {
        "identifier": "corner-1",
        "x": 40.0,
        "y": 40.0,
        "referenceTargets": [
            "corner-2"
        ]
    },
    {
        "identifier": "corner-2",
        "x": 50.0,
        "y": 50.0,
        "referenceTargets": [
            "class-2"
        ]
    }
]
```

Response object 
```
{
    "nodes": [
        {
            "identifier": "class-1",
            "label": {
                "fi": "Testiluokka"
            },
            "parentClasses": [],
            "position": {
                "x": 0.0,
                "y": 10.0
            },
            "attributes": [],
            "associations": [
                {
                    "identifier": "association-1",
                    "label": {
                        "fi": "testiassosiaatio 1"
                    },
                    "referenceTarget": "corner-1"
                }
            ]
        },
        {
            "identifier": "class-2",
            "label": {
                "fi": "Testiluokka 2"
            },
            "parentClasses": [],
            "position": {
                "x": 10.0,
                "y": 20.0
            },
            "attributes": [],
            "associations": []
        }
    ],
    "hiddenNodes": [
        {
            "identifier": "corner-1",
            "position": {
                "x": 40.0,
                "y": 40.0
            },
            "referenceTarget": "corner-2"
        },
        {
            "identifier": "corner-2",
            "position": {
                "x": 50.0,
                "y": 50.0
            },
            "referenceTarget": "class-2"
        },
    ]
}
```