### PR TITLE
YTI-3194: version control get

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
@@ -19,6 +19,8 @@ public class DataModelInfoDTO extends ResourceCommonDTO {
     private String contact;
     private Map<String, String> documentation = Map.of();
     private Set<LinkDTO> links = Set.of();
+    private String version;
+    private String versionIri;
 
     public ModelType getType() {
         return type;
@@ -138,5 +140,21 @@ public class DataModelInfoDTO extends ResourceCommonDTO {
 
     public void setLinks(Set<LinkDTO> links) {
         this.links = links;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersionIri() {
+        return versionIri;
+    }
+
+    public void setVersionIri(String versionIri) {
+        this.versionIri = versionIri;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -100,8 +100,9 @@ public class ClassController {
     })
     @GetMapping(value = "/library/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ClassInfoDTO getClass(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                 @PathVariable @Parameter(description = "Class identifier") String classIdentifier){
-        return (ClassInfoDTO) classService.get(prefix, classIdentifier);
+                                 @PathVariable @Parameter(description = "Class identifier") String classIdentifier,
+                                 @RequestParam(required = false) @Parameter(description = "Version") String version){
+        return (ClassInfoDTO) classService.get(prefix, version, classIdentifier);
     }
 
     @Operation(summary = "Get a node shape from a profile")
@@ -110,8 +111,9 @@ public class ClassController {
             @ApiResponse(responseCode = "404", description = "Node shape not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
     })    @GetMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}", produces = APPLICATION_JSON_VALUE)
     public NodeShapeInfoDTO getNodeShape(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                         @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier){
-        return (NodeShapeInfoDTO) classService.get(prefix, nodeShapeIdentifier);
+                                         @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier,
+                                         @RequestParam(required = false) @Parameter(description = "Version") String version){
+        return (NodeShapeInfoDTO) classService.get(prefix, version, nodeShapeIdentifier);
     }
 
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -97,8 +97,9 @@ public class DataModelController {
             @ApiResponse(responseCode = "404", description = "Data model was not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))}),
     })
     @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)
-    public DataModelInfoDTO getModel(@PathVariable @Parameter(description = "Data model prefix") String prefix){
-        return dataModelService.get(prefix);
+    public DataModelInfoDTO getModel(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                                     @RequestParam(required = false) @Parameter(description = "Model version, if empty gets the draft version") String version){
+        return dataModelService.get(prefix, version);
     }
 
     @Operation(summary = "Check if prefix already exists")
@@ -120,9 +121,10 @@ public class DataModelController {
     }
 
     @PostMapping(value = "/{prefix}/release")
-    public void createRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                              @RequestParam @Parameter(description = "Semantic version") String version,
-                              @RequestParam @Parameter(description = "Status") Status status) {
-        dataModelService.createRelease(prefix, version, status);
+    public ResponseEntity<String> createRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                                                @RequestParam @Parameter(description = "Semantic version") String version,
+                                                @RequestParam @Parameter(description = "Status") Status status) throws URISyntaxException {
+        var uri = dataModelService.createRelease(prefix, version, status);
+        return ResponseEntity.created(uri).build();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -33,7 +33,8 @@ public class ExportController {
             produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8"})
     public ResponseEntity<String> export(@PathVariable @Parameter(description = "Data model prefix") String prefix,
                                          @PathVariable(required = false) @Parameter(description = "Resource identifier") String resourceIdentifier,
+                                         @RequestParam(required = false) @Parameter(description = "Version") String version,
                                          @RequestHeader(value = HttpHeaders.ACCEPT) String accept){
-        return dataModelService.export(prefix, resourceIdentifier, accept);
+        return dataModelService.export(prefix, version, resourceIdentifier, accept);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -167,9 +167,10 @@ public class ResourceController {
     })
     @GetMapping(value = "/library/{prefix}/{resourceIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ResourceInfoDTO getResource(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                       @PathVariable @Parameter(description = "Attribute or association identifier") String resourceIdentifier){
+                                       @PathVariable @Parameter(description = "Attribute or association identifier") String resourceIdentifier,
+                                       @RequestParam(required = false) @Parameter(description = "Version") String version){
         //TODO check if this can be generic instead of casting
-        return (ResourceInfoDTO) resourceService.get(prefix, resourceIdentifier);
+        return (ResourceInfoDTO) resourceService.get(prefix, version, resourceIdentifier);
     }
 
     @Operation(summary = "Find a property shape from a profile")
@@ -179,8 +180,9 @@ public class ResourceController {
     })
     @GetMapping(value = "/profile/{prefix}/{propertyShapeIdentifier}", produces = APPLICATION_JSON_VALUE)
     public PropertyShapeInfoDTO getPropertyShape(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                                 @PathVariable @Parameter(description = "Property shape identifier") String propertyShapeIdentifier){
-        return (PropertyShapeInfoDTO) resourceService.get(prefix, propertyShapeIdentifier);
+                                                 @PathVariable @Parameter(description = "Property shape identifier") String propertyShapeIdentifier,
+                                                 @RequestParam(required = false) @Parameter(description = "Version") String version){
+        return (PropertyShapeInfoDTO) resourceService.get(prefix, version, propertyShapeIdentifier);
     }
 
     @Operation(summary = "Get an external resource from imports")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationController.java
@@ -29,8 +29,9 @@ public class VisualizationController {
     @Operation(summary = "Get data for model visualization")
     @ApiResponse(responseCode = "200", description = "Visualization data found for model")
     @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)
-    public VisualizationResultDTO getVisualizationData(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
-        return visualizationService.getVisualizationData(prefix);
+    public VisualizationResultDTO getVisualizationData(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                                                       @RequestParam(required = false) @Parameter(description = "Version of the model") String version) {
+        return visualizationService.getVisualizationData(prefix, version);
     }
 
     @Operation(summary = "Saves position data for visualization components")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -198,8 +198,16 @@ public class ModelMapper {
         datamodelDTO.setPrefix(prefix);
 
         var modelResource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
-        datamodelDTO.setStatus(Status.valueOf(MapperUtils.propertyToString(modelResource, OWL.versionInfo)));
 
+        var versionInfo = MapperUtils.arrayPropertyToList(modelResource, OWL.versionInfo);
+        versionInfo.forEach(ver -> {
+            if(Arrays.stream(Status.values()).map(Status::name).anyMatch(ver::equals)){
+                datamodelDTO.setStatus(Status.valueOf(ver));
+            }else{
+                datamodelDTO.setVersion(ver);
+            }
+        });
+        datamodelDTO.setVersionIri(MapperUtils.propertyToString(modelResource, OWL2.versionIRI));
         if(MapperUtils.isApplicationProfile(modelResource)){
             datamodelDTO.setType(ModelType.PROFILE);
         }else if(MapperUtils.isLibrary(modelResource)){

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -14,6 +14,7 @@ public class ResourceSearchRequest extends BaseSearchRequest{
     private ModelType limitToModelType;
     private String targetClass;
     private Set<String> additionalResources;
+    private String fromVersion;
 
     public String getLimitToDataModel() {
         return limitToDataModel;
@@ -69,5 +70,13 @@ public class ResourceSearchRequest extends BaseSearchRequest{
 
     public void setAdditionalResources(Set<String> additionalResources) {
         this.additionalResources = additionalResources;
+    }
+
+    public String getFromVersion() {
+        return fromVersion;
+    }
+
+    public void setFromVersion(String fromVersion) {
+        this.fromVersion = fromVersion;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
@@ -16,6 +16,7 @@ public class IndexResource extends IndexBase {
     private String range;
     private String subject;
     private String targetClass;
+    private String fromVersion;
 
     public ResourceType getResourceType() {
         return resourceType;
@@ -95,5 +96,13 @@ public class IndexResource extends IndexBase {
 
     public void setTargetClass(String targetClass) {
         this.targetClass = targetClass;
+    }
+
+    public String getFromVersion() {
+        return fromVersion;
+    }
+
+    public void setFromVersion(String fromVersion) {
+        this.fromVersion = fromVersion;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
@@ -4,10 +4,6 @@ import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
-import org.opensearch.client.opensearch._types.SortOptions;
-import org.opensearch.client.opensearch._types.SortOptionsBuilders;
-import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.mapping.FieldType;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -79,18 +75,11 @@ public class ModelQueryFactory {
             finalQuery.should(should).minimumShouldMatch("1");
         }
 
-        var sortLang = request.getSortLang() != null ? request.getSortLang() : QueryFactoryUtils.DEFAULT_SORT_LANG;
-        var sort = SortOptionsBuilders.field()
-                .field("label." + sortLang + ".keyword")
-                .order(SortOrder.Asc)
-                .unmappedType(FieldType.Keyword)
-                .build();
-
         var sr = new SearchRequest.Builder()
                 .index(OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL)
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
-                .sort(SortOptions.of(s -> s.field(sort)))
+                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
                 .query(finalQuery.build()._toQuery())
                 .build();
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -16,7 +16,10 @@ import fi.vm.yti.datamodel.api.v2.repository.ImportsRepository;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.arq.querybuilder.AskBuilder;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.vocabulary.OWL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,13 +76,19 @@ public class ClassService {
         this.searchIndexService = searchIndexService;
     }
 
-    public ResourceInfoBaseDTO get(String prefix, String classIdentifier) {
+    public ResourceInfoBaseDTO get(String prefix, String version, String classIdentifier) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+
+        var versionUri = modelURI;
+        if(version != null){
+            versionUri += ModelConstants.RESOURCE_SEPARATOR + version;
+        }
+
         var classURI = modelURI + ModelConstants.RESOURCE_SEPARATOR + classIdentifier;
-        if(!coreRepository.resourceExistsInGraph(modelURI , classURI)){
+        if(!coreRepository.resourceExistsInGraph(versionUri , classURI)){
             throw new ResourceNotFoundException(classURI);
         }
-        var model = coreRepository.fetch(modelURI);
+        var model = coreRepository.fetch(versionUri);
         var hasRightToModel = authorizationManager.hasRightToModel(prefix, model);
 
         var orgModel = coreRepository.getOrganizations();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -6,6 +6,8 @@ import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
@@ -18,16 +20,19 @@ import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 
@@ -64,8 +69,12 @@ public class DataModelService {
         this.userProvider = userProvider;
     }
 
-    public DataModelInfoDTO get(String prefix) {
-        var model = coreRepository.fetch(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
+    public DataModelInfoDTO get(String prefix, String version) {
+        var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        if(version != null) {
+            graphUri += ModelConstants.RESOURCE_SEPARATOR + version;
+        }
+        var model = coreRepository.fetch(graphUri);
         var hasRightsToModel = authorizationManager.hasRightToModel(prefix, model);
 
         var userMapper = hasRightsToModel ? groupManagementService.mapUser() : null;
@@ -122,15 +131,19 @@ public class DataModelService {
         return coreRepository.graphExists(ModelConstants.SUOMI_FI_NAMESPACE + prefix);
     }
 
-    public ResponseEntity<String> export(String prefix, String resource, String accept) {
+    public ResponseEntity<String> export(String prefix, String version, String resource, String accept) {
         var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        logger.info("Exporting datamodel {}, {}", modelURI, accept);
+        var versionUri = modelURI;
+        if(version != null) {
+            versionUri += ModelConstants.RESOURCE_SEPARATOR + version;
+        }
+        logger.info("Exporting datamodel {}, {}", versionUri, accept);
 
         Model exportedModel;
         Model model;
 
         try {
-            model = coreRepository.fetch(modelURI);
+            model = coreRepository.fetch(versionUri);
         } catch (ResourceNotFoundException e) {
             // cannot throw ResourceNotFoundException because accept header is not application/json
             return ResponseEntity.notFound().build();
@@ -175,7 +188,7 @@ public class DataModelService {
     }
 
 
-    public void createRelease(String prefix, String version, Status status) {
+    public URI createRelease(String prefix, String version, Status status) throws URISyntaxException {
         var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         if(!status.equals(Status.SUGGESTED) && !status.equals(Status.VALID)){
             throw new MappingError("Status has to be SUGGESTED or VALID");
@@ -187,6 +200,7 @@ public class DataModelService {
 
         //This gets the current "DRAFT" version
         var model = coreRepository.fetch(modelUri);
+        check(authorizationManager.hasRightToModel(prefix, model));
         var priorVersionUri = MapperUtils.propertyToString(model.getResource(modelUri), OWL.priorVersion);
         if(priorVersionUri != null){
             var priorVersion = priorVersionUri.substring(priorVersionUri.lastIndexOf("/")  + 1);
@@ -208,9 +222,16 @@ public class DataModelService {
         coreRepository.put(versionUri, model);
 
         var newVersion = mapper.mapToIndexModel(modelUri, model);
-        var draftIndex = mapper.mapToIndexModel(modelUri, newDraft);
         openSearchIndexer.createModelToIndex(newVersion);
-        openSearchIndexer.updateModelToIndex(draftIndex);
+        var list = new ArrayList<IndexResource>();
+        var resources = model.listSubjectsWithProperty(RDF.type, OWL.Class)
+                .andThen(model.listSubjectsWithProperty(RDF.type, OWL.ObjectProperty))
+                .andThen(model.listSubjectsWithProperty(RDF.type, OWL.DatatypeProperty))
+                .andThen(model.listSubjectsWithProperty(RDF.type, SH.NodeShape));
+        resources.forEach(resource -> list.add(ResourceMapper.mapToIndexResource(model, resource.getURI())));
+        openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE, list);
+        //Draft model does not need to be indexed since opensearch specific properties on it did not change
+        return new URI(versionUri);
 
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -46,6 +46,7 @@ public class DataModelService {
     private final GroupManagementService groupManagementService;
     private final ModelMapper mapper;
     private final TerminologyService terminologyService;
+    private final VisualizationService visualisationService;
     private final CodeListService codeListService;
     private final OpenSearchIndexer openSearchIndexer;
     private final AuthenticatedUserProvider userProvider;
@@ -56,6 +57,7 @@ public class DataModelService {
                             GroupManagementService groupManagementService,
                             ModelMapper modelMapper,
                             TerminologyService terminologyService,
+                            VisualizationService visualizationService,
                             CodeListService codeListService,
                             OpenSearchIndexer openSearchIndexer,
                             AuthenticatedUserProvider userProvider) {
@@ -64,6 +66,7 @@ public class DataModelService {
         this.groupManagementService = groupManagementService;
         this.mapper = modelMapper;
         this.terminologyService = terminologyService;
+        this.visualisationService = visualizationService;
         this.codeListService = codeListService;
         this.openSearchIndexer = openSearchIndexer;
         this.userProvider = userProvider;
@@ -230,6 +233,7 @@ public class DataModelService {
                 .andThen(model.listSubjectsWithProperty(RDF.type, SH.NodeShape));
         resources.forEach(resource -> list.add(ResourceMapper.mapToIndexResource(model, resource.getURI())));
         openSearchIndexer.bulkInsert(OpenSearchIndexer.OPEN_SEARCH_INDEX_RESOURCE, list);
+        visualisationService.saveVersionedPositions(prefix, version);
         //Draft model does not need to be indexed since opensearch specific properties on it did not change
         return new URI(versionUri);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -62,13 +62,17 @@ public class ResourceService {
         this.openSearchIndexer = openSearchIndexer;
     }
 
-    public ResourceInfoBaseDTO get(String prefix, String identifier) {
+    public ResourceInfoBaseDTO get(String prefix, String version, String identifier) {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        if(!coreRepository.resourceExistsInGraph(graphUri,graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier)){
+        var versionUri = graphUri;
+        if(version != null){
+            versionUri += ModelConstants.RESOURCE_SEPARATOR + version;
+        }
+        if(!coreRepository.resourceExistsInGraph(versionUri,graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier)){
             throw new ResourceNotFoundException(identifier);
         }
 
-        var model = coreRepository.fetch(graphUri);
+        var model = coreRepository.fetch(versionUri);
         var orgModel = coreRepository.getOrganizations();
         var hasRightToModel = authorizationManager.hasRightToModel(prefix, model);
         var modelResource = model.getResource(graphUri);

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -372,6 +372,20 @@ class ModelMapperTest {
     }
 
     @Test
+    void testMapToDatamodelDTOVersion() {
+        var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_version.ttl");
+        var nsModel = MapperTestUtils.getModelFromFile("/test_datamodel_internal_reference.ttl");
+        when(coreRepository.fetch("http://uri.suomi.fi/datamodel/ns/int")).thenReturn(nsModel);
+        var result = mapper.mapToDataModelDTO("test", m, null);
+
+
+        //no need to check other values since the file should be almost the same as above with the exception of version properties
+        assertEquals("1.0.1", result.getVersion());
+        assertEquals(Status.VALID, result.getStatus());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", result.getVersionIri());
+    }
+
+    @Test
     void testMapReleaseProperties() {
         //Model is loaded from the Draft version and mapping the properties will make it into a release version
         var m = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -227,7 +227,7 @@ class ResourceMapperTest {
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestClass");
 
         assertEquals(ResourceType.CLASS, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
@@ -235,6 +235,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
+        assertEquals("1.0.1", indexClass.getFromVersion());
     }
 
     @Test
@@ -245,7 +246,7 @@ class ResourceMapperTest {
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
 
         assertEquals(ResourceType.ATTRIBUTE, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAttribute", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAttribute", indexClass.getIdentifier());
@@ -255,6 +256,7 @@ class ResourceMapperTest {
         assertEquals("test attribute", indexClass.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
         assertEquals("rdf:Literal", indexClass.getRange());
+        assertEquals("1.0.1", indexClass.getFromVersion());
     }
 
     @Test
@@ -265,7 +267,7 @@ class ResourceMapperTest {
         var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
 
         assertEquals(ResourceType.ASSOCIATION, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", indexClass.getId());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAssociation", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAssociation", indexClass.getIdentifier());
@@ -275,6 +277,7 @@ class ResourceMapperTest {
         assertEquals("test association", indexClass.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
+        assertEquals("1.0.1", indexClass.getFromVersion());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -106,7 +106,7 @@ class DataModelControllerTest {
 
     @Test
     void shouldReturnModel() throws Exception {
-        when(dataModelService.get(anyString())).thenReturn(new DataModelInfoDTO());
+        when(dataModelService.get(anyString(), eq(null))).thenReturn(new DataModelInfoDTO());
         this.mvc
                 .perform(get("/v2/model/test")
                         .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -114,7 +114,7 @@ class DataModelControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
 
-        verify(dataModelService).get(anyString());
+        verify(dataModelService).get(anyString(), eq(null));
         verifyNoMoreInteractions(dataModelService);
     }
 
@@ -419,7 +419,7 @@ class DataModelControllerTest {
         mvc.perform(post("/v2/model/test/release")
                         .param("status", "VALID")
                         .param("version","1.0.1"))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         verify(dataModelService).createRelease("test", "1.0.1", Status.VALID);
         verifyNoMoreInteractions(dataModelService);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
@@ -45,7 +45,24 @@ class ExportControllerTest {
         mvc.perform(get("/v2/export/test")
                 .header("Accept", "application/ld+json"))
                 .andExpect(status().isOk());
-        verify(dataModelService).export("test", null, "application/ld+json");
+        verify(dataModelService).export("test", null, null, "application/ld+json");
+    }
+
+    @Test
+    void shouldCallDataModelServiceWithVersion() throws Exception {
+        mvc.perform(get("/v2/export/test")
+                        .header("Accept", "application/ld+json")
+                        .param("version", "1.0.0"))
+                .andExpect(status().isOk());
+        verify(dataModelService).export("test", "1.0.0", null, "application/ld+json");
+    }
+
+    @Test
+    void shouldCallDataModelServiceWithResource() throws Exception {
+        mvc.perform(get("/v2/export/test/Resource")
+                        .header("Accept", "application/ld+json"))
+                .andExpect(status().isOk());
+        verify(dataModelService).export("test", null, "Resource", "application/ld+json");
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,7 +68,6 @@ class ResourceControllerTest {
                 .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(resourceDTO)))
-                .andDo(print())
                 .andExpect(status().isCreated());
         //validator
         if (resourceType.equals("attribute")) {
@@ -222,7 +220,6 @@ class ResourceControllerTest {
                 .perform(post("/v2/resource/profile/test/attribute")
                         .contentType("application/json")
                         .content(EndpointUtils.convertObjectToJsonString(dto)))
-                .andDo(print())
                 .andExpect(status().isCreated());
 
         verify(resourceService).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -190,7 +190,16 @@ class ResourceControllerTest {
     void shouldGetResource() throws Exception {
         mvc.perform(get("/v2/resource/library/test/TestAttribute"))
                 .andExpect(status().isOk());
-        verify(resourceService).get(anyString(), anyString());
+        verify(resourceService).get(anyString(), eq(null), anyString());
+        verifyNoMoreInteractions(resourceService);
+    }
+
+    @Test
+    void shouldGetResourceWithVersion() throws Exception {
+        mvc.perform(get("/v2/resource/library/test/TestAttribute")
+                        .param("version", "1.0.1"))
+                .andExpect(status().isOk());
+        verify(resourceService).get(anyString(), eq("1.0.1"), anyString());
         verifyNoMoreInteractions(resourceService);
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/VisualizationControllerTest.java
@@ -1,0 +1,73 @@
+package fi.vm.yti.datamodel.api.v2.endpoint;
+
+import fi.vm.yti.datamodel.api.v2.dto.PositionDataDTO;
+import fi.vm.yti.datamodel.api.v2.service.VisualizationService;
+import fi.vm.yti.datamodel.api.v2.validator.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(VisualizationController.class)
+@ActiveProfiles("junit")
+class VisualizationControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private VisualizationService visualizationService;
+
+    @Autowired
+    private VisualizationController visualizationController;
+
+    @BeforeEach
+    void setup() {
+        mvc = MockMvcBuilders
+                .standaloneSetup(this.visualizationController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void testGetVisualizationData() throws Exception {
+        mvc.perform(get("/v2/visualization/{prefix}", "test"))
+                .andExpect(status().isOk());
+
+        verify(visualizationService).getVisualizationData("test", null);
+
+        mvc.perform(get("/v2/visualization/{prefix}", "test")
+                        .param("version", "1.0.1"))
+                .andExpect(status().isOk());
+        verify(visualizationService).getVisualizationData("test", "1.0.1");
+    }
+
+    @Test
+    void testSavePositions() throws Exception {
+        mvc.perform(put("/v2/visualization/{prefix}/positions", "test")
+                        .contentType("application/json")
+                        .content(EndpointUtils.convertObjectToJsonString(new ArrayList<PositionDataDTO>()))
+                )
+                .andExpect(status().isNoContent());
+
+        verify(visualizationService).savePositionData(eq("test"), anyList());
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
@@ -19,6 +19,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.function.Consumer;
+
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -75,6 +77,6 @@ class OpenSearchIndexerTest {
 
         openSearchIndexer.initResourceIndex();
 
-        verify(coreRepository).queryConstruct(any(Query.class));
+        verify(coreRepository).querySelect(any(Query.class), any(Consumer.class));
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -58,7 +58,6 @@ class ResourceQueryFactoryTest {
         var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(),
                 new ArrayList<>(), new HashSet<>());
         String expected = OpenSearchUtils.getJsonString("/es/attributeListRequest.json");
-        String real = OpenSearchUtils.getPayload(attributeListQuery);
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(attributeListQuery), JSONCompareMode.LENIENT);
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -58,6 +58,7 @@ class ResourceQueryFactoryTest {
         var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(),
                 new ArrayList<>(), new HashSet<>());
         String expected = OpenSearchUtils.getJsonString("/es/attributeListRequest.json");
+        String real = OpenSearchUtils.getPayload(attributeListQuery);
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(attributeListQuery), JSONCompareMode.LENIENT);
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -83,12 +83,29 @@ class ClassServiceTest {
         when(resourceService.mapUriLabels()).thenReturn(mock(Consumer.class));
 
         try(var mapper = mockStatic(ClassMapper.class)) {
-            classService.get("test", "TestClass");
+            classService.get("test", null, "TestClass");
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
-        verify(coreRepository).fetch(anyString());
+        verify(coreRepository).resourceExistsInGraph("http://uri.suomi.fi/datamodel/ns/test", "http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test");
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
+        verify(coreRepository).getOrganizations();
+    }
+
+    @Test
+    void getWithVersion() {
+        when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
+        when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
+        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+        when(resourceService.mapUriLabels()).thenReturn(mock(Consumer.class));
+
+        try(var mapper = mockStatic(ClassMapper.class)) {
+            classService.get("test", "1.0.1", "TestClass");
+        }
+
+        verify(coreRepository).resourceExistsInGraph("http://uri.suomi.fi/datamodel/ns/test/1.0.1", "http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test/1.0.1");
+        verify(authorizationManager).hasRightToModel(eq("test"), any(Model.class));
         verify(coreRepository).getOrganizations();
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -76,10 +76,21 @@ class DataModelServiceTest {
     void get() {
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
 
-        dataModelService.get("test");
+        dataModelService.get("test", null);
 
-        verify(coreRepository).fetch(anyString());
-        verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test");
+        verify(authorizationManager).hasRightToModel(eq("test"), any(Model.class));
+        verify(modelMapper).mapToDataModelDTO(anyString(), any(Model.class), eq(null));
+    }
+
+    @Test
+    void getWithVersion() {
+        when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
+
+        dataModelService.get("test", "1.0.1");
+
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test/1.0.1");
+        verify(authorizationManager).hasRightToModel(eq("test"), any(Model.class));
         verify(modelMapper).mapToDataModelDTO(anyString(), any(Model.class), eq(null));
     }
 
@@ -162,14 +173,14 @@ class DataModelServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
-        var response = dataModelService.export("test", null, "text/turtle");
+        var response = dataModelService.export("test", null, null, "text/turtle");
         assertNotNull(response.getBody());
         assertTrue(response.getBody().contains("test:TestClass"));
         assertTrue(response.getBody().contains("test:TestAttribute"));
         assertTrue(response.getBody().contains("test:TestAssociation"));
 
         //resource
-        response = dataModelService.export("test", "TestClass", "text/turtle");
+        response = dataModelService.export("test", null, "TestClass", "text/turtle");
         assertNotNull(response.getBody());
         assertTrue(response.getBody().contains("test:TestClass"));
         assertFalse(response.getBody().contains("test:TestAttribute"));
@@ -180,7 +191,7 @@ class DataModelServiceTest {
     void shouldGetModelWithAcceptHeader(String accept) {
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
 
-        var response = dataModelService.export("test", null, accept);
+        var response = dataModelService.export("test", null, null, accept);
         assertTrue(response.getStatusCode().is2xxSuccessful());
         //TODO can this be fixed
     }
@@ -190,7 +201,7 @@ class DataModelServiceTest {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(false);
-        var response = dataModelService.export("test", null, "text/turtle");
+        var response = dataModelService.export("test", null, null, "text/turtle");
         assertTrue(response.getStatusCode().is2xxSuccessful());
         assertNotNull(response.getBody());
         assertFalse(response.getBody().contains("skos:editorialNote"));
@@ -198,8 +209,9 @@ class DataModelServiceTest {
 
 
     @Test
-    void testCreateRelease(){
+    void testCreateRelease() throws URISyntaxException {
         var model = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
         //remove prior version property since we want to test without
         model.getResource("http://uri.suomi.fi/datamodel/ns/test").removeAll(OWL.priorVersion);
         when(coreRepository.fetch(anyString())).thenReturn(model);
@@ -209,6 +221,9 @@ class DataModelServiceTest {
 
         dataModelService.createRelease("test", "1.0.1", Status.VALID);
 
+
+        verify(coreRepository).fetch(anyString());
+        verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verify(modelMapper).mapReleaseProperties(model,
                 "http://uri.suomi.fi/datamodel/ns/test",
                 "1.0.1",
@@ -220,15 +235,15 @@ class DataModelServiceTest {
         verify(coreRepository).put(eq("http://uri.suomi.fi/datamodel/ns/test/1.0.1"), any(Model.class));
         verify(coreRepository).put(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
 
-        verify(modelMapper, times(2)).mapToIndexModel(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
+        verify(modelMapper).mapToIndexModel(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
         verify(openSearchIndexer).createModelToIndex(any(IndexModel.class));
-        verify(openSearchIndexer).updateModelToIndex(any(IndexModel.class));
     }
 
     @Test
     void testCreateReleaseInvalidVersions(){
         var model = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
         when(coreRepository.fetch(anyString())).thenReturn(model);
+        when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
         var error = assertThrows(MappingError.class ,() -> dataModelService.createRelease("test", "not valid semver", Status.VALID));
         assertEquals("Error during mapping: Not valid Semantic version string", error.getMessage());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -59,6 +59,9 @@ class DataModelServiceTest {
     TerminologyService terminologyService;
 
     @MockBean
+    VisualizationService visualizationService;
+
+    @MockBean
     CodeListService codeListService;
 
     @MockBean
@@ -237,6 +240,7 @@ class DataModelServiceTest {
 
         verify(modelMapper).mapToIndexModel(eq("http://uri.suomi.fi/datamodel/ns/test"), any(Model.class));
         verify(openSearchIndexer).createModelToIndex(any(IndexModel.class));
+        verify(visualizationService).saveVersionedPositions("test", "1.0.1");
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -85,13 +85,32 @@ class ResourceServiceTest {
         when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
 
         try(var mapper = mockStatic(ResourceMapper.class)) {
-            resourceService.get("test", "TestClass");
+            resourceService.get("test", null, "TestResource");
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
-        verify(coreRepository).fetch(anyString());
-        verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
+        verify(coreRepository).resourceExistsInGraph("http://uri.suomi.fi/datamodel/ns/test", "http://uri.suomi.fi/datamodel/ns/test/TestResource");
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test");
+        verify(authorizationManager).hasRightToModel(eq("test"), any(Model.class));
         verify(coreRepository).getOrganizations();
+
+    }
+
+    @Test
+    void getWithVersion() {
+        when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
+        when(coreRepository.fetch(anyString())).thenReturn(EndpointUtils.getMockModel(OWL.Ontology));
+        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+
+        try(var mapper = mockStatic(ResourceMapper.class)) {
+            resourceService.get("test", "1.0.1", "TestResource");
+        }
+
+
+        verify(coreRepository).resourceExistsInGraph("http://uri.suomi.fi/datamodel/ns/test/1.0.1", "http://uri.suomi.fi/datamodel/ns/test/TestResource");
+        verify(coreRepository).fetch("http://uri.suomi.fi/datamodel/ns/test/1.0.1");
+        verify(authorizationManager).hasRightToModel(eq("test"), any(Model.class));
+        verify(coreRepository).getOrganizations();
+
     }
 
     @ParameterizedTest

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -55,7 +55,7 @@ class VisualizationServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "test")).thenReturn(positionModel);
 
-        var visualizationData = visualizationService.getVisualizationData("test");
+        var visualizationData = visualizationService.getVisualizationData("test", null);
 
         // should contain 3 classes, 2 references to external models and two attribute references (rdfs:domain)
         assertEquals(7, visualizationData.getNodes().size());
@@ -79,7 +79,7 @@ class VisualizationServiceTest {
         when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "visuprof")).thenReturn(positionModel);
         when(resourceService.findResources(anySet())).thenReturn(externalPropertiesModel);
 
-        var visualizationData = visualizationService.getVisualizationData("visuprof");
+        var visualizationData = visualizationService.getVisualizationData("visuprof", null);
 
         assertEquals(3, visualizationData.getNodes().size());
 
@@ -120,12 +120,25 @@ class VisualizationServiceTest {
 
         visualizationService.savePositionData("test-model", List.of(positionData));
 
-        verify(coreRepository).delete(graphURI);
         verify(coreRepository).put(eq(graphURI), modelCaptor.capture());
 
         var resourceURI = graphURI + ModelConstants.RESOURCE_SEPARATOR + positionData.getIdentifier();
         var resource = modelCaptor.getValue().getResource(resourceURI);
         assertEquals("pos-1", resource.getProperty(DCTerms.identifier).getString());
+    }
+
+    @Test
+    void saveVersionedPositions() {
+        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+        when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
+        when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+
+        visualizationService.saveVersionedPositions("test-model", "1.0.0");
+
+        verify(coreRepository).fetch(graphURI);
+        verify(coreRepository).put(eq(graphURI + ModelConstants.RESOURCE_SEPARATOR + "1.0.0"), any(Model.class));
+
+
     }
 
     private static Model getExternalPropertiesResult() {

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -30,7 +30,14 @@
               "ATTRIBUTE"
             ]
           }
-        }
+        },
+        { "bool": {
+          "must_not": [{
+            "exists": {
+              "field": "fromVersion"
+            }
+          }]
+        } }
       ],
       "should": [
         {

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -47,7 +47,14 @@
               }
             ]
           }
-        }
+        },
+        { "bool": {
+          "must_not": [{
+            "exists": {
+              "field": "fromVersion"
+            }
+          }]
+        } }
       ],
       "should": [
         {

--- a/src/test/resources/models/test_datamodel_library_version.ttl
+++ b/src/test/resources/models/test_datamodel_library_version.ttl
@@ -1,0 +1,38 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix ext:     <https://www.example.com/ns/ext> .
+@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+
+<http://uri.suomi.fi/datamodel/ns/test>
+        a                               owl:Ontology ;
+        rdfs:comment                    "test desc"@fi ;
+        rdfs:label                      "testlabel"@fi ;
+        dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+        dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
+        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+        dcterms:language                "fi" ;
+        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/terminology/test> ;
+        dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespacePrefix
+                "test" ;
+        iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+        owl:versionInfo                 "VALID", "1.0.1" ;
+        iow:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        iow:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        iow:contact                     "test@localhost"                       ;
+        iow:documentation               "hello\ntest"@fi                       ;
+        rdfs:seeAlso                    [
+                                            dcterms:description "link description" ;
+                                            dcterms:title       "link title" ;
+                                            foaf:homepage       "https://example.com"
+                                        ] ;
+        owl:versionIRI                  "http://uri.suomi.fi/datamodel/ns/test/1.0.1" ;
+        owl:priorVersion                "http://uri.suomi.fi/datamodel/ns/test/1.0.0" .

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -26,7 +26,7 @@ dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-owl:versionInfo                 "VALID" .
+owl:versionInfo                 "VALID", "1.0.1".
 
 <https://www.example.com/ns/ext>
 dcterms:type                        rdfs:Resource ;


### PR DESCRIPTION
Changelog:

**Endpoints**
- All get endpoints can now optionally get a certain version of a datamodel or its resource

**DTO**
- Model Info DTO with version info

**Indexing**
- Change resource indexing to have version info so its possible to filter resources based on version
- Initial indexing for resources changed to now get the datamodel and list subjects instead of trying to build a single datamodel of all resources

**QueryFactory**
- From Version possible for resource queries
- Made Sort by lang into generic function in util class


**Create release**
- Now returns versionIri and 201
- Don't reindex DRAFT version since nothing indexable changes 