### PR TITLE
YTI-3196: Status migration and change

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V5_VersionStatus.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V5_VersionStatus.java
@@ -1,0 +1,97 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.migration.MigrationTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V5_VersionStatus implements MigrationTask {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(V5_VersionStatus.class);
+
+    private final CoreRepository coreRepository;
+
+    public V5_VersionStatus(CoreRepository coreRepository) {
+        this.coreRepository = coreRepository;
+    }
+
+    @Override
+    public void migrate() {
+        LOG.info("Migrating statuses");
+
+        var draftToSuggestion = """
+                PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX iow: <http://uri.suomi.fi/datamodel/ns/iow/>
+                
+                DELETE {
+                   GRAPH ?g {
+                     ?s owl:versionInfo "DRAFT" .
+                   }
+                }
+                INSERT {
+                  GRAPH ?g {
+                     ?s owl:versionInfo "SUGGESTED"
+                  }
+                }
+                WHERE {
+                   GRAPH ?g {
+                     ?s rdf:type owl:Ontology .
+                     ?s owl:versionInfo "DRAFT" .
+                   }
+                }""";
+
+        coreRepository.queryUpdate(draftToSuggestion);
+
+        var incompleteToDraft = """
+                PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX iow: <http://uri.suomi.fi/datamodel/ns/iow/>
+                
+                DELETE {
+                   GRAPH ?g {
+                     ?s owl:versionInfo "INCOMPLETE" .
+                   }
+                }
+                INSERT {
+                  GRAPH ?g {
+                     ?s owl:versionInfo "DRAFT"
+                  }
+                }
+                WHERE {
+                   GRAPH ?g {
+                     ?s rdf:type owl:Ontology .
+                     ?s owl:versionInfo "INCOMPLETE" .
+                   }
+                }""";
+
+        coreRepository.queryUpdate(incompleteToDraft);
+
+        var invalidToRetired = """
+                PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX iow: <http://uri.suomi.fi/datamodel/ns/iow/>
+                
+                DELETE {
+                   GRAPH ?g {
+                     ?s owl:versionInfo "INVALID" .
+                   }
+                }
+                INSERT {
+                  GRAPH ?g {
+                     ?s owl:versionInfo "RETIRED"
+                  }
+                }
+                WHERE {
+                   GRAPH ?g {
+                     ?s rdf:type owl:Ontology .
+                     ?s owl:versionInfo "INVALID" .
+                   }
+                }""";
+
+        coreRepository.queryUpdate(invalidToRetired);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Status.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/Status.java
@@ -1,5 +1,9 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
 public enum Status {
-    INCOMPLETE, DRAFT, VALID, SUPERSEDED, RETIRED, INVALID,
+    DRAFT,
+    VALID,
+    SUPERSEDED,
+    RETIRED,
+    SUGGESTED,
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -60,7 +60,7 @@ public class ModelMapper {
         var creationDate = new XSDDateTime(Calendar.getInstance());
         var modelResource = model.createResource(modelUri)
                 .addProperty(RDF.type, OWL.Ontology)
-                .addProperty(OWL.versionInfo, modelDTO.getStatus().name())
+                .addProperty(OWL.versionInfo, Status.DRAFT.name())
                 .addProperty(DCTerms.identifier, UUID.randomUUID().toString())
                 .addProperty(Iow.contentModified, ResourceFactory.createTypedLiteral(creationDate))
                 .addProperty(DCAP.preferredXMLNamespacePrefix, modelDTO.getPrefix())
@@ -116,7 +116,10 @@ public class ModelMapper {
 
         var langs = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
 
+
+        //TODO this will change that current model cannot be changed unless they are published and old ones have restricted choices
         MapperUtils.updateStringProperty(modelResource, OWL.versionInfo, dataModelDTO.getStatus().name());
+
 
         MapperUtils.updateLocalizedProperty(langs, dataModelDTO.getLabel(), modelResource, RDFS.label, model);
         MapperUtils.updateLocalizedProperty(langs, dataModelDTO.getDescription(), modelResource, RDFS.comment, model);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/CountRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/CountRequest.java
@@ -13,7 +13,7 @@ public class CountRequest {
     private Set<Status> status;
     private Set<UUID> organizations;
     private Set<String> groups;
-    private Set<UUID> includeIncompleteFrom;
+    private Set<UUID> includeDraftFrom;
 
     public String getQuery() {
         return query;
@@ -63,11 +63,11 @@ public class CountRequest {
         this.groups = groups;
     }
 
-    public Set<UUID> getIncludeIncompleteFrom() {
-        return includeIncompleteFrom;
+    public Set<UUID> getIncludeDraftFrom() {
+        return includeDraftFrom;
     }
 
-    public void setIncludeIncompleteFrom(Set<UUID> includeIncompleteFrom) {
-        this.includeIncompleteFrom = includeIncompleteFrom;
+    public void setIncludeDraftFrom(Set<UUID> includeDraftFrom) {
+        this.includeDraftFrom = includeDraftFrom;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ModelSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ModelSearchRequest.java
@@ -11,7 +11,7 @@ public class ModelSearchRequest extends BaseSearchRequest {
 
     private Set<ModelType> type;
 
-    private Set<UUID> includeIncompleteFrom;
+    private Set<UUID> includeDraftFrom;
 
     private Set<UUID> organizations;
 
@@ -35,12 +35,12 @@ public class ModelSearchRequest extends BaseSearchRequest {
         this.type = type;
     }
 
-    public Set<UUID> getIncludeIncompleteFrom() {
-        return includeIncompleteFrom;
+    public Set<UUID> getIncludeDraftFrom() {
+        return includeDraftFrom;
     }
 
-    public void setIncludeIncompleteFrom(Set<UUID> includeIncompleteFrom) {
-        this.includeIncompleteFrom = includeIncompleteFrom;
+    public void setIncludeDraftFrom(Set<UUID> includeDraftFrom) {
+        this.includeDraftFrom = includeDraftFrom;
     }
 
     public Set<UUID> getOrganizations() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/CountQueryFactory.java
@@ -30,13 +30,13 @@ public class CountQueryFactory {
         var must = new ArrayList<Query>();
         var should = new ArrayList<Query>();
 
-        var incompleteFrom = request.getIncludeIncompleteFrom();
+        var incompleteFrom = request.getIncludeDraftFrom();
         if(incompleteFrom != null && !incompleteFrom.isEmpty()){
             var incompleteFromQuery = QueryFactoryUtils.termsQuery("contributor", incompleteFrom.stream().map(UUID::toString).toList());
             should.add(incompleteFromQuery);
         }
 
-        should.add(QueryFactoryUtils.hideIncompleteStatusQuery());
+        should.add(QueryFactoryUtils.hideDraftStatusQuery());
 
         var queryString = request.getQuery();
         if(queryString != null && !queryString.isBlank()){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
@@ -36,10 +36,10 @@ public class QueryFactoryUtils {
 
     //COMMON QUERIES
 
-    public static Query hideIncompleteStatusQuery(){
+    public static Query hideDraftStatusQuery(){
         var termQuery = TermQuery.of(q -> q
                 .field("status")
-                .value(FieldValue.of(Status.INCOMPLETE.name()))
+                .value(FieldValue.of(Status.DRAFT.name()))
                 )._toQuery();
         return BoolQuery.of(q -> q.mustNot(termQuery))._toQuery();
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -34,7 +34,7 @@ public class ResourceQueryFactory {
             should.add(QueryFactoryUtils.termsQuery("isDefinedBy", allowedDatamodels));
         }
 
-        should.add(QueryFactoryUtils.hideIncompleteStatusQuery());
+        should.add(QueryFactoryUtils.hideDraftStatusQuery());
 
         var query = request.getQuery();
         if(query != null && !query.isBlank()){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -29,7 +29,10 @@ import org.topbraid.shacl.vocabulary.SH;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -116,7 +119,7 @@ public class ClassService {
 
     public List<IndexResourceInfo> getNodeShapes(String targetClass) throws IOException {
         var request = new ResourceSearchRequest();
-        request.setStatus(Set.of(Status.VALID, Status.DRAFT));
+        request.setStatus(Set.of(Status.VALID, Status.SUGGESTED));
         request.setTargetClass(targetClass);
         return searchIndexService
                 .searchInternalResourcesWithInfo(request, userProvider.getUser())

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -29,7 +29,7 @@ public class DataModelValidator extends BaseValidator implements
     public boolean isValid(DataModelDTO dataModel, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
         checkPrefix(context, dataModel);
-        checkStatus(context, dataModel.getStatus());
+        checkModelStatus(context, dataModel);
         checkLanguages(context, dataModel);
         checkLabels(context, dataModel);
         checkDescription(context, dataModel);
@@ -79,6 +79,15 @@ public class DataModelValidator extends BaseValidator implements
         }
 
         checkLanguageTags(context, languages, "languages");
+    }
+
+    private void checkModelStatus(ConstraintValidatorContext context, DataModelDTO dataModelDTO) {
+        //TODO in the future resources should not have statuses
+        if(!updateModel && dataModelDTO.getStatus() != null) {
+            addConstraintViolation(context, "not-allowed-creation", "status");
+        }else if(updateModel && dataModelDTO.getStatus() == null) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "status");
+        }
     }
 
     /**

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -169,7 +169,7 @@ class ClassMapperTest {
 
         var dto = new ClassDTO();
         dto.setLabel(Map.of("fi", "new label"));
-        dto.setStatus(Status.INVALID);
+        dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
         dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
         dto.setSubClassOf(Set.of("https://www.example.com/ns/ext/NewSub"));
@@ -198,7 +198,7 @@ class ClassMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
-        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals(Status.RETIRED.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -144,7 +144,7 @@ class NodeShapeMapperTest {
 
         var dto = new NodeShapeDTO();
         dto.setLabel(Map.of("fi", "new label"));
-        dto.setStatus(Status.INVALID);
+        dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
@@ -169,7 +169,7 @@ class NodeShapeMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals(Status.RETIRED.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -479,7 +479,7 @@ class ResourceMapperTest {
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
-        dto.setStatus(Status.INVALID);
+        dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
         dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
@@ -513,7 +513,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
-        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals(Status.RETIRED.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
@@ -531,7 +531,7 @@ class ResourceMapperTest {
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
-        dto.setStatus(Status.INVALID);
+        dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
         dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
@@ -564,7 +564,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
-        assertEquals(Status.INVALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
+        assertEquals(Status.RETIRED.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -213,7 +213,9 @@ class DataModelControllerTest {
         if(!updateModel){
             dataModelDTO.setPrefix("test");
         }
-        dataModelDTO.setStatus(Status.DRAFT);
+        if(updateModel) {
+            dataModelDTO.setStatus(Status.DRAFT);
+        }
         dataModelDTO.setTerminologies(Set.of("http://uri.suomi.fi/terminology/test"));
         var linkDTO = new LinkDTO();
         linkDTO.setName("test link");

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/CountQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/CountQueryFactoryTest.java
@@ -49,7 +49,7 @@ class CountQueryFactoryTest {
                                 .build())
                         .build())
                 .aggregations(getAggregation("statuses", Map.of(
-                        Status.DRAFT.name(), 7L,
+                        Status.SUGGESTED.name(), 7L,
                         Status.VALID.name(), 1L
                 )))
                 .aggregations(getAggregation("groups", Map.of(
@@ -70,7 +70,7 @@ class CountQueryFactoryTest {
         assertEquals(1L, groups.get("P21"));
 
         assertEquals(2, statuses.keySet().size());
-        assertEquals(7, statuses.get(Status.DRAFT.name()));
+        assertEquals(7, statuses.get(Status.SUGGESTED.name()));
         assertEquals(1, statuses.get(Status.VALID.name()));
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ModelQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ModelQueryFactoryTest.java
@@ -27,11 +27,11 @@ class ModelQueryFactoryTest {
         request.setLanguage("en");
         request.setPageFrom(1);
         request.setPageSize(100);
-        request.setStatus(Set.of(Status.DRAFT, Status.VALID));
+        request.setStatus(Set.of(Status.SUGGESTED, Status.VALID));
         request.setSortLang("en");
-        request.setIncludeIncompleteFrom(Set.of(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
+        request.setIncludeDraftFrom(Set.of(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
 
-        var modelQuery = ModelQueryFactory.createModelQuery(request);
+        var modelQuery = ModelQueryFactory.createModelQuery(request, false);
 
         String expected = OpenSearchUtils.getJsonString("/es/modelrequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(modelQuery), JSONCompareMode.LENIENT);
@@ -44,7 +44,7 @@ class ModelQueryFactoryTest {
     void createModelClassQueryDefaultsTest() {
         var request = new ModelSearchRequest();
 
-        var modelQuery = ModelQueryFactory.createModelQuery(request);
+        var modelQuery = ModelQueryFactory.createModelQuery(request, false);
 
         assertEquals("Page from value not matching", 0, modelQuery.from());
         assertEquals("Page size value not matching", 10, modelQuery.size());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -26,7 +26,7 @@ class ResourceQueryFactoryTest {
         request.setFromAddedNamespaces(true);
         request.setPageFrom(1);
         request.setPageSize(100);
-        request.setStatus(Set.of(Status.DRAFT, Status.VALID));
+        request.setStatus(Set.of(Status.SUGGESTED, Status.VALID));
         request.setSortLang("en");
         request.setTargetClass("http://uri.suomi.fi/datamodel/ns/test/TestClass");
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -39,7 +39,7 @@
               {
                 "term": {
                   "status": {
-                    "value": "INCOMPLETE"
+                    "value": "DRAFT"
                   }
                 }
               }

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -14,7 +14,7 @@
         },
         {
           "terms": {
-            "status": ["VALID", "DRAFT"]
+            "status": ["VALID", "SUGGESTED"]
           }
         },
         {
@@ -56,7 +56,7 @@
               {
                 "term": {
                   "status": {
-                    "value": "INCOMPLETE"
+                    "value": "DRAFT"
                   }
                 }
               }

--- a/src/test/resources/es/modelrequest.json
+++ b/src/test/resources/es/modelrequest.json
@@ -33,7 +33,7 @@
         },
         {
           "terms": {
-            "status": ["DRAFT", "VALID"]
+            "status": ["SUGGESTED", "VALID"]
           }
         },
         {
@@ -51,7 +51,7 @@
               {
                 "term": {
                   "status": {
-                    "value": "INCOMPLETE"
+                    "value": "DRAFT"
                   }
                 }
               }

--- a/src/test/resources/es/models_count_request.json
+++ b/src/test/resources/es/models_count_request.json
@@ -7,7 +7,7 @@
       "should": [
         {
           "bool": {
-            "must_not": [{ "term": { "status": { "value": "INCOMPLETE" } } }]
+            "must_not": [{ "term": { "status": { "value": "DRAFT" } } }]
           }
         }
       ]


### PR DESCRIPTION
Changelog:
- **Status**
   - Removed INVALID
   - Removed INCOMPLETE
   - DRAFT --> SUGGESTION
   - INCOMPLETE --> DRAFT
- **Migrate**
  - NOTE: INVALID --> RETIRED just in case some use this
- **Opeansearch**
  -  DRAFT now hidden by default
  -  SUGGESTED shown by default with VALID
  - Fix should query a bit (caused DRAFT not to show if superuser) now if superuser no should query is shown
 - **Mapping**
   - Creation DRAFT is default now for datamodel
   - Creation does not allow to use custom status anymore
- Fixed some unit tests involving Status