### PR TITLE
YTI-3206 Attribute and association restrictions for library

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -161,6 +161,33 @@ public class ClassController {
         classService.handlePropertyShapeReference(prefix, nodeShapeIdentifier, uri, false);
     }
 
+    @Operation(summary = "Add class restriction to the class")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Class restriction added to the class successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this model"),
+            @ApiResponse(responseCode = "404", description = "Class or resource cannot be found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
+    })
+    @PutMapping(value = "/library/{prefix}/{classIdentifier}/properties")
+    public void addClassRestrictionReference(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                                              @PathVariable @Parameter(description = "Class identifier restriction is added to") String classIdentifier,
+                                              @RequestParam @Parameter(description = "Attribute or association uri to be added as a restriction") String uri) {
+        classService.handleClassRestrictionReference(prefix, classIdentifier, uri, false);
+    }
+
+    @Operation(summary = "Delete class restriction from the class")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Class restriction deleted from the class successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this model"),
+            @ApiResponse(responseCode = "404", description = "Class or resource cannot be found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
+    })
+    @ApiResponse(responseCode = "200", description = "Property reference deleted successfully")
+    @DeleteMapping(value = "/library/{prefix}/{classIdentifier}/properties")
+    public void deleteClassRestrictionReference(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                                             @PathVariable @Parameter(description = "Class identifier restriction is removed from") String classIdentifier,
+                                             @RequestParam @Parameter(description = "Attribute or association uri to be added as a restriction") String uri) {
+        classService.handleClassRestrictionReference(prefix, classIdentifier, uri, true);
+    }
+
     @Operation(summary = "Delete property reference from node shape")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Property reference deleted successfully"),

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -287,7 +287,7 @@ public class ClassMapper {
         classResources.listSubjects().forEach(res -> {
             var resDTO = new SimpleResourceDTO();
             resDTO.setUri(res.getURI());
-            resDTO.setIdentifier(res.getProperty(DCTerms.identifier).getString());
+            resDTO.setIdentifier(MapperUtils.getLiteral(res, DCTerms.identifier, String.class));
             resDTO.setLabel(MapperUtils.localizedPropertyToMap(res, RDFS.label));
             resDTO.setNote(MapperUtils.localizedPropertyToMap(res, RDFS.comment));
             resDTO.setCurie(MapperUtils.uriToURIDTO(res.getURI(), classResources).getCurie());
@@ -300,11 +300,10 @@ public class ClassMapper {
                 throw new MappingError("ModelUri null for resource");
             }
             resDTO.setModelId(MapperUtils.getModelIdFromNamespace(modelUri));
-            var type = res.getProperty(RDF.type).getResource();
-            if(type.equals(OWL.ObjectProperty)){
-                associations.add(resDTO);
-            }else if(type.equals(OWL.DatatypeProperty)){
+            if (MapperUtils.hasType(res, OWL.DatatypeProperty)) {
                 attributes.add(resDTO);
+            } else if (MapperUtils.hasType(OWL.ObjectProperty)) {
+                associations.add(resDTO);
             }
             dto.setAssociation(associations);
             dto.setAttribute(attributes);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -302,7 +302,7 @@ public class ClassMapper {
             resDTO.setModelId(MapperUtils.getModelIdFromNamespace(modelUri));
             if (MapperUtils.hasType(res, OWL.DatatypeProperty)) {
                 attributes.add(resDTO);
-            } else if (MapperUtils.hasType(OWL.ObjectProperty)) {
+            } else if (MapperUtils.hasType(res, OWL.ObjectProperty)) {
                 associations.add(resDTO);
             }
             dto.setAssociation(associations);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -6,10 +6,7 @@ import fi.vm.yti.security.YtiUser;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.vocabulary.*;
 
@@ -123,11 +120,14 @@ public class MapperUtils {
     public static List<String> arrayPropertyToList(Resource resource, Property property){
         var list = new ArrayList<String>();
         try{
-            var statement = resource.getProperty(property);
-            if (statement == null) {
+            var statement = resource.listProperties(property)
+                    .filterDrop(p -> p.getObject().isAnon())
+                    .toList();
+            if (statement.isEmpty()) {
                 return list;
             }
-            statement.getList()
+            statement.get(0)
+                    .getList()
                     .asJavaList()
                     .forEach(node -> list.add(node.toString()));
         }catch(JenaException ex){
@@ -145,21 +145,7 @@ public class MapperUtils {
      * @return Set of property values, empty if property is not found
      */
     public static Set<String> arrayPropertyToSet(Resource resource, Property property){
-        var list = new HashSet<String>();
-        try{
-            var statement = resource.getProperty(property);
-            if (statement == null) {
-                return list;
-            }
-            statement.getList()
-                    .asJavaList()
-                    .forEach(node -> list.add(node.toString()));
-        }catch(JenaException ex){
-            //if item could not be gotten as list it means it is multiple statements of the property
-            resource.listProperties(property)
-                    .forEach(val -> list.add(val.getObject().toString()));
-        }
-        return list;
+        return new HashSet<>(arrayPropertyToList(resource, property));
     }
 
     /**
@@ -441,5 +427,15 @@ public class MapperUtils {
         }
 
         mapper.accept(uris);
+    }
+
+    public static RDFList getList(Model model, Resource resource, Property property) {
+        var obj = resource.getProperty(property).getObject();
+
+        if (!obj.canAs(RDFList.class)) {
+            throw new MappingError(String.format("Property %s in resource %s is not RDFList",
+                    property, resource));
+        }
+        return model.getList(obj.asResource());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -192,6 +192,8 @@ public class MapperUtils {
             return type.cast(literal.getBoolean());
         } else if (type.equals(Double.class)) {
             return type.cast(literal.getDouble());
+        } else if (type.equals(String.class)) {
+            return type.cast(literal.getString());
         }
         return null;
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -158,6 +158,10 @@ public class ModelMapper {
             dataModelDTO.getCodeLists().forEach(codeList -> MapperUtils.addOptionalUriProperty(modelResource, DCTerms.requires, codeList));
         }
 
+        // remove blank nodes
+        modelResource.listProperties(RDFS.seeAlso)
+                .mapWith(Statement::getObject)
+                .forEach(obj -> model.removeAll(obj.asResource(), null, null));
         modelResource.removeAll(RDFS.seeAlso);
         dataModelDTO.getLinks().forEach(linkDTO -> addLinkToModel(model, modelResource, linkDTO));
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -16,10 +16,7 @@ import fi.vm.yti.datamodel.api.v2.repository.ImportsRepository;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.arq.querybuilder.AskBuilder;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.SimpleSelector;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.OWL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,10 +90,10 @@ public class ClassService {
             dto = ClassMapper.mapToClassDTO(model, modelURI, classIdentifier, orgModel,
                     hasRightToModel, userMapper);
             var classResource = model.getResource(classURI);
-            var restrictions = classResource.listProperties(OWL.intersectionOf)
-                    .filterKeep(s -> s.getObject().asResource().hasProperty(OWL.onProperty))
-                    .mapWith(s -> s.getResource().getProperty(OWL.onProperty).getObject().toString())
-                    .toSet();
+
+            var restrictions = ClassMapper.getClassRestrictionList(model, classResource)
+                    .stream().map(restriction -> MapperUtils.propertyToString(restriction.asResource(), OWL.onProperty))
+                    .collect(Collectors.toSet());
             var findResourcesModel = resourceService.findResources(restrictions);
             ClassMapper.addClassResourcesToDTO(findResourcesModel, (ClassInfoDTO) dto, terminologyService.mapConceptToResource());
         } else {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -20,6 +20,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.SimpleSelector;
+import org.apache.jena.vocabulary.OWL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,8 +92,13 @@ public class ClassService {
         if (MapperUtils.isLibrary(model.getResource(modelURI))) {
             dto = ClassMapper.mapToClassDTO(model, modelURI, classIdentifier, orgModel,
                     hasRightToModel, userMapper);
-            var classResources = coreRepository.queryConstruct(ClassMapper.getClassResourcesQuery(classURI, false));
-            ClassMapper.addClassResourcesToDTO(classResources, (ClassInfoDTO) dto, terminologyService.mapConceptToResource());
+            var classResource = model.getResource(classURI);
+            var restrictions = classResource.listProperties(OWL.intersectionOf)
+                    .filterKeep(s -> s.getObject().asResource().hasProperty(OWL.onProperty))
+                    .mapWith(s -> s.getResource().getProperty(OWL.onProperty).getObject().toString())
+                    .toSet();
+            var findResourcesModel = resourceService.findResources(restrictions);
+            ClassMapper.addClassResourcesToDTO(findResourcesModel, (ClassInfoDTO) dto, terminologyService.mapConceptToResource());
         } else {
             dto = ClassMapper.mapToNodeShapeDTO(model, modelURI, classIdentifier, orgModel,
                     hasRightToModel, userMapper);
@@ -334,6 +340,33 @@ public class ClassService {
         }else {
             ClassMapper.mapAppendNodeShapeProperty(classResource, uri, existingProperties);
         }
+        coreRepository.put(modelURI, model);
+    }
+
+    public void handleClassRestrictionReference(String prefix, String classIdentifier, String uri, boolean delete) {
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var model = coreRepository.fetch(modelURI);
+        var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + classIdentifier;
+
+        if(!coreRepository.resourceExistsInGraph(modelURI, classURI)){
+            throw new ResourceNotFoundException(classURI);
+        }
+
+        check(authorizationManager.hasRightToModel(prefix, model));
+
+        var classResource = model.getResource(classURI);
+        var findResourceModel = resourceService.findResources(Set.of(uri));
+        var propertyResource = findResourceModel.getResource(uri);
+        if (findResourceModel.size() == 0) {
+            throw new ResourceNotFoundException(uri);
+        }
+
+        if (delete) {
+            ClassMapper.mapRemoveClassRestrictionProperty(model, classResource, propertyResource.getURI());
+        } else {
+            ClassMapper.mapClassRestrictionProperty(model, classResource, propertyResource);
+        }
+
         coreRepository.put(modelURI, model);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -10,7 +10,6 @@ import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
 import org.springframework.stereotype.Service;
 import org.topbraid.shacl.vocabulary.SH;
 
@@ -149,7 +148,10 @@ public class VisualizationService {
     private static List<Resource> getAttributesAndAssociations(
             Model model, Resource classResource, Resource modelResource) {
         if (MapperUtils.isLibrary(modelResource)) {
-            return model.listSubjectsWithProperty(RDFS.domain, classResource).toList();
+            return model.listObjectsOfProperty(OWL.intersectionOf)
+                    .mapWith(n -> model.getResource(n.asResource()
+                            .getProperty(OWL.onProperty).getObject().toString()))
+                    .toList();
         } else if (MapperUtils.isApplicationProfile(modelResource)) {
             return classResource.listProperties(SH.property)
                     .mapWith(Statement::getResource)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -148,8 +148,8 @@ public class VisualizationService {
     private static List<Resource> getAttributesAndAssociations(
             Model model, Resource classResource, Resource modelResource) {
         if (MapperUtils.isLibrary(modelResource)) {
-            return model.listObjectsOfProperty(OWL.intersectionOf)
-                    .mapWith(n -> model.getResource(n.asResource()
+            return classResource.listProperties(OWL.intersectionOf)
+                    .mapWith(n -> model.getResource(n.getObject().asResource()
                             .getProperty(OWL.onProperty).getObject().toString()))
                     .toList();
         } else if (MapperUtils.isApplicationProfile(modelResource)) {

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -372,36 +372,6 @@ class ModelMapperTest {
     }
 
     @Test
-    void testMapToDatamodelDtoOld(){
-        var mOld = MapperTestUtils.getModelFromFile("/test_datamodel_v1.ttl");
-
-        var resultOld = mapper.mapToDataModelDTO("testaa", mOld, null);
-
-        assertEquals("testaa", resultOld.getPrefix());
-        assertEquals(ModelType.PROFILE, resultOld.getType());
-        assertEquals(Status.DRAFT, resultOld.getStatus());
-
-        assertEquals(1, resultOld.getLabel().size());
-        assertTrue(resultOld.getLabel().containsValue("Testaa"));
-        assertTrue(resultOld.getLabel().containsKey("fi"));
-
-
-        assertEquals(1, resultOld.getDescription().size());
-        assertTrue(resultOld.getDescription().containsValue("Testaa desc"));
-        assertTrue(resultOld.getDescription().containsKey("fi"));
-
-        assertEquals(2, resultOld.getLanguages().size());
-        assertTrue(resultOld.getLanguages().contains("fi"));
-        assertTrue(resultOld.getLanguages().contains("en"));
-
-        assertEquals(1, resultOld.getOrganizations().size());
-        assertEquals("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63", resultOld.getOrganizations().stream().findFirst().orElseThrow().getId());
-
-        assertEquals(1, resultOld.getGroups().size());
-        assertEquals("P11", resultOld.getGroups().stream().findFirst().orElseThrow().getIdentifier());
-    }
-
-    @Test
     void testMapToIndexModel() {
         var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
 
@@ -431,37 +401,5 @@ class ModelMapperTest {
 
         assertEquals(1, result.getIsPartOf().size());
         assertTrue(result.getIsPartOf().contains("P11"));
-    }
-
-    @Test
-    void testMapToIndexModelOld(){
-        var mOld = MapperTestUtils.getModelFromFile("/test_datamodel_v1.ttl");
-
-        var resultOld = mapper.mapToIndexModel("testaa", mOld);
-
-        assertEquals("testaa", resultOld.getPrefix());
-        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "testaa", resultOld.getId());
-        assertEquals(ModelType.PROFILE, resultOld.getType());
-        assertEquals(Status.DRAFT, resultOld.getStatus());
-        assertEquals("2018-03-20T16:21:07.067Z", resultOld.getModified());
-        assertEquals("2018-03-20T17:59:44", resultOld.getCreated());
-
-        assertEquals(1, resultOld.getLabel().size());
-        assertTrue(resultOld.getLabel().containsValue("Testaa"));
-        assertTrue(resultOld.getLabel().containsKey("fi"));
-
-        assertEquals(1, resultOld.getComment().size());
-        assertTrue(resultOld.getComment().containsValue("Testaa desc"));
-        assertTrue(resultOld.getComment().containsKey("fi"));
-
-        assertEquals(2, resultOld.getLanguage().size());
-        assertTrue(resultOld.getLanguage().contains("fi"));
-        assertTrue(resultOld.getLanguage().contains("en"));
-
-        assertEquals(1, resultOld.getContributor().size());
-        assertTrue(resultOld.getContributor().contains(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
-
-        assertEquals(1, resultOld.getIsPartOf().size());
-        assertTrue(resultOld.getIsPartOf().contains("P11"));
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -699,6 +699,27 @@ class ResourceMapperTest {
         assertEquals(ResourceType.ASSOCIATION, indexResource2.getResourceType());
     }
 
+    @Test
+    void testUpdateRestrictionsAfterRangeChange() {
+        var model = MapperTestUtils.getModelFromFile("/class_with_owl_restrictions.ttl");
+
+        var graphUri = "http://uri.suomi.fi/datamodel/ns/model";
+        var identifier = "attribute-1";
+
+        // update range to xsd:integer
+        var dto = new ResourceDTO();
+        dto.setIdentifier(identifier);
+        dto.setLabel(Map.of("fi", "test label"));
+        dto.setRange("xsd:integer");
+
+        ResourceMapper.mapToUpdateResource(graphUri, model, identifier, dto, EndpointUtils.mockUser);
+
+        var classResource = model.getResource(graphUri + "/class-1");
+        var restrictionResource = classResource.getProperty(OWL.intersectionOf).getObject().asResource();
+
+        assertEquals("xsd:integer", restrictionResource.getProperty(OWL.someValuesFrom).getObject().toString());
+    }
+
     private Model getOrgModel(){
         var model = ModelFactory.createDefaultModel();
               model.createResource("urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -8,10 +8,7 @@ import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
 import org.junit.jupiter.api.Test;
@@ -701,23 +698,30 @@ class ResourceMapperTest {
 
     @Test
     void testUpdateRestrictionsAfterRangeChange() {
-        var model = MapperTestUtils.getModelFromFile("/class_with_owl_restrictions.ttl");
+        var model = MapperTestUtils.getModelFromFile("/model_with_owl_restrictions.ttl");
 
         var graphUri = "http://uri.suomi.fi/datamodel/ns/model";
         var identifier = "attribute-1";
+        var newRange = XSD.integer.getURI();
 
         // update range to xsd:integer
         var dto = new ResourceDTO();
         dto.setIdentifier(identifier);
         dto.setLabel(Map.of("fi", "test label"));
-        dto.setRange("xsd:integer");
+        dto.setRange(newRange);
 
         ResourceMapper.mapToUpdateResource(graphUri, model, identifier, dto, EndpointUtils.mockUser);
 
         var classResource = model.getResource(graphUri + "/class-1");
-        var restrictionResource = classResource.getProperty(OWL.intersectionOf).getObject().asResource();
+        var list = classResource.getProperty(OWL.equivalentClass).getObject()
+                .asResource().getProperty(OWL.intersectionOf).getObject().as(RDFList.class);
 
-        assertEquals("xsd:integer", restrictionResource.getProperty(OWL.someValuesFrom).getObject().toString());
+        var updated = list.asJavaList().stream()
+                .filter(r -> r.asResource().getProperty(OWL.onProperty).getObject().toString()
+                        .equals("http://uri.suomi.fi/datamodel/ns/model/attribute-1"))
+                .findFirst();
+        assertTrue(updated.isPresent());
+        assertEquals(newRange, updated.get().asResource().getProperty(OWL.someValuesFrom).getObject().toString());
     }
 
     private Model getOrgModel(){

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -48,7 +48,28 @@ class VisualizationServiceTest {
     private VisualizationService visualizationService;
 
     @Test
-    void testMapVisualizationData() {
+    void testMapVisualizationDataLibrary() {
+        var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_visualization.ttl");
+        var positionModel = MapperTestUtils.getModelFromFile("/positions.ttl");
+
+        when(coreRepository.fetch(anyString())).thenReturn(model);
+        when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "test")).thenReturn(positionModel);
+
+        var visualizationData = visualizationService.getVisualizationData("test");
+
+        // should contain 3 classes and 2 references to external models
+        assertEquals(5, visualizationData.getNodes().size());
+
+        var cls = findClass(visualizationData.getNodes(), "testclass1");
+        assertEquals(1, cls.getAttributes().size());
+        assertEquals(1, cls.getAssociations().size());
+
+        var extClass = findClass(visualizationData.getNodes(), "ext:ExternalClass");
+        assertNotNull(extClass);
+    }
+
+    @Test
+    void testMapVisualizationDataProfile() {
         var model = MapperTestUtils.getModelFromFile("/models/test_application_profile_visualization.ttl");
         var positionModel = MapperTestUtils.getModelFromFile("/positions.ttl");
         var externalPropertiesModel = getExternalPropertiesResult();

--- a/src/test/resources/class_with_owl_restrictions.ttl
+++ b/src/test/resources/class_with_owl_restrictions.ttl
@@ -1,0 +1,22 @@
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<http://uri.suomi.fi/datamodel/ns/model/class-1>
+        rdf:type            owl:Class ;
+        owl:intersectionOf  [ rdf:type            owl:Restriction ;
+                              owl:onProperty      <http://uri.suomi.fi/datamodel/ns/model/attribute-1> ;
+                              owl:someValuesFrom  xsd:anyURI
+                            ] .
+
+<http://uri.suomi.fi/datamodel/ns/model/attribute-1>
+        rdf:type    owl:DatatypeProperty ;
+        rdfs:range  xsd:anyURI .
+
+<http://uri.suomi.fi/datamodel/ns/model/class-2>
+        rdf:type            owl:Class ;
+        owl:intersectionOf  [ rdf:type            owl:Restriction ;
+                              owl:onProperty      <http://uri.suomi.fi/datamodel/ns/model/attribute-1> ;
+                              owl:someValuesFrom  xsd:anyURI
+                            ] .

--- a/src/test/resources/model_with_owl_restrictions.ttl
+++ b/src/test/resources/model_with_owl_restrictions.ttl
@@ -1,0 +1,35 @@
+
+
+<http://uri.suomi.fi/datamodel/ns/model/attribute-1>
+        a       <http://www.w3.org/2002/07/owl#DatatypeProperty> ;
+        <http://www.w3.org/2000/01/rdf-schema#range>
+                <http://www.w3.org/2001/XMLSchema#anyURI> .
+
+<http://uri.suomi.fi/datamodel/ns/model/class-1>
+        a       <http://www.w3.org/2002/07/owl#Class> ;
+        <http://www.w3.org/2002/07/owl#equivalentClass>  <http://uri.suomi.fi/datamodel/ns/model/class-2> ;
+        <http://www.w3.org/2002/07/owl#equivalentClass>
+                [ a       <http://www.w3.org/2002/07/owl#Class> ;
+                  <http://www.w3.org/2002/07/owl#intersectionOf>
+                          ( [ a       <http://www.w3.org/2002/07/owl#Restriction> ;
+                              <http://www.w3.org/2002/07/owl#onProperty>
+                                      <http://uri.suomi.fi/datamodel/ns/model/attribute-1> ;
+                              <http://www.w3.org/2002/07/owl#someValuesFrom>
+                                      <http://www.w3.org/2001/XMLSchema#anyURI>
+                            ]
+                            [ a       <http://www.w3.org/2002/07/owl#Restriction> ;
+                              <http://www.w3.org/2002/07/owl#onProperty>
+                                      <http://uri.suomi.fi/datamodel/ns/model/attribute-2> ;
+                              <http://www.w3.org/2002/07/owl#someValuesFrom>
+                                      <http://www.w3.org/2001/XMLSchema#anyURI>
+                            ]
+                          )
+                ] .
+
+<http://uri.suomi.fi/datamodel/ns/model/attribute-2>
+        a       <http://www.w3.org/2002/07/owl#DatatypeProperty> ;
+        <http://www.w3.org/2000/01/rdf-schema#range>
+                <http://www.w3.org/2001/XMLSchema#anyURI> .
+
+<http://uri.suomi.fi/datamodel/ns/model/class-2>
+        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/src/test/resources/models/test_datamodel_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_visualization.ttl
@@ -17,7 +17,17 @@ test:testclass1  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "testclass1"^^xsd:NCName ;
         rdfs:label           "Label 1"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/yti-model/TestClass> .
+        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/yti-model/TestClass> ;
+        owl:intersectionOf   [
+            rdf:type  owl:Restriction ;
+            owl:onProperty      test:attribute-1 ;
+            owl:someValuesFrom  <xsd:string>
+        ] ;
+        owl:intersectionOf   [
+            rdf:type  owl:Restriction ;
+            owl:onProperty      test:association-1 ;
+            owl:someValuesFrom  <http://uri.suomi.fi/datamodel/ns/visu/testclass2>
+        ] .
 
 test:testclass2  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
@@ -35,7 +45,8 @@ test:attribute-1  rdf:type  owl:DatatypeProperty ;
         rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass1> ;
         rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
-        rdfs:label          "testiattribuutti"@fi .
+        rdfs:label          "testiattribuutti"@fi ;
+        rdfs:range          <xsd:string> .
 
 test:association-1 rdf:type  owl:ObjectProperty ;
         rdfs:domain         <http://uri.suomi.fi/datamodel/ns/test/testclass1> ;

--- a/src/test/resources/models/test_datamodel_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_visualization.ttl
@@ -18,16 +18,20 @@ test:testclass1  rdf:type     owl:Class ;
         dcterms:identifier   "testclass1"^^xsd:NCName ;
         rdfs:label           "Label 1"@fi ;
         rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/yti-model/TestClass> ;
-        owl:intersectionOf   [
-            rdf:type  owl:Restriction ;
-            owl:onProperty      test:attribute-1 ;
-            owl:someValuesFrom  <xsd:string>
-        ] ;
-        owl:intersectionOf   [
-            rdf:type  owl:Restriction ;
-            owl:onProperty      test:association-1 ;
-            owl:someValuesFrom  <http://uri.suomi.fi/datamodel/ns/visu/testclass2>
-        ] .
+        owl:equivalentClass
+                        [ rdf:type       owl:Class ;
+                          owl:intersectionOf   ([
+                            rdf:type  owl:Restriction ;
+                            owl:onProperty      test:attribute-1 ;
+                            owl:someValuesFrom  <xsd:string>
+                          ]
+                          [
+                              rdf:type  owl:Restriction ;
+                              owl:onProperty      test:association-1 ;
+                              owl:someValuesFrom  <http://uri.suomi.fi/datamodel/ns/visu/testclass2>
+                          ]
+                       )
+            ] .
 
 test:testclass2  rdf:type     owl:Class ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;


### PR DESCRIPTION
Create anonymous resources for restrictions as follows
```
<http://uri.suomi.fi/datamodel/ns/model/class-1>
        a       owl:Class ;
        owl:equivalentClass
                [ a       owl:Class ;
                  owl:intersectionOf
                          ( [ a       owl:Restriction ;
                              owl:onProperty
                                      <http://uri.suomi.fi/datamodel/ns/model/attribute-1> ;
                              owl:someValuesFrom
                                      <http://www.w3.org/2001/XMLSchema#anyURI>
                            ]
                            [ a       owl:Restriction ;
                              owl:onProperty
                                      <http://uri.suomi.fi/datamodel/ns/model/attribute-2> ;
                              owl:someValuesFrom
                                      <http://www.w3.org/2001/XMLSchema#anyURI>
                            ]
                          )
                ] .
```
- Add new endpoints for adding and removing restrictions (similar to corresponding functionality in applications)
- Creating attribute and association listings are based on restrictions, not rdfs:domain and rdfs:range
- OWL:someValuedFrom is the value of attribute's / association's range property. If that changes, also all owl:someValuesFrom triples are updated (in the same model)
- Similar changes to generating visualization data
- Some checks for skipping anonymous resources
- Removed some tests which use data of the old application