### PR TITLE
YTI-2680: Remove old sh:node properties

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/index/OpenSearchConnector.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/index/OpenSearchConnector.java
@@ -1,19 +1,22 @@
 package fi.vm.yti.datamodel.api.index;
 
-import java.io.IOException;
-
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
-import org.opensearch.client.opensearch._types.mapping.*;
-import org.opensearch.client.opensearch.core.*;
-import org.opensearch.client.opensearch.indices.*;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.core.DeleteRequest;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.UpdateRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
 
 import static fi.vm.yti.datamodel.api.v2.opensearch.OpenSearchUtil.logPayload;
 
@@ -78,7 +81,7 @@ public class OpenSearchConnector {
         var request = new CreateIndexRequest.Builder()
                 .index(index)
                 .mappings(mappings).build();
-        logPayload(request);
+        logPayload(request, index);
         try {
             client.indices().create(request);
             logger.info("Index {} created", index);
@@ -98,7 +101,7 @@ public class OpenSearchConnector {
                     .document(doc)
                     .build();
 
-            logPayload(indexReq);
+            logPayload(indexReq, index);
             client.index(indexReq);
             logger.info("Indexed {} to {}}", id, index);
         } catch (IOException | OpenSearchException e) {
@@ -116,7 +119,7 @@ public class OpenSearchConnector {
                     .id(encId)
                     .doc(doc)
                     .build();
-            logPayload(request);
+            logPayload(request, index);
             client.update(request, String.class);
             logger.info("Updated {} to {}", id, index);
         } catch (IOException | OpenSearchException e) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchUtil.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchUtil.java
@@ -20,13 +20,13 @@ public class OpenSearchUtil {
      *
      * @param object object
      */
-    public static void logPayload(JsonpSerializable object) {
+    public static void logPayload(JsonpSerializable object, String index) {
         if (LOG.isDebugEnabled()) {
             var out = new ByteArrayOutputStream();
             var generator = MAPPER.jsonProvider().createGenerator(out);
             MAPPER.serialize(object, generator);
             generator.close();
-            LOG.debug("Payload for object of type {}", object.getClass().getSimpleName());
+            LOG.debug("Payload for object of type {} in index {}", object.getClass().getSimpleName(), index);
             LOG.debug(out.toString());
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
@@ -90,7 +90,7 @@ public class CountQueryFactory {
                 .aggregations("groups", getAggregation("isPartOf"))
                 .build();
 
-        logPayload(sr);
+        logPayload(sr, OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL);
         return sr;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
@@ -91,7 +91,7 @@ public class ModelQueryFactory {
                 .query(finalQuery._toQuery())
                 .build();
 
-        logPayload(sr);
+        logPayload(sr, OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL);
         return sr;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -14,7 +14,10 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static fi.vm.yti.datamodel.api.v2.opensearch.OpenSearchUtil.logPayload;
 
@@ -51,6 +54,7 @@ public class ResourceQueryFactory {
                     .should(QueryFactoryUtils.termsQuery("id", request.getAdditionalResources() != null
                             ? request.getAdditionalResources()
                             : Collections.emptySet()))
+                    .minimumShouldMatch("1")
                     .build().
                     _toQuery()
             );
@@ -93,7 +97,7 @@ public class ResourceQueryFactory {
                 .query(finalQuery)
                 .sort(SortOptions.of(sortOptions -> sortOptions.field(sort)))
                 .build();
-        logPayload(sr);
+        logPayload(sr, String.join(", ", indices));
         return sr;
     }
 
@@ -132,7 +136,8 @@ public class ResourceQueryFactory {
             isDefinedByCondition.addAll(restrictedDataModels);
         }
 
-        if (limitToDataModel != null) {
+        //Limit to datamodel shouldn't be added in the intersection if it's not the right ModelType
+        if (limitToDataModel != null && (restrictedDataModels.isEmpty() || restrictedDataModels.contains(limitToDataModel))) {
             isDefinedByCondition.add(limitToDataModel);
         }
         return isDefinedByCondition;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.index.OpenSearchConnector;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.OpenSearchException;
@@ -234,6 +235,7 @@ public class SearchIndexService {
         var resource = model.getResource(modelUri);
         namespaces.addAll(MapperUtils.arrayPropertyToList(resource, OWL.imports));
         namespaces.addAll(MapperUtils.arrayPropertyToList(resource, DCTerms.requires));
+        namespaces.removeIf(ns -> ns.startsWith(ModelConstants.CODELIST_NAMESPACE) || ns.startsWith(ModelConstants.TERMINOLOGY_NAMESPACE));
     }
 
     private Set<UUID> getOrganizationsForUser(YtiUser user){

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -36,8 +36,7 @@
                 "terms": {
                   "isDefinedBy": [
                     "http://uri.suomi.fi/datamodel/ns/addedNs",
-                    "http://external-data.com/test",
-                    "http://uri.suomi.fi/datamodel/ns/test"
+                    "http://external-data.com/test"
                   ]
                 }
               },


### PR DESCRIPTION
Changelog:
- Show what index opensearch payload was from
- Don't add limitToDataModel if it is not the right type
- Remove old sh:node properties if changing and add new ones
- Remove old sh;node properties if removing
