### PR TITLE
YTI-2673 add curie identifiers

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ClassInfoDTO.java
@@ -5,24 +5,24 @@ import java.util.List;
 import java.util.Set;
 
 public class ClassInfoDTO extends ResourceInfoBaseDTO {
-    private Set<String> equivalentClass;
-    private Set<String> subClassOf;
+    private Set<UriDTO> equivalentClass;
+    private Set<UriDTO> subClassOf;
     private List<SimpleResourceDTO> attribute = new ArrayList<>();
     private List<SimpleResourceDTO> association = new ArrayList<>();
 
-    public Set<String> getEquivalentClass() {
+    public Set<UriDTO> getEquivalentClass() {
         return equivalentClass;
     }
 
-    public void setEquivalentClass(Set<String> equivalentClass) {
+    public void setEquivalentClass(Set<UriDTO> equivalentClass) {
         this.equivalentClass = equivalentClass;
     }
 
-    public Set<String> getSubClassOf() {
+    public Set<UriDTO> getSubClassOf() {
         return subClassOf;
     }
 
-    public void setSubClassOf(Set<String> subClassOf) {
+    public void setSubClassOf(Set<UriDTO> subClassOf) {
         this.subClassOf = subClassOf;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
@@ -4,24 +4,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NodeShapeInfoDTO extends ResourceInfoBaseDTO {
-    private String targetClass;
-    private String targetNode;
+    private UriDTO targetClass;
+    private UriDTO targetNode;
     private List<SimplePropertyShapeDTO> attribute = new ArrayList<>();
     private List<SimplePropertyShapeDTO> association = new ArrayList<>();
 
-    public String getTargetClass() {
+    public UriDTO getTargetClass() {
         return targetClass;
     }
 
-    public void setTargetClass(String targetClass) {
+    public void setTargetClass(UriDTO targetClass) {
         this.targetClass = targetClass;
     }
 
-    public String getTargetNode() {
+    public UriDTO getTargetNode() {
         return targetNode;
     }
 
-    public void setTargetNode(String targetNode) {
+    public void setTargetNode(UriDTO targetNode) {
         this.targetNode = targetNode;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PropertyShapeInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/PropertyShapeInfoDTO.java
@@ -6,8 +6,8 @@ import java.util.List;
 public class PropertyShapeInfoDTO extends ResourceInfoBaseDTO {
 
     private ResourceType type;
-    private String path;
-    private String classType;
+    private UriDTO path;
+    private UriDTO classType;
     private String dataType;
     private List<String> allowedValues = new ArrayList<>();
     private String defaultValue;
@@ -30,19 +30,19 @@ public class PropertyShapeInfoDTO extends ResourceInfoBaseDTO {
         this.type = type;
     }
 
-    public String getPath() {
+    public UriDTO getPath() {
         return path;
     }
 
-    public void setPath(String path) {
+    public void setPath(UriDTO path) {
         this.path = path;
     }
 
-    public String getClassType() {
+    public UriDTO getClassType() {
         return classType;
     }
 
-    public void setClassType(String classType) {
+    public void setClassType(UriDTO classType) {
         this.classType = classType;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
@@ -11,6 +11,7 @@ public class ResourceInfoBaseDTO extends ResourceCommonDTO {
     private String identifier;
     private Map<String, String> note;
     private String uri;
+    private String curie;
     private Set<OrganizationDTO> contributor;
     private String contact;
 
@@ -68,6 +69,14 @@ public class ResourceInfoBaseDTO extends ResourceCommonDTO {
 
     public void setUri(String uri) {
         this.uri = uri;
+    }
+
+    public String getCurie() {
+        return curie;
+    }
+
+    public void setCurie(String curie) {
+        this.curie = curie;
     }
 
     public Set<OrganizationDTO> getContributor() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoDTO.java
@@ -5,10 +5,10 @@ import java.util.Set;
 public class ResourceInfoDTO extends ResourceInfoBaseDTO {
 
     private ResourceType type;
-    private Set<String> subResourceOf;
-    private Set<String> equivalentResource;
-    private String domain;
-    private String range;
+    private Set<UriDTO> subResourceOf;
+    private Set<UriDTO> equivalentResource;
+    private UriDTO domain;
+    private UriDTO range;
 
     public ResourceType getType() {
         return type;
@@ -18,35 +18,35 @@ public class ResourceInfoDTO extends ResourceInfoBaseDTO {
         this.type = type;
     }
 
-    public Set<String> getSubResourceOf() {
+    public Set<UriDTO> getSubResourceOf() {
         return subResourceOf;
     }
 
-    public void setSubResourceOf(Set<String> subResourceOf) {
+    public void setSubResourceOf(Set<UriDTO> subResourceOf) {
         this.subResourceOf = subResourceOf;
     }
 
-    public Set<String> getEquivalentResource() {
+    public Set<UriDTO> getEquivalentResource() {
         return equivalentResource;
     }
 
-    public void setEquivalentResource(Set<String> equivalentResource) {
+    public void setEquivalentResource(Set<UriDTO> equivalentResource) {
         this.equivalentResource = equivalentResource;
     }
 
-    public String getDomain() {
+    public UriDTO getDomain() {
         return domain;
     }
 
-    public void setDomain(String domain) {
+    public void setDomain(UriDTO domain) {
         this.domain = domain;
     }
 
-    public String getRange() {
+    public UriDTO getRange() {
         return range;
     }
 
-    public void setRange(String range) {
+    public void setRange(UriDTO range) {
         this.range = range;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/UriDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/UriDTO.java
@@ -1,0 +1,42 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import com.google.common.base.Objects;
+
+public class UriDTO {
+    private String uri;
+    private String curie;
+
+    public UriDTO(String uri) {
+        this.uri = uri;
+    }
+
+    public UriDTO(String uri, String curie) {
+        this.uri = uri;
+        this.curie = curie;
+    }
+
+    public String getCurie() {
+        return curie;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UriDTO uriDTO = (UriDTO) o;
+        return Objects.equal(uri, uriDTO.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(uri);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -1,11 +1,10 @@
 package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
-import fi.vm.yti.datamodel.api.v2.dto.DCAP;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
-import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.service.JenaService;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,8 +12,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.vocabulary.DCTerms;
-import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +21,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.StringWriter;
-import java.util.List;
 
 @RestController
 @RequestMapping("v2/export")
@@ -77,7 +73,7 @@ public class ExportController {
             exportedModel = model;
         }
 
-        addNsPrefixes(modelURI, exportedModel);
+        DataModelUtils.addPrefixesToModel(modelURI, exportedModel);
 
         // remove editorial notes from resources
         if (!authorizationManager.hasRightToModel(prefix, model)) {
@@ -99,29 +95,5 @@ public class ExportController {
                 RDFDataMgr.write(stringWriter, exportedModel, Lang.JSONLD);
         }
         return ResponseEntity.ok().body(stringWriter.toString());
-    }
-
-    private static void addNsPrefixes(String modelURI, Model model) {
-        model.setNsPrefixes(ModelConstants.PREFIXES);
-        model.setNsPrefix(MapperUtils.getModelIdFromNamespace(modelURI), modelURI + ModelConstants.RESOURCE_SEPARATOR);
-
-        var modelResource = model.getResource(modelURI);
-
-        List.of(OWL.imports, DCTerms.requires).forEach(property ->
-            modelResource.listProperties(property).forEach(res -> {
-                var uri = res.getObject().toString();
-                if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
-                    var prefix = MapperUtils.getModelIdFromNamespace(uri);
-                    model.setNsPrefix(prefix, uri + ModelConstants.RESOURCE_SEPARATOR);
-                } else if (!uri.contains("uri.suomi.fi")) {
-                    // handle external namespaces, skip for now terminologies and code lists
-                    var extResource = model.getResource(uri);
-                    var extPrefix = MapperUtils.propertyToString(extResource, DCAP.preferredXMLNamespacePrefix);
-                    if (extPrefix != null) {
-                        model.setNsPrefix(extPrefix, uri);
-                    }
-                }
-            })
-        );
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
 import fi.vm.yti.security.YtiUser;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
@@ -212,7 +213,10 @@ public class ClassMapper {
                                             Model orgModel,
                                             boolean hasRightToModel) {
 
-        dto.setUri(resource.getURI());
+        var uriDTO = MapperUtils.uriToURIDTO(resource.getURI(), resource.getModel());
+        dto.setUri(uriDTO.getUri());
+        dto.setCurie(uriDTO.getCurie());
+
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
         dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, OWL.versionInfo)));
 
@@ -253,11 +257,16 @@ public class ClassMapper {
         var classResource = model.getResource(classUri);
         var modelResource = model.getResource(modelUri);
 
+        DataModelUtils.addPrefixesToModel(modelResource.getURI(), model);
+
         mapCommonInfoDTO(dto, classResource, modelResource, orgModel, hasRightToModel);
         MapperUtils.mapCreationInfo(dto, classResource, userMapper);
 
-        dto.setSubClassOf(MapperUtils.arrayPropertyToSet(classResource, RDFS.subClassOf));
-        dto.setEquivalentClass(MapperUtils.arrayPropertyToSet(classResource, OWL.equivalentClass));
+        var subClasses = MapperUtils.arrayPropertyToSet(classResource, RDFS.subClassOf);
+        var equivalentClasses = MapperUtils.arrayPropertyToSet(classResource, OWL.equivalentClass);
+
+        dto.setSubClassOf(MapperUtils.uriToURIDTOs(subClasses, model));
+        dto.setEquivalentClass(MapperUtils.uriToURIDTOs(equivalentClasses, model));
 
         return dto;
     }
@@ -272,11 +281,15 @@ public class ClassMapper {
         var nodeShapeResource = model.getResource(nodeShapeURI);
         var modelResource = model.getResource(modelUri);
 
+        DataModelUtils.addPrefixesToModel(modelUri, model);
+
         mapCommonInfoDTO(dto, nodeShapeResource, modelResource, orgModel, hasRightToModel);
         MapperUtils.mapCreationInfo(dto, nodeShapeResource, userMapper);
 
-        dto.setTargetClass(MapperUtils.propertyToString(nodeShapeResource, SH.targetClass));
-        dto.setTargetNode(MapperUtils.propertyToString(nodeShapeResource, SH.node));
+        dto.setTargetClass(MapperUtils.uriToURIDTO(
+                MapperUtils.propertyToString(nodeShapeResource, SH.targetClass), model));
+        dto.setTargetNode(MapperUtils.uriToURIDTO(
+                MapperUtils.propertyToString(nodeShapeResource, SH.node), model));
 
         return dto;
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -16,6 +16,7 @@ import org.apache.jena.vocabulary.RDF;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class MapperUtils {
 
@@ -329,5 +330,31 @@ public class MapperUtils {
         if (userMapper != null) {
             userMapper.accept(dto);
         }
+    }
+
+    public static UriDTO uriToURIDTO(String uri, Model model) {
+        if (uri == null) {
+            return null;
+        }
+        var u = NodeFactory.createURI(uri);
+        var prefix = model.getNsURIPrefix(u.getNameSpace());
+        if (prefix != null) {
+            return new UriDTO(uri, String.format("%s:%s", prefix, u.getLocalName()));
+        } else if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
+            return new UriDTO(uri, uri
+                    .replace(ModelConstants.SUOMI_FI_NAMESPACE, "")
+                    .replace(ModelConstants.RESOURCE_SEPARATOR, ":")
+            );
+        } else {
+            // use last element of the path as a prefix, if it could not determine
+            var parts = u.getNameSpace().split("\\W");
+            return new UriDTO(uri, String.format("%s:%s", parts[parts.length - 1], u.getLocalName()));
+        }
+    }
+
+    public static Set<UriDTO> uriToURIDTOs(Collection<String> uris, Model model) {
+        return uris.stream()
+                .map(s -> uriToURIDTO(s, model))
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexBase.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexBase.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public abstract class IndexBase {
     private String id;
+    private String curie;
     private Map<String, String> label;
     private Status status;
     private String modified;
@@ -17,6 +18,14 @@ public abstract class IndexBase {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getCurie() {
+        return curie;
+    }
+
+    public void setCurie(String curie) {
+        this.curie = curie;
     }
 
     public Map<String, String> getLabel() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
@@ -1,15 +1,47 @@
 package fi.vm.yti.datamodel.api.v2.utils;
 
+import fi.vm.yti.datamodel.api.v2.dto.DCAP;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.OWL;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public class DataModelUtils {
 
-    private DataModelUtils(){
+    private DataModelUtils() {
         //Util class
     }
 
     public static String encode(String param) {
         return URLEncoder.encode(param, StandardCharsets.UTF_8);
+    }
+
+    public static void addPrefixesToModel(String modelURI, Model model) {
+        model.setNsPrefixes(ModelConstants.PREFIXES);
+        model.setNsPrefix(MapperUtils.getModelIdFromNamespace(modelURI), modelURI + ModelConstants.RESOURCE_SEPARATOR);
+
+        var modelResource = model.getResource(modelURI);
+
+        List.of(OWL.imports, DCTerms.requires).forEach(property ->
+                modelResource.listProperties(property).forEach(res -> {
+                    var uri = res.getObject().toString();
+                    if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
+                        var prefix = MapperUtils.getModelIdFromNamespace(uri);
+                        model.setNsPrefix(prefix, uri + ModelConstants.RESOURCE_SEPARATOR);
+                    } else if (!uri.contains("uri.suomi.fi")) {
+                        // handle external namespaces, skip for now terminologies and code lists
+                        var extResource = model.getResource(uri);
+                        var extPrefix = MapperUtils.propertyToString(extResource, DCAP.preferredXMLNamespacePrefix);
+                        if (extPrefix != null) {
+                            model.setNsPrefix(extPrefix, uri);
+                        }
+                    }
+                })
+        );
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
@@ -43,7 +43,7 @@ public class ClassValidator extends BaseValidator implements
                 var asUri = NodeFactory.createURI(eqClass);
                 //if namespace is resolvable make sure class can be found in resolved namespace
                 if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
-                        && jenaService.doesResourceExistInImportedNamespace(asUri.getNameSpace(), asUri.getURI())){
+                        && !jenaService.doesResourceExistInImportedNamespace(asUri.getNameSpace(), asUri.getURI())){
                     addConstraintViolation(context, "class-not-found-in-resolved-namespace", "eqClass");
                 }
             });
@@ -57,7 +57,7 @@ public class ClassValidator extends BaseValidator implements
                 var asUri = NodeFactory.createURI(subClass);
                 //if namespace is resolvable make sure class can be found in resolved namespace
                 if(jenaService.doesResolvedNamespaceExist(asUri.getNameSpace())
-                        && jenaService.doesResourceExistInImportedNamespace(asUri.getNameSpace(), asUri.getURI())){
+                        && !jenaService.doesResourceExistInImportedNamespace(asUri.getNameSpace(), asUri.getURI())){
                     addConstraintViolation(context, "class-not-found-in-resolved-namespace", "subClassOf");
                 }
             });

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -102,9 +102,9 @@ class ClassMapperTest {
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals("TestClass", dto.getIdentifier());
         assertEquals(1, dto.getEquivalentClass().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", dto.getEquivalentClass().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/EqClass"), dto.getEquivalentClass().stream().findFirst().orElse(null));
         assertEquals(1, dto.getSubClassOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", dto.getSubClassOf().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/SubClass"), dto.getSubClassOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getLabel().size());
         assertEquals("test label", dto.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -110,7 +110,7 @@ class NodeShapeMapperTest {
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/target/Class", dto.getTargetClass());
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/target/Class"), dto.getTargetClass());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
@@ -1,9 +1,6 @@
 package fi.vm.yti.datamodel.api.mapper;
 
-import fi.vm.yti.datamodel.api.v2.dto.Iow;
-import fi.vm.yti.datamodel.api.v2.dto.PropertyShapeDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
@@ -83,7 +80,8 @@ class PropertyShapeMapperTest {
         assertEquals("test property shape", dto.getLabel().get("fi"));
         assertEquals(Status.DRAFT, dto.getStatus());
         assertEquals("TestPropertyShape", dto.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/ytm/some-attribute", dto.getPath());
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/ytm/some-attribute"), dto.getPath());
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/ytm/some-class"), dto.getClassType());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("foo", dto.getDefaultValue());
         assertTrue(dto.getAllowedValues().containsAll(List.of("foo", "bar")));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -257,7 +257,7 @@ class ResourceMapperTest {
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test attribute", indexClass.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
+        assertEquals("rdf:Literal", indexClass.getRange());
     }
 
     @Test
@@ -343,9 +343,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAttribute", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -356,8 +356,10 @@ class ResourceMapperTest {
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain().getUri());
+        assertEquals("test:DomainClass", dto.getDomain().getCurie());
+        assertEquals("rdf:Literal", dto.getRange().getUri());
+        assertEquals("rdf:Literal", dto.getRange().getCurie());
     }
 
     @Test
@@ -372,9 +374,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", dto.getSubResourceOf().stream().findFirst().orElse(""));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", dto.getEquivalentResource().stream().findFirst().orElse(""));
+        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAssociation", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -385,8 +387,8 @@ class ResourceMapperTest {
         assertEquals("test org", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", dto.getContributor().stream().findFirst().orElseThrow().getId());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain().getUri());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange().getUri());
     }
 
     @Test
@@ -484,7 +486,7 @@ class ResourceMapperTest {
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
         dto.setDomain("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass");
+        dto.setRange("xsd:integer");
 
         assertEquals(OWL.DatatypeProperty, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
@@ -498,7 +500,7 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("rdf:Literal", MapperUtils.propertyToString(resource, RDFS.range));
 
 
         ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", dto, mockUser);
@@ -519,7 +521,7 @@ class ResourceMapperTest {
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals("xsd:integer", MapperUtils.propertyToString(resource, RDFS.range));
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -425,8 +425,8 @@ class ClassControllerTest {
         dto.setStatus(Status.DRAFT);
         dto.setSubject("http://uri.suomi.fi/terminology/notrealurl");
         dto.setLabel(Map.of("fi", "test label"));
-        dto.setEquivalentClass(Set.of("tietomallit.suomi.fi/ns/notrealns/FakeClass"));
-        dto.setSubClassOf(Set.of("tietomallit.suomi.fi/ns/notrealns/FakeClass"));
+        dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/notrealns/FakeClass"));
+        dto.setSubClassOf(Set.of("http://uri.suomi.fi/datamodel/ns/notrealns/FakeClass"));
         dto.setNote(Map.of("fi", "test note"));
         return dto;
     }

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -63,7 +63,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test/DomainClass> ;
-        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test/RangeClass> .
+        rdfs:range              <rdf:Literal> .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
         rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -71,7 +71,8 @@ test:TestPropertyShape  rdf:type  sh:PropertyShape ;
         sh:minExclusive      6 ;
         sh:maxExclusive      8 ;
         iow:codeList         <http://uri.suomi.fi/codelist/Test> ;
-        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .
+        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> ;
+        sh:class             <http://uri.suomi.fi/datamodel/ns/ytm/some-class> .
 
 test:DeactivatedPropertyShape  rdf:type  sh:PropertyShape ;
         rdf:type             owl:DatatypeProperty ;


### PR DESCRIPTION
- add curie beside to uri in response objects (ResourceBaseInfoDTO), also for index resource
- add utility function for setting model prefixes (moved from ExportController)
- change uri references (e.g. domain, subclassOf, equivalentProperties) to UriDTO objects containing both uri and curie. Determine curie from model's prefixes or straight from uri if prefix not added to the model.
- fixed validation for subclasses and equivalentClasses