### PR TITLE
YTI-3191 fix handling owl:equivalentClass

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -133,7 +133,12 @@ public class ClassMapper {
         var dcTermsRequires = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires);
 
         var equivalentClasses = classDTO.getEquivalentClass();
-        classResource.removeAll(OWL.equivalentClass);
+
+        var eqProps = classResource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .toList();
+        model.remove(eqProps);
+
         equivalentClasses.forEach(eq -> MapperUtils.addResourceRelationship(owlImports, dcTermsRequires, classResource, OWL.equivalentClass, eq));
 
         var subClassOf = classDTO.getSubClassOf();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -133,6 +133,7 @@ public class MapperUtils {
         }catch(JenaException ex){
             //if item could not be gotten as list it means it is multiple statements of the property
             resource.listProperties(property)
+                    .filterDrop(p -> p.getObject().isAnon())
                     .forEach(val -> list.add(val.getObject().toString()));
         }
         return list;

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -183,7 +183,9 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .next().getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
@@ -197,7 +199,9 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .next().getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.RETIRED.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
@@ -206,6 +210,9 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
+
+        // class restrictions added to owl:equivalentClass property should remain
+        assertEquals(1, resource.listProperties(OWL.equivalentClass).filterKeep(p -> p.getObject().isAnon()).toList().size());
     }
 
     // null values should delete (some) properties from resource
@@ -223,7 +230,9 @@ class ClassMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .next().getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals(Status.VALID.name(), resource.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
@@ -256,7 +265,9 @@ class ClassMapperTest {
         dto.setNote(Collections.emptyMap());
 
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.getProperty(OWL.equivalentClass).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqClass", resource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .next().getObject().toString());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
@@ -264,7 +275,9 @@ class ClassMapperTest {
         ClassMapper.mapToUpdateOntologyClass(m, "http://uri.suomi.fi/datamodel/ns/test", resource, dto, mockUser);
 
         assertNull(resource.getProperty(DCTerms.subject));
-        assertNull(resource.getProperty(OWL.equivalentClass));
+        assertEquals(0, resource.listProperties(OWL.equivalentClass)
+                .filterDrop(p -> p.getObject().isAnon())
+                .toList().size());
         //OWl thing is default value if all subClassOf is emptied
         assertEquals(OWL.Thing, resource.getProperty(RDFS.subClassOf).getResource());
         assertNull(resource.getProperty(SKOS.editorialNote));

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -46,7 +46,16 @@ test:TestClass  rdf:type     owl:Class ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test note fi"@fi, "test note en"@en ;
         iow:creator           "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        iow:modifier          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" .
+        iow:modifier          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        owl:equivalentClass
+                [ rdf:type       owl:Class ;
+                  owl:intersectionOf   ([
+                                                rdf:type  owl:Restriction ;
+                                                owl:onProperty      test:TestAttribute ;
+                                                owl:someValuesFrom  <xsd:string>
+                                        ]
+                                 )
+                ] .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;


### PR DESCRIPTION
When handling class's owl:equivalentClass resource, check that the object is not anonymous