### PR TITLE
allow deleting properties by omitting the value in update

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -108,7 +108,7 @@ public class MapperUtils {
                                                Resource resource,
                                                Property property,
                                                Model model) {
-        if(data != null && languages != null && !languages.isEmpty()){
+        if (data != null && languages != null && !languages.isEmpty()) {
             resource.removeAll(property);
             addLocalizedProperty(languages, data, resource, property, model);
         }
@@ -204,11 +204,9 @@ public class MapperUtils {
      * @param value Value
      */
     public static void updateStringProperty(Resource resource, Property property, String value){
-        if(value != null){
-            resource.removeAll(property);
-            if(!value.isBlank()){
-                resource.addProperty(property, value);
-            }
+        resource.removeAll(property);
+        if (value != null && !value.isBlank()){
+            resource.addProperty(property, value);
         }
     }
 
@@ -218,8 +216,8 @@ public class MapperUtils {
         }
     }
     public static void updateLiteral(Resource resource, Property property, Object value){
+        resource.removeAll(property);
         if (value != null) {
-            resource.removeAll(property);
             resource.addLiteral(property, value);
         }
     }
@@ -231,12 +229,10 @@ public class MapperUtils {
      * @param property Property
      * @param value Value
      */
-    public static void updateUriProperty(Resource resource, Property property, String value){
-        if(value != null){
-            resource.removeAll(property);
-            if(!value.isBlank()){
-                resource.addProperty(property, ResourceFactory.createResource(value));
-            }
+    public static void updateUriProperty(Resource resource, Property property, String value) {
+        resource.removeAll(property);
+        if (value != null && !value.isBlank()) {
+            resource.addProperty(property, ResourceFactory.createResource(value));
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -108,8 +108,8 @@ public class MapperUtils {
                                                Resource resource,
                                                Property property,
                                                Model model) {
+        resource.removeAll(property);
         if (data != null && languages != null && !languages.isEmpty()) {
-            resource.removeAll(property);
             addLocalizedProperty(languages, data, resource, property, model);
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
@@ -56,9 +56,14 @@ public class PropertyShapeValidator extends BaseValidator implements ConstraintV
 
     private void checkPath(ConstraintValidatorContext context, PropertyShapeDTO dto) {
         var path = dto.getPath();
-        if(path != null && !path.isBlank()){
+
+        if (path == null || path.isBlank()) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "path");
+        }
+
+        if (path != null && !path.isBlank()) {
             var checkImports = !path.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if(!resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty), checkImports)){
+            if (!resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty), checkImports)) {
                 addConstraintViolation(context, "not-property-or-doesnt-exist", "path");
             }
         }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -207,6 +207,7 @@ class ClassMapperTest {
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
     }
 
+    // null values should delete (some) properties from resource
     @Test
     void testMapToUpdateClassNullValuesDTO(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
@@ -231,13 +232,13 @@ class ClassMapperTest {
 
         assertEquals(OWL.Class, resource.getProperty(RDF.type).getResource());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
-        assertEquals("test label", resource.getProperty(RDFS.label).getLiteral().getString());
-        assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
+        assertNull(resource.getProperty(RDFS.label));
+        assertNull(resource.getProperty(RDFS.label));
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
+        assertNull(resource.getProperty(DCTerms.subject));
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
-        assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
-        assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
+        assertNull(resource.getProperty(SKOS.editorialNote));
+        assertEquals(0, resource.listProperties(RDFS.comment).toList().size());
     }
 
     @Test


### PR DESCRIPTION
The following calls will remove the value if it's missing from the payload:

* updateStringProperty
* updateLiteral
* updateUriProperty

This is done by always calling removeAll, and then checking if value should be added. e.g.:
```java
        resource.removeAll(property);
        if (value != null) {
            resource.addLiteral(property, value);
        }
```

Added validation for missing sh:path.

Fixed tests for invalid attribute restrictions and association restrictions. Previously they all failed for the same reason, instead of for the things that were actually being tested.
* `checkIfResourceIsOneOfTypes` is mocked, so the tests don't fail by default
* The test providers will also provide `String[] expectedResult`, which is a list of all the validation errors that the particular test case should cause