### PR TITLE
YTI-3194: Datamodel version control

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -121,7 +121,7 @@ public class DataModelController {
 
     @PostMapping(value = "/{prefix}/release")
     public void createRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                              @RequestParam @Parameter(description = "Semver version") String version,
+                              @RequestParam @Parameter(description = "Semantic version") String version,
                               @RequestParam @Parameter(description = "Status") Status status) {
         dataModelService.createRelease(prefix, version, status);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -3,6 +3,7 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
 import fi.vm.yti.datamodel.api.v2.dto.DataModelInfoDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ApiError;
 import fi.vm.yti.datamodel.api.v2.service.DataModelService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidDatamodel;
@@ -116,5 +117,12 @@ public class DataModelController {
     @DeleteMapping(value = "/{prefix}")
     public void deleteModel(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
         dataModelService.delete(prefix);
+    }
+
+    @PostMapping(value = "/{prefix}/release")
+    public void createRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                              @RequestParam @Parameter(description = "Semver version") String version,
+                              @RequestParam @Parameter(description = "Status") Status status) {
+        dataModelService.createRelease(prefix, version, status);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexModel.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexModel.java
@@ -17,6 +17,9 @@ public class IndexModel extends IndexBase {
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     private List<String> isPartOf;
     private List<String> language;
+    private String uri;
+    private String versionIri;
+    private String version;
 
     public String getContentModified() {
         return contentModified;
@@ -74,4 +77,27 @@ public class IndexModel extends IndexBase {
         this.language = language;
     }
 
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getVersionIri() {
+        return versionIri;
+    }
+
+    public void setVersionIri(String versionIri) {
+        this.versionIri = versionIri;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -206,5 +206,11 @@ public class DataModelService {
         mapper.mapPriorVersion(newDraft, modelUri, versionUri);
         coreRepository.put(modelUri, newDraft);
         coreRepository.put(versionUri, model);
+
+        var newVersion = mapper.mapToIndexModel(modelUri, model);
+        var draftIndex = mapper.mapToIndexModel(modelUri, newDraft);
+        openSearchIndexer.createModelToIndex(newVersion);
+        openSearchIndexer.updateModelToIndex(draftIndex);
+
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -1,21 +1,23 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
-import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
-import fi.vm.yti.datamodel.api.v2.dto.DataModelInfoDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.ModelType;
+import fi.vm.yti.datamodel.api.v2.dto.*;
+import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
+import fi.vm.yti.datamodel.api.v2.utils.SemVer;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +82,7 @@ public class DataModelService {
 
         coreRepository.put(graphUri, jenaModel);
 
-        var indexModel = mapper.mapToIndexModel(dto.getPrefix(), jenaModel);
+        var indexModel = mapper.mapToIndexModel(graphUri, jenaModel);
         openSearchIndexer.createModelToIndex(indexModel);
         return new URI(graphUri);
     }
@@ -97,7 +99,7 @@ public class DataModelService {
 
         coreRepository.put(graphUri, jenaModel);
 
-        var indexModel = mapper.mapToIndexModel(prefix, jenaModel);
+        var indexModel = mapper.mapToIndexModel(graphUri, jenaModel);
         openSearchIndexer.updateModelToIndex(indexModel);
     }
 
@@ -172,4 +174,37 @@ public class DataModelService {
         return ResponseEntity.ok(stringWriter.toString());
     }
 
+
+    public void createRelease(String prefix, String version, Status status) {
+        var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        if(!status.equals(Status.SUGGESTED) && !status.equals(Status.VALID)){
+            throw new MappingError("Status has to be SUGGESTED or VALID");
+        }
+
+        if(!version.matches(SemVer.VALID_REGEX)){
+            throw new MappingError("Not valid Semantic version string");
+        }
+
+        //This gets the current "DRAFT" version
+        var model = coreRepository.fetch(modelUri);
+        var priorVersionUri = MapperUtils.propertyToString(model.getResource(modelUri), OWL.priorVersion);
+        if(priorVersionUri != null){
+            var priorVersion = priorVersionUri.substring(priorVersionUri.lastIndexOf("/")  + 1);
+            var result = SemVer.compareSemVers(priorVersion, version);
+            if(result == 0){
+                throw new MappingError("Same version number");
+            }
+            if(result > 0) {
+                throw new MappingError("Older version given");
+            }
+        }
+
+        var newDraft = ModelFactory.createDefaultModel().add(model);
+
+        var versionUri = mapper.mapReleaseProperties(model, modelUri, version, status);
+        //Map new newest release to draft model
+        mapper.mapPriorVersion(newDraft, modelUri, versionUri);
+        coreRepository.put(modelUri, newDraft);
+        coreRepository.put(versionUri, model);
+    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SemVer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SemVer.java
@@ -1,0 +1,83 @@
+package fi.vm.yti.datamodel.api.v2.utils;
+
+public class SemVer {
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final String preRelease;
+
+    //Long regex string, but it's the one defined in semver.org (see near bottom of page)
+    public static final String VALID_REGEX = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
+    public SemVer(String version) {
+        if(version.contains("+")){
+            version = version.substring(0, version.indexOf("+"));
+        }
+        var versionSplit = version.split("\\.", 3);
+        major = Integer.parseInt(versionSplit[0]);
+        minor = Integer.parseInt(versionSplit[1]);
+        if(versionSplit[2].contains("-")) {
+            var split = versionSplit[2].split("-", 2);
+            patch = Integer.parseInt(split[0]);
+            preRelease = split[1];
+        }else{
+            patch = Integer.parseInt(versionSplit[2]);
+            preRelease = null;
+        }
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    public String getPreRelease() {
+        return preRelease;
+    }
+
+    public static int compareSemVers(String a, String b){
+        var semVerA = new SemVer(a);
+        var semVerB = new SemVer(b);
+
+        if(semVerA.getMajor() != semVerB.getMajor()) {
+            return Integer.compare(semVerA.getMajor(), semVerB.getMajor());
+        }
+        if(semVerA.getMinor() != (semVerB.getMinor())){
+            return Integer.compare(semVerA.getMinor(), semVerB.getMinor());
+        }
+        if(semVerA.getPatch() != (semVerB.getPatch())){
+            return Integer.compare(semVerA.getPatch(), semVerB.getPatch());
+        }
+
+        if(semVerA.getPreRelease() != null && semVerB.getPreRelease() == null) {
+            return -1;
+        }
+        if(semVerA.getPreRelease() == null && semVerB.getPreRelease() != null) {
+            return 1;
+        }
+        if(semVerA.getPreRelease() != null && semVerB.getPreRelease() != null){
+            return comparePreRelease(semVerA.getPreRelease(), semVerB.getPreRelease());
+        }
+
+        return 0;
+    }
+
+    private static int comparePreRelease(String a, String b) {
+        var aSplit = a.split("\\.");
+        var bSplit = b.split("\\.");
+
+        for(int i=0; i< aSplit.length &&i< bSplit.length; i++){
+            if(aSplit[i].equals(bSplit[i])) {
+                return aSplit[i].compareTo(bSplit[i]);
+            }
+        }
+        return bSplit.length - aSplit.length;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SparqlUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/SparqlUtils.java
@@ -1,13 +1,28 @@
 package fi.vm.yti.datamodel.api.v2.utils;
 
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.rdf.model.Property;
+
+import java.util.UUID;
 
 public class SparqlUtils {
 
 
     private SparqlUtils(){
         //Util class
+    }
+
+    public static void addRequiredToGraphConstruct(String subjectVariable, ConstructBuilder builder, WhereBuilder whereBuilder,  Property property){
+        var propertyName = "?" + UUID.randomUUID().toString().substring(0, 7);
+        builder.addConstruct("?g", property, propertyName);
+        whereBuilder.addWhere(subjectVariable, property, propertyName);
+    }
+
+    public static void addOptionalToGraphConstruct(String subjectVariable, ConstructBuilder builder, WhereBuilder whereBuilder,  Property property){
+        var propertyName = "?" + UUID.randomUUID().toString().substring(0, 7);
+        builder.addConstruct("?g", property, propertyName);
+        whereBuilder.addOptional(subjectVariable, property, propertyName);
     }
 
     public static void addConstructProperty(String graphVariable, ConstructBuilder builder, Property property, String propertyName) {

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -372,10 +372,38 @@ class ModelMapperTest {
     }
 
     @Test
+    void testMapReleaseProperties() {
+        //Model is loaded from the Draft version and mapping the properties will make it into a release version
+        var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        final var graphUri = "http://uri.suomi.fi/datamodel/ns/test";
+
+        var versionUri = mapper.mapReleaseProperties(m, graphUri, "1.0.1", Status.VALID);
+
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", versionUri);
+        var resource = m.getResource(graphUri);
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", MapperUtils.propertyToString(resource, OWL2.versionIRI));
+
+        var versionInfoList = List.of(Status.VALID.name(), "1.0.1");
+        assertTrue(MapperUtils.arrayPropertyToList(resource, OWL.versionInfo).containsAll(versionInfoList));
+
+        assertEquals(graphUri + "/1.0.0", MapperUtils.propertyToString(resource, OWL.priorVersion));
+    }
+
+    @Test
+    void testMapPriorVersion() {
+        //This is loaded as if it was a draft version
+        var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        mapper.mapPriorVersion(m, "http://uri.suomi.fi/datamodel/ns/test", "http://uri.suomi.fi/datamodel/ns/test/1.0.0");
+
+        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.0", MapperUtils.propertyToString(resource, OWL.priorVersion));
+    }
+
+    @Test
     void testMapToIndexModel() {
         var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
 
-        var result = mapper.mapToIndexModel("test", m);
+        var result = mapper.mapToIndexModel("http://uri.suomi.fi/datamodel/ns/test", m);
 
         assertEquals("test", result.getPrefix());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test", result.getId());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -413,4 +413,15 @@ class DataModelControllerTest {
         verifyNoMoreInteractions(dataModelService);
     }
 
+
+    @Test
+    void shouldCreateRelease() throws Exception {
+        mvc.perform(post("/v2/model/test/release")
+                        .param("status", "VALID")
+                        .param("version","1.0.1"))
+                .andExpect(status().isOk());
+
+        verify(dataModelService).createRelease("test", "1.0.1", Status.VALID);
+        verifyNoMoreInteractions(dataModelService);
+    }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -205,6 +205,7 @@ class DataModelServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(modelMapper.mapReleaseProperties(any(Model.class), anyString(), anyString(), any(Status.class)))
                 .thenReturn("http://uri.suomi.fi/datamodel/ns/test/1.0.1");
+        when(modelMapper.mapToIndexModel(anyString(), any(Model.class))).thenReturn(mock(IndexModel.class));
 
         dataModelService.createRelease("test", "1.0.1", Status.VALID);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -35,8 +35,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @Import({
@@ -219,6 +218,10 @@ class DataModelServiceTest {
 
         verify(coreRepository).put(eq("http://uri.suomi.fi/datamodel/ns/test/1.0.1"), any(Model.class));
         verify(coreRepository).put(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
+
+        verify(modelMapper, times(2)).mapToIndexModel(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
+        verify(openSearchIndexer).createModelToIndex(any(IndexModel.class));
+        verify(openSearchIndexer).updateModelToIndex(any(IndexModel.class));
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/utils/SemVerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/utils/SemVerTest.java
@@ -1,0 +1,99 @@
+package fi.vm.yti.datamodel.api.v2.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SemVerTest {
+
+    @Test
+    void testSemverSortList() {
+        //This is a randomly generated list of valid semvers
+        var preSorted = List.of(
+                "0.4.1-rc2",
+                "0.8.7",
+                "1.0.0-alpha",
+                "1.0.1-alpha.1",
+                "1.2.3-rc1",
+                "1.5.0",
+                "1.9.0",
+                "2.0.0-alpha.2",
+                "2.0.0",
+                "2.0.4",
+                "3.3.5-rc5",
+                "4.2.1-rc4",
+                "4.7.8-rc3",
+                "6.1.3-alpha.6",
+                "7.2.6",
+                "7.4.9",
+                "8.0.6-alpha.9",
+                "8.9.1-alpha.4",
+                "9.3.7-alpha.3",
+                "9.7.0-rc8"
+        );
+
+        var list = new ArrayList<>(List.of(
+                "1.0.0-alpha",
+                "2.0.0",
+                "1.2.3-rc1",
+                "1.0.1-alpha.1",
+                "2.0.0-alpha.2",
+                "1.5.0",
+                "0.4.1-rc2",
+                "9.3.7-alpha.3",
+                "7.2.6",
+                "4.7.8-rc3",
+                "8.9.1-alpha.4",
+                "2.0.4",
+                "4.2.1-rc4",
+                "1.9.0",
+                "3.3.5-rc5",
+                "0.8.7",
+                "6.1.3-alpha.6",
+                "7.4.9",
+                "9.7.0-rc8",
+                "8.0.6-alpha.9"
+        ));
+
+        list.sort(SemVer::compareSemVers);
+        assertEquals(list, preSorted);
+    }
+
+    @Test
+    void testSemverSortPreReleaseList(){
+        //This list is from https://semver.org/#spec-item-11 See section 11.4
+        var preReleaseListSorted = List.of(
+                "1.0.0-alpha",
+                "1.0.0-alpha.1",
+                "1.0.0-alpha.beta",
+                "1.0.0-beta",
+                "1.0.0-beta.2",
+                "1.0.0-beta.11",
+                "1.0.0-rc.1",
+                "1.0.0");
+        var sortablePreReleaseList = new ArrayList<>(preReleaseListSorted);
+        //order should not change when sorting
+        sortablePreReleaseList.sort(SemVer::compareSemVers);
+        assertEquals(preReleaseListSorted, sortablePreReleaseList);
+    }
+
+    @Test
+    void testSemverCompare() {
+        //Second is Larger https://semver.org/#spec-item-2
+        assertTrue(SemVer.compareSemVers("1.0.0","1.0.1") < 0);
+        //Second is smaller
+        assertTrue(SemVer.compareSemVers("2.0.1","1.2.3") > 0);
+        //Same
+        assertEquals(0, SemVer.compareSemVers("2.0.0", "2.0.0"));
+        //Same because build information doesn't matter https://semver.org/#spec-item-10
+        assertEquals(0, SemVer.compareSemVers("2.0.0", "2.0.0+buildinfo"));
+        //Same as build info doesn't matter even in pre-release
+        assertEquals(0, SemVer.compareSemVers("2.0.0-beta", "2.0.0-beta+buildinfo"));
+        //Actual release is larger than pre-release https://semver.org/#spec-item-9
+        assertTrue(SemVer.compareSemVers("2.0.0","2.0.0-alpha") > 0);
+    }
+}

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -33,7 +33,8 @@
                                             dcterms:description "link description" ;
                                             dcterms:title       "link title" ;
                                             foaf:homepage       "https://example.com"
-                                        ] .
+                                        ] ;
+        owl:priorVersion                "http://uri.suomi.fi/datamodel/ns/test/1.0.0" .
 
 <https://www.example.com/ns/ext>
         dcterms:type                        rdfs:Resource ;


### PR DESCRIPTION
Changelog:

**Controller**
- New endpoint  `v2/model/{prefix}/release`

**Indexing**
- New fields for datamodel
- Id now has version number attached so that they can still be unique
- Datamodel index construct query rewritten. It can now handle datamodels with same uri from different named graphs


**Semantic versioning**
- New SemVer class for comparing Semantic versions
- Is  able to differentiate between preReleases as well

**ModelMapper**
- Adding version release specific properties
- Not adding non-mvp properties yet

**DatamodelService**
- Function for creating release
- Check status for only allowing VALID AND SUGGESTED
- Check that string matches SemVer regex
- Check that new version is bigger than older one
- Map version properties to new release
- Map new release version uri to current draft
- Save both to fuseki
- Save both to opensearch index
