### PR TITLE
Prefix min changed from 3 to 2

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -17,10 +17,10 @@ public class ValidationConstants {
     public static final int EMAIL_FIELD_MAX_LENGTH = 320;
     public static final int TEXT_AREA_MAX_LENGTH = 5000;
 
-    public static final int PREFIX_MIN_LENGTH = 3;
+    public static final int PREFIX_MIN_LENGTH = 2;
     public static final int PREFIX_MAX_LENGTH = 32;
     public static final int RESOURCE_IDENTIFIER_MAX_LENGTH = 32;
-    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]{2,}";
+    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
 
     public static final Map<String, String> RESERVED_NAMESPACES = Map.ofEntries(
             Map.entry("owl", "http://www.w3.org/2002/07/owl#"),


### PR DESCRIPTION
Changes in this PR:
- Prefix min length changed from 3 to 2
- Regex updated to accept prefixes of length 2