### PR TITLE
YTI-3125 old data migration

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
@@ -38,8 +39,11 @@ public class RestConfig {
 
     @Bean("uriResolveClient")
     WebClient uriResolveClient() {
+        var size = 20 * 1024 * 1024;
         return WebClient.builder()
                 .defaultHeaders(headers -> headers.addAll(defaultHttpHeaders))
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size)).build())
                 .baseUrl(URI_SUOMI_FI)
                 .clientConnector(new ReactorClientHttpConnector(
                                 HttpClient.create(getConnectionProvider("uriResolve"))

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/DataMigrationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/DataMigrationController.java
@@ -1,0 +1,61 @@
+package fi.vm.yti.datamodel.api.migration;
+
+import fi.vm.yti.datamodel.api.security.AuthorizationManager;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static fi.vm.yti.security.AuthorizationException.check;
+
+@RestController
+@RequestMapping("v2/migration")
+public class DataMigrationController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataMigrationController.class);
+
+    @Value("${datamodel.v1.migration.url:https://tietomallit.dev.yti.cloud.dvv.fi}")
+    String serviceURL;
+
+    private final V1DataMigrationService migrationService;
+    private final AuthorizationManager authorizationManager;
+
+    public DataMigrationController(V1DataMigrationService migrationService,
+                                   AuthorizationManager authorizationManager) {
+        this.migrationService = migrationService;
+        this.authorizationManager = authorizationManager;
+    }
+
+    @GetMapping
+    public void migrate(@RequestParam String prefix) {
+        check(authorizationManager.hasRightToDoMigration());
+
+        var oldData = ModelFactory.createDefaultModel();
+
+        /*
+        var stream = getClass().getResourceAsStream("/merialsuun_simple.ttl");
+        RDFDataMgr.read(oldData, stream, RDFLanguages.TURTLE);
+        */
+
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        RDFParser.create()
+                .source(serviceURL + "/datamodel-api/api/v1/exportModel?graph=" + DataModelUtils.encode(modelURI))
+                .lang(Lang.JSONLD)
+                .acceptHeader("application/ld+json")
+                .parse(oldData);
+
+        try {
+            migrationService.migrateLibrary(prefix, oldData);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMapper.java
@@ -1,0 +1,138 @@
+package fi.vm.yti.datamodel.api.migration;
+
+import fi.vm.yti.datamodel.api.v2.dto.*;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.*;
+import org.topbraid.shacl.vocabulary.SH;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class V1DataMapper {
+
+    private V1DataMapper() {}
+
+    private static final Property DOCUMENTATION =
+            ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#documentation");
+
+    public static DataModelDTO getLibraryMetadata(String modelURI, Model oldData, Model serviceCategories, String defaultOrganization) {
+        var modelResource = oldData.getResource(modelURI);
+        var dto = new DataModelDTO();
+        dto.setPrefix(MapperUtils.getLiteral(modelResource, DCAP.preferredXMLNamespacePrefix, String.class));
+        dto.setLabel(MapperUtils.localizedPropertyToMap(modelResource, RDFS.label));
+        dto.setDescription(MapperUtils.localizedPropertyToMap(modelResource, RDFS.comment));
+        dto.setStatus(Status.DRAFT);
+
+        var groups = new HashSet<String>();
+        MapperUtils.arrayPropertyToSet(modelResource, DCTerms.isPartOf)
+                .forEach(g -> groups.add(MapperUtils.propertyToString(serviceCategories.getResource(g), SKOS.notation)));
+        dto.setGroups(groups);
+
+        if (defaultOrganization == null || defaultOrganization.isBlank()) {
+            var org = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.contributor).stream()
+                .map(o -> UUID.fromString(o.replace("urn:uuid:", "")))
+                .collect(Collectors.toSet());
+            dto.setOrganizations(org);
+        } else {
+            dto.setOrganizations(Set.of(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
+        }
+
+        var languages = MapperUtils.getList(oldData, modelResource, DCTerms.language)
+                .asJavaList().stream()
+                .map(l -> l.asLiteral().getString())
+                .collect(Collectors.toSet());
+        dto.setLanguages(languages);
+
+        dto.setTerminologies(MapperUtils.arrayPropertyToSet(modelResource, DCTerms.references));
+
+        var internalNamespaces = new HashSet<String>();
+        var externalNamespaces = new HashSet<ExternalNamespaceDTO>();
+
+        MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires)
+                .forEach(ns -> {
+                    if (!ns.contains("uri.suomi.fi")) {
+                        var extResource = oldData.getResource(ns);
+                        var ext = new ExternalNamespaceDTO();
+                        ext.setNamespace(ns);
+                        ext.setName(MapperUtils.localizedPropertyToMap(extResource, RDFS.label).entrySet().iterator().next().getValue());
+                        ext.setPrefix(MapperUtils.propertyToString(extResource, DCAP.preferredXMLNamespacePrefix));
+                        externalNamespaces.add(ext);
+                    }
+                });
+
+        dto.setInternalNamespaces(internalNamespaces);
+        dto.setExternalNamespaces(externalNamespaces);
+
+        if (modelResource.hasProperty(DCTerms.relation)) {
+            var links = MapperUtils.getList(oldData, modelResource, DCTerms.relation).asJavaList().stream().map(link -> {
+                var linkDTO = new LinkDTO();
+                var title = MapperUtils.localizedPropertyToMap(link.asResource(), DCTerms.title);
+                var description = MapperUtils.localizedPropertyToMap(link.asResource(), DCTerms.description);
+                linkDTO.setUri(MapperUtils.propertyToString(link.asResource(), FOAF.homepage));
+                linkDTO.setName(title.isEmpty() ? "" : title.entrySet().iterator().next().getValue());
+                linkDTO.setDescription(description.isEmpty() ? "" : description.entrySet().iterator().next().getValue());
+                return linkDTO;
+            }).collect(Collectors.toSet());
+            dto.setLinks(links);
+        }
+
+        dto.setDocumentation(MapperUtils.localizedPropertyToMap(modelResource, DOCUMENTATION));
+
+        return dto;
+    }
+
+    public static ClassDTO mapLibraryClass(Resource classResource) {
+        var dto = new ClassDTO();
+        mapCommon(dto, classResource);
+        dto.setLabel(MapperUtils.localizedPropertyToMap(classResource, SH.name));
+        dto.setNote(MapperUtils.localizedPropertyToMap(classResource, SH.description));
+        var subClasses = MapperUtils.arrayPropertyToSet(classResource, RDFS.subClassOf).stream()
+                .map(V1DataMapper::fixNamespace)
+                .collect(Collectors.toSet());
+        dto.setSubClassOf(subClasses);
+        return dto;
+    }
+
+    public static ResourceDTO mapLibraryResource(Resource resource) {
+        var dto = new ResourceDTO();
+        mapCommon(dto, resource);
+        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+        dto.setNote(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
+        var range = fixNamespace(MapperUtils.propertyToString(resource, RDFS.range));
+
+        if (MapperUtils.hasType(resource, OWL.DatatypeProperty) && range != null) {
+            range = range.replace(ModelConstants.PREFIXES.get("rdf"), "rdf:");
+            range = range.replace(ModelConstants.PREFIXES.get("rdfs"), "rdfs:");
+            range = range.replace(ModelConstants.PREFIXES.get("owl"), "owl:");
+        }
+        dto.setRange(range);
+        return dto;
+    }
+
+    public static List<Resource> findResourcesByType(Model oldData, Resource type) {
+            return oldData.listSubjectsWithProperty(RDF.type, type)
+                    .mapWith(s -> oldData.getResource(s.getURI()))
+                    .toList();
+    }
+
+    private static void mapCommon(BaseDTO dto, Resource resource) {
+        dto.setIdentifier(resource.getLocalName());
+        dto.setStatus(Status.DRAFT);
+        dto.setEditorialNote(MapperUtils.propertyToString(resource, SKOS.editorialNote));
+        dto.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
+    }
+
+    private static String fixNamespace(String uri) {
+        if (uri != null && uri.contains("uri.suomi.fi")) {
+            return uri.replace("#", ModelConstants.RESOURCE_SEPARATOR);
+        } else if (uri != null) {
+            return uri.replace("http://www.w3.org/2001/XMLSchema#", "xsd:");
+        }
+        return uri;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
@@ -1,0 +1,250 @@
+package fi.vm.yti.datamodel.api.migration;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import fi.vm.yti.datamodel.api.v2.dto.Iow;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.ModelType;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
+import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.service.ClassService;
+import fi.vm.yti.datamodel.api.v2.service.DataModelService;
+import fi.vm.yti.datamodel.api.v2.service.ResourceService;
+import org.apache.jena.arq.querybuilder.UpdateBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.util.ResourceUtils;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDFS;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.topbraid.shacl.vocabulary.SH;
+
+import java.net.URISyntaxException;
+import java.util.Set;
+
+@Service
+public class V1DataMigrationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(V1DataMigrationService.class);
+    public static final String URI_SUOMI_FI = "uri.suomi.fi";
+
+    private final DataModelService dataModelService;
+    private final ClassService classService;
+    private final ResourceService resourceService;
+    private final CoreRepository coreRepository;
+
+    private final LoadingCache<String, Model> modelCache = CacheBuilder.newBuilder().build(getLoader());
+
+    @Value("${datamodel.v1.migration.defaultOrganization:}")
+    private String defaultOrganization;
+
+    public V1DataMigrationService(DataModelService dataModelService,
+                                  ClassService classService,
+                                  ResourceService resourceService,
+                                  CoreRepository coreRepository) {
+        this.dataModelService = dataModelService;
+        this.classService = classService;
+        this.resourceService = resourceService;
+        this.coreRepository = coreRepository;
+    }
+
+    public void migrateLibrary(String prefix, Model oldData) throws URISyntaxException {
+
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
+        var groupModel = coreRepository.getServiceCategories();
+        var dataModel = V1DataMapper.getLibraryMetadata(modelURI, oldData, groupModel, defaultOrganization);
+
+        Resource modelResource = oldData.getResource(modelURI);
+
+        if (!MapperUtils.hasType(modelResource,
+                ResourceFactory.createProperty("http://purl.org/ws-mmi-dc/terms/MetadataVocabulary"))) {
+            throw new RuntimeException("Not a library");
+        }
+
+        // create data model
+        var dataModelURI = dataModelService.create(dataModel, ModelType.LIBRARY);
+
+        updateRequires(modelURI, modelResource);
+        handleModifiedInfo(modelURI, modelResource);
+
+        LOG.info("Created datamodel {}", dataModelURI);
+
+        // create classes
+        handleAddResources(prefix, oldData, modelURI, ResourceType.CLASS);
+
+        // create attributes and associations
+        handleAddResources(prefix, oldData, modelURI, ResourceType.ATTRIBUTE);
+        handleAddResources(prefix, oldData, modelURI, ResourceType.ASSOCIATION);
+
+        // add class restrictions
+        handleRestrictions(oldData, modelURI);
+    }
+
+    private void handleRestrictions(Model oldData, String modelURI) {
+        var newModel = coreRepository.fetch(modelURI);
+        V1DataMapper.findResourcesByType(oldData, RDFS.Class).forEach(cls -> {
+
+            if (!includesToModel(modelURI, cls)) {
+                return;
+            }
+
+            var classResource = newModel.getResource(cls.getURI().replace("#", ModelConstants.RESOURCE_SEPARATOR));
+            MapperUtils.arrayPropertyToList(cls, SH.property).forEach(property -> {
+                var restrictionRes = oldData.getResource(property);
+                var path = MapperUtils.propertyToString(restrictionRes, SH.path);
+                if (path == null) {
+                    return;
+                }
+
+                Resource targetRes;
+                var ns = NodeFactory.createURI(path).getNameSpace().replace("#", "");
+
+                if (ns.contains(URI_SUOMI_FI)) {
+                    Resource temp;
+                    if (ns.equals(modelURI)) {
+                        // current model
+                        temp = oldData.getResource(path);
+                    } else {
+                        // reference to other model in Interoperability platform
+                        temp = modelCache.getUnchecked(ns).getResource(path);
+                        if (temp == null) {
+                            LOG.info("Resource {} not found from cached models", path);
+                            return;
+                        }
+                        var range = MapperUtils.propertyToString(temp, RDFS.range);
+
+                        if (range != null && range.contains(URI_SUOMI_FI)) {
+                            temp.removeAll(RDFS.range);
+                            temp.addProperty(RDFS.range, ResourceFactory.createResource(range.replace("#", ModelConstants.RESOURCE_SEPARATOR)));
+                        }
+                    }
+                    if (temp.getURI().contains("#")) {
+                        targetRes = ResourceUtils.renameResource(temp, temp.getURI().replace("#", ModelConstants.RESOURCE_SEPARATOR));
+                    } else {
+                        targetRes = temp;
+                    }
+                } else {
+                    // reference to external resource
+                    targetRes = resourceService.findResources(Set.of(path)).getResource(path);
+                }
+
+                LOG.info("add restriction {} to class {}", targetRes.getURI(), classResource.getURI());
+                ClassMapper.mapClassRestrictionProperty(newModel, classResource, targetRes);
+            });
+        });
+        coreRepository.put(modelURI, newModel);
+    }
+
+    private void handleAddResources(String prefix, Model oldData, String modelURI, ResourceType type) {
+        Resource property;
+
+        if (type.equals(ResourceType.ASSOCIATION)) {
+            property = OWL.ObjectProperty;
+        } else if (type.equals(ResourceType.ATTRIBUTE)) {
+            property = OWL.DatatypeProperty;
+        } else {
+            property = RDFS.Class;
+        }
+
+        V1DataMapper.findResourcesByType(oldData, property).forEach(resource -> {
+            if (!includesToModel(modelURI, resource)) {
+                LOG.info("Skip external resource {} added directly to the model", resource.getURI());
+                return;
+            }
+
+            try {
+                if (type.equals(ResourceType.CLASS)) {
+                    var dto = V1DataMapper.mapLibraryClass(resource);
+                    var classURI = classService.create(prefix, dto, false);
+                    LOG.info("Created class {}", classURI);
+                } else {
+                    var dto = V1DataMapper.mapLibraryResource(resource);
+                    var resourceURI = resourceService.create(prefix, dto, type, false);
+                    LOG.info("Created resource {}", resourceURI);
+                }
+                handleModifiedInfo(modelURI, oldData.getResource(modelURI));
+            } catch (Exception e) {
+                LOG.error("Error creating class {} to model {}: {}", resource.getURI(), modelURI, e.getMessage());
+            }
+        });
+    }
+
+    private CacheLoader<String, Model> getLoader() {
+
+        return new CacheLoader<>() {
+            @Override
+            public @NotNull Model load(@NotNull String ns) {
+                try {
+                    LOG.info("Try to fetch model {} from Fuseki", ns);
+                    return coreRepository.fetch(ns);
+                } catch (Exception e) {
+                    LOG.info("Model not exists {}", ns);
+                }
+                var temp = ModelFactory.createDefaultModel();
+                LOG.info("Fetch reference datamodel and add to cache {}", ns);
+                RDFParser.create()
+                        .source(ns)
+                        .lang(Lang.JSONLD)
+                        .acceptHeader("application/ld+json")
+                        .parse(temp);
+                return temp;
+            }
+        };
+    }
+
+    private static boolean includesToModel(String modelURI, Resource resource) {
+        return modelURI.equals(MapperUtils.propertyToString(resource, RDFS.isDefinedBy));
+    }
+
+    private void updateRequires(String modelURI, Resource modelResource) {
+        var builder = new UpdateBuilder();
+        var g = NodeFactory.createURI(modelURI);
+        MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires)
+                .forEach(ns -> {
+                    if (ns.contains(URI_SUOMI_FI)) {
+                        builder.addInsert(g, g, DCTerms.requires, NodeFactory.createURI(ns));
+                    }
+                });
+        coreRepository.queryUpdate(builder.buildRequest());
+    }
+
+    public void handleModifiedInfo(String modelURI, Resource resource) {
+        var graph = NodeFactory.createURI(modelURI);
+
+        var builder = new UpdateBuilder();
+        builder.addPrefixes(ModelConstants.PREFIXES);
+
+        var created = resource.getProperty(DCTerms.created).getLiteral().getString();
+        var modified = resource.getProperty(DCTerms.modified).getLiteral().getString();
+
+        builder.addDelete(graph, "?s", DCTerms.created, "?created")
+                .addDelete(graph, "?s", DCTerms.modified, "?modified")
+                .addDelete(graph, "?s", Iow.creator, "?creator")
+                .addDelete(graph, "?s", Iow.modifier, "?modifier")
+                .addInsert(graph, "?s", DCTerms.created, created)
+                .addInsert(graph, "?s", DCTerms.modified, modified)
+                .addGraph(graph, new WhereBuilder()
+                        .addWhere("?s", DCTerms.created, "?created")
+                        .addWhere("?s", DCTerms.modified, "?modified")
+                        .addWhere("?s", Iow.creator, "?creator")
+                        .addWhere("?s", Iow.modifier, "?modifier"));
+
+        LOG.info("Add created {} and modified {} for resource {}", created, modified, resource.getURI());
+
+        coreRepository.queryUpdate(builder.buildRequest());
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -400,12 +400,6 @@ public class ClassMapper {
         if (existingEqClassResource.hasNext()) {
             var res = existingEqClassResource.next();
             rdfList = MapperUtils.getList(model, res, OWL.intersectionOf);
-
-            if (rdfList.asJavaList().stream()
-                    .anyMatch(r -> r.asResource().getProperty(OWL.onProperty).getObject().equals(propertyResource))) {
-                throw new MappingError(String.format("Property %s already added", propertyResource.getURI()));
-            }
-
             rdfList.add(restrictionResource);
         } else {
             Resource equvalentClassResource = model.createResource();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -349,12 +349,16 @@ public class ModelMapper {
                 .forEach(prop -> {
             var ns = prop.getObject().toString();
             if(ns.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)){
-                var nsModel = coreRepository.fetch(ns);
-                var nsResource = nsModel.getResource(ns);
                 var dto = new InternalNamespaceDTO();
-                dto.setNamespace(ns);
-                dto.setPrefix(MapperUtils.propertyToString(nsResource, DCAP.preferredXMLNamespacePrefix));
-                dto.setName(MapperUtils.localizedPropertyToMap(nsResource, RDFS.label));
+                try {
+                    var nsModel = coreRepository.fetch(ns);
+                    var nsResource = nsModel.getResource(ns);
+                    dto.setNamespace(ns);
+                    dto.setPrefix(MapperUtils.propertyToString(nsResource, DCAP.preferredXMLNamespacePrefix));
+                    dto.setName(MapperUtils.localizedPropertyToMap(nsResource, RDFS.label));
+                } catch (Exception e) {
+                    dto.setNamespace(ns);
+                }
                 intNs.add(dto);
             }else {
                 var extNsModel = model.getResource(ns);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -155,7 +155,11 @@ public class VisualizationMapper {
             var dto = new VisualizationReferenceDTO();
             var target = MapperUtils.propertyToString(resource, RDFS.range);
             mapCommon(dto, resource, namespaces);
-            dto.setReferenceTarget(getReferenceIdentifier(target, namespaces));
+            if (target == null) {
+                dto.setReferenceTarget(MapperUtils.uriToURIDTO(resource.getURI(), model).getCurie());
+            } else {
+                dto.setReferenceTarget(getReferenceIdentifier(target, namespaces));
+            }
             return dto;
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -155,11 +155,7 @@ public class VisualizationMapper {
             var dto = new VisualizationReferenceDTO();
             var target = MapperUtils.propertyToString(resource, RDFS.range);
             mapCommon(dto, resource, namespaces);
-            if (target == null) {
-                dto.setReferenceTarget(MapperUtils.uriToURIDTO(resource.getURI(), model).getCurie());
-            } else {
-                dto.setReferenceTarget(getReferenceIdentifier(target, namespaces));
-            }
+            dto.setReferenceTarget(getReferenceIdentifier(target, namespaces));
             return dto;
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -14,6 +14,7 @@ import org.apache.jena.arq.querybuilder.AskBuilder;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.*;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -250,19 +251,23 @@ public class ResourceService {
         var importsBuilder = new ConstructBuilder()
                 .addPrefixes(ModelConstants.PREFIXES);
 
+        var predicates = List.of(RDFS.isDefinedBy, DCTerms.identifier, RDF.type, RDFS.label,
+                RDFS.range, SH.path, SH.datatype, SH.minCount, SH.maxCount);
+
         var iterator = resourceURIs.iterator();
         var count = 0;
         while (iterator.hasNext()) {
-            var pred = "?p" + count;
-            var obj = "?o" + count;
             String uri = iterator.next();
             var resource = ResourceFactory.createResource(uri);
-            if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
-                coreBuilder.addConstruct(resource, pred, obj);
-                coreBuilder.addOptional(resource, pred, obj);
-            } else {
-                importsBuilder.addConstruct(resource, pred, obj);
-                importsBuilder.addOptional(resource, pred, obj);
+            for (var pred : predicates) {
+                var obj = "?" + pred.getLocalName() + count;
+                if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
+                    coreBuilder.addConstruct(resource, pred, obj);
+                    coreBuilder.addOptional(resource, pred, obj);
+                } else {
+                    importsBuilder.addConstruct(resource, pred, obj);
+                    importsBuilder.addOptional(resource, pred, obj);
+                }
             }
             count++;
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -251,8 +251,9 @@ public class ResourceService {
         var importsBuilder = new ConstructBuilder()
                 .addPrefixes(ModelConstants.PREFIXES);
 
+        // TODO: resource type specific list of properties?
         var predicates = List.of(RDFS.isDefinedBy, DCTerms.identifier, RDF.type, RDFS.label,
-                RDFS.range, SH.path, SH.datatype, SH.minCount, SH.maxCount);
+                RDFS.range, DCTerms.subject, SH.path, SH.datatype, SH.minCount, SH.maxCount);
 
         var iterator = resourceURIs.iterator();
         var count = 0;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -75,7 +75,7 @@ public class TerminologyService {
 
                 if (node.isPresent()) {
                     var model = TerminologyMapper.mapTerminologyToJenaModel(u, node.get());
-                    conceptRepository.put(uri.toString(), model);
+                    conceptRepository.put(uri.toString().replaceAll("/?$", ""), model);
                 } else {
                     LOG.warn("Could not find node with type TerminologicalVocabulary from {}", uri);
                 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/TerminologyService.java
@@ -74,8 +74,9 @@ public class TerminologyService {
                         .findFirst();
 
                 if (node.isPresent()) {
-                    var model = TerminologyMapper.mapTerminologyToJenaModel(u, node.get());
-                    conceptRepository.put(uri.toString().replaceAll("/?$", ""), model);
+                    var terminologyURI = u.replaceAll("/?$", "");
+                    var model = TerminologyMapper.mapTerminologyToJenaModel(terminologyURI, node.get());
+                    conceptRepository.put(terminologyURI, model);
                 } else {
                     LOG.warn("Could not find node with type TerminologicalVocabulary from {}", uri);
                 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
@@ -1,0 +1,91 @@
+package fi.vm.yti.datamodel.api.v2.migration;
+
+import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.migration.V1DataMigrationService;
+import fi.vm.yti.datamodel.api.v2.dto.*;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.service.ClassService;
+import fi.vm.yti.datamodel.api.v2.service.DataModelService;
+import fi.vm.yti.datamodel.api.v2.service.ResourceService;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        V1DataMigrationService.class
+})
+class DataMigrationTest {
+
+    @MockBean
+    DataModelService dataModelService;
+    @MockBean
+    ClassService classService;
+    @MockBean
+    ResourceService resourceService;
+    @MockBean
+    CoreRepository coreRepository;
+
+    @Captor
+    ArgumentCaptor<DataModelDTO> dataModelCaptor;
+    @Captor
+    ArgumentCaptor<BaseDTO> baseDtoCaptor;
+    @Captor
+    ArgumentCaptor<Model> modelCaptor;
+
+    @Autowired
+    V1DataMigrationService migrationService;
+
+    @Test
+    void testLibraryMigration() throws URISyntaxException {
+        var modelURI = "http://uri.suomi.fi/datamodel/ns/merialsuun";
+        var prefix = "merialsuun";
+
+        when(coreRepository.getServiceCategories())
+                .thenReturn(MapperTestUtils.getModelFromFile("/service-categories.ttl"));
+        var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
+
+        // external model (tihatos)
+        var refModel = ModelFactory.createDefaultModel();
+        var refResource = refModel.getResource("http://uri.suomi.fi/datamodel/ns/tihatos#kohdistuu");
+        refResource.addProperty(RDFS.range, "http://uri.suomi.fi/datamodel/ns/tihatos#Asia");
+        when(coreRepository.fetch("http://uri.suomi.fi/datamodel/ns/tihatos")).thenReturn(refModel);
+
+        var newModel = ModelFactory.createDefaultModel();
+        newModel.createResource(modelURI + ModelConstants.RESOURCE_SEPARATOR + "MerialuesuunnitelmanKohde");
+        newModel.createResource(modelURI + ModelConstants.RESOURCE_SEPARATOR + "Lahtotietoaineisto");
+        when(coreRepository.fetch(modelURI)).thenReturn(newModel);
+
+        migrationService.migrateLibrary(prefix, oldData);
+
+        verify(dataModelService).create(dataModelCaptor.capture(), eq(ModelType.LIBRARY));
+        verify(classService, times(2)).create(eq(prefix), baseDtoCaptor.capture(), eq(false));
+        verify(resourceService).create(eq(prefix), baseDtoCaptor.capture(), eq(ResourceType.ATTRIBUTE), eq(false));
+        verify(resourceService).create(eq(prefix), baseDtoCaptor.capture(), eq(ResourceType.ASSOCIATION), eq(false));
+        verify(coreRepository).put(eq(modelURI), modelCaptor.capture());
+
+        assertEquals(prefix, dataModelCaptor.getValue().getPrefix());
+
+        var resourcePrefixes = baseDtoCaptor.getAllValues().stream().map(BaseDTO::getIdentifier).toList();
+
+        assertEquals(4, resourcePrefixes.size());
+        assertTrue(resourcePrefixes.containsAll(List.of("koostuu", "kohdenimi", "Lahtotietoaineisto", "MerialuesuunnitelmanKohde")));
+
+        // Class Lahtotietoaineisto should have property owl:equivalentClass containing class restrictions
+        assertTrue(modelCaptor.getValue().getResource(modelURI + "/Lahtotietoaineisto").hasProperty(OWL.equivalentClass));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
@@ -14,6 +14,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Import({
         V1DataMigrationService.class
 })
+@Disabled
 class DataMigrationTest {
 
     @MockBean

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
@@ -7,8 +7,11 @@ import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import fi.vm.yti.datamodel.api.v2.service.ClassService;
 import fi.vm.yti.datamodel.api.v2.service.DataModelService;
 import fi.vm.yti.datamodel.api.v2.service.ResourceService;
+import fi.vm.yti.datamodel.api.v2.service.VisualizationService;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.Test;
@@ -39,7 +42,8 @@ class DataMigrationTest {
     ResourceService resourceService;
     @MockBean
     CoreRepository coreRepository;
-
+    @MockBean
+    VisualizationService visualizationService;
     @Captor
     ArgumentCaptor<DataModelDTO> dataModelCaptor;
     @Captor
@@ -86,6 +90,9 @@ class DataMigrationTest {
         assertTrue(resourcePrefixes.containsAll(List.of("koostuu", "kohdenimi", "Lahtotietoaineisto", "MerialuesuunnitelmanKohde")));
 
         // Class Lahtotietoaineisto should have property owl:equivalentClass containing class restrictions
-        assertTrue(modelCaptor.getValue().getResource(modelURI + "/Lahtotietoaineisto").hasProperty(OWL.equivalentClass));
+        var result = modelCaptor.getValue();
+        assertTrue(result.getResource(modelURI + "/Lahtotietoaineisto").hasProperty(OWL.equivalentClass));
+
+        RDFDataMgr.write(System.out, result, RDFFormat.TURTLE);
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
@@ -1,0 +1,106 @@
+package fi.vm.yti.datamodel.api.v2.migration;
+
+import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.migration.V1DataMapper;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class V1DataMapperTest {
+
+    public static final String GRAPH_URI = "http://uri.suomi.fi/datamodel/ns/merialsuun";
+
+    @Test
+    void testMapOldLibraryMetadata() {
+
+        var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
+        var serviceCategories = MapperTestUtils.getModelFromFile("/service-categories.ttl");
+        var result = V1DataMapper.getLibraryMetadata(GRAPH_URI, oldData, serviceCategories, null);
+
+        assertEquals("merialsuun", result.getPrefix());
+        assertEquals("Merialuesuunnitelma", result.getLabel().get("fi"));
+        assertEquals(Set.of("fi", "sv", "en"), result.getLanguages());
+        assertEquals("P11", result.getGroups().iterator().next());
+        assertEquals(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"), result.getOrganizations().iterator().next());
+        assertEquals(Status.DRAFT, result.getStatus());
+        assertEquals("Sample description", result.getDescription().get("fi"));
+        assertEquals(Set.of("http://uri.suomi.fi/terminology/rytj/", "http://uri.suomi.fi/terminology/geoinfsan/"), result.getTerminologies());
+
+        // internal namespaces have to add separately without validation
+        assertEquals(Set.of(), result.getInternalNamespaces());
+
+        var externalNamespace = result.getExternalNamespaces().iterator().next();
+        assertEquals("test_un", externalNamespace.getPrefix());
+        assertEquals("https://vocabulary.uncefact.org/", externalNamespace.getNamespace());
+        assertEquals("test un", externalNamespace.getName());
+
+        assertEquals(2, result.getLinks().size());
+        var link = result.getLinks().stream()
+                .filter(l -> l.getName().equals("Ympäristöministerio/Merialuesuunnittelu"))
+                .findFirst();
+        assertTrue(link.isPresent());
+        assertEquals("Test description", link.get().getDescription());
+        assertEquals("https://ym.fi/merialuesuunnittelu", link.get().getUri());
+
+        assertEquals("Sample documentation...", result.getDocumentation().get("fi"));
+    }
+
+    @Test
+    void testMapOldLibraryAttributes() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
+
+        var attributes = V1DataMapper.findResourcesByType(oldData, OWL.DatatypeProperty);
+
+        assertEquals(1, attributes.size());
+
+        var dto = V1DataMapper.mapLibraryResource(attributes.get(0));
+        assertEquals("kohdenimi", dto.getIdentifier());
+        assertEquals("Kohdenimi", dto.getLabel().get("fi"));
+        assertEquals("xsd:string", dto.getRange());
+        assertEquals("Kohteen nimi suomeksi.", dto.getNote().get("fi"));
+    }
+
+    @Test
+    void testMapOldLibraryAssociations() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
+
+        var associations = V1DataMapper.findResourcesByType(oldData, OWL.ObjectProperty);
+
+        assertEquals(1, associations.size());
+
+        var dto = V1DataMapper.mapLibraryResource(associations.get(0));
+        assertEquals("koostuu", dto.getIdentifier());
+        assertEquals("Koostuu", dto.getLabel().get("fi"));
+        assertEquals(GRAPH_URI + "/MerialuesuunnitelmanKohde", dto.getRange());
+    }
+
+    @Test
+    void testMapOldLibraryClasses() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
+
+        var classes = V1DataMapper.findResourcesByType(oldData, RDFS.Class);
+
+        assertEquals(2, classes.size());
+
+        var c1 = classes.stream()
+                .filter(c -> c.getURI().equals(GRAPH_URI + "#Lahtotietoaineisto"))
+                .findFirst();
+
+        assertTrue(c1.isPresent());
+
+        var dto = V1DataMapper.mapLibraryClass(c1.get());
+
+        assertEquals("Lahtotietoaineisto", dto.getIdentifier());
+        assertEquals("Lähtötietoaineisto", dto.getLabel().get("fi"));
+        assertEquals("Test description", dto.getNote().get("fi"));
+        assertEquals("http://uri.suomi.fi/terminology/rytj-kaava/concept-13", dto.getSubject());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/rak/Lahtotietoaineisto", dto.getSubClassOf().iterator().next());
+        assertEquals("Test editorial note", dto.getEditorialNote());
+    }
+}

--- a/src/test/resources/migration/merialsuun.ttl
+++ b/src/test/resources/migration/merialsuun.ttl
@@ -1,0 +1,151 @@
+@prefix adms:       <http://www.w3.org/ns/adms#> .
+@prefix afn:        <http://jena.hpl.hp.com/ARQ/function#> .
+@prefix at:         <http://publications.europa.eu/ontology/authority/> .
+@prefix dc:         <http://purl.org/dc/elements/1.1/> .
+@prefix dcam:       <http://purl.org/dc/dcam/> .
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
+@prefix httpv:      <http://www.w3.org/2011/http#> .
+@prefix iow:        <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix jhs:        <http://uri.suomi.fi/datamodel/ns/jhs#> .
+@prefix kmr:        <http://uri.suomi.fi/datamodel/ns/kmr#> .
+@prefix merialsuun: <http://uri.suomi.fi/datamodel/ns/merialsuun#> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix prov:       <http://www.w3.org/ns/prov#> .
+@prefix rak:        <http://uri.suomi.fi/datamodel/ns/rak#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rytj:       <http://uri.suomi.fi/datamodel/ns/rytj#> .
+@prefix rytj-tj:    <http://uri.suomi.fi/datamodel/ns/rytj-tj#> .
+@prefix schema:     <http://schema.org/> .
+@prefix sd:         <http://www.w3.org/ns/sparql-service-description#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosxl:     <http://www.w3.org/2008/05/skos-xl#> .
+@prefix text:       <http://jena.apache.org/text#> .
+@prefix tihatos:    <http://uri.suomi.fi/datamodel/ns/tihatos#> .
+@prefix ts:         <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix void:       <http://rdfs.org/ns/void#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix test_un:    <https://vocabulary.uncefact.org/> .
+
+
+<http://uri.suomi.fi/datamodel/ns/merialsuun>
+        rdf:type                        dcap:MetadataVocabulary , owl:Ontology ;
+        rdfs:comment                    "Sample description"@fi ;
+        rdfs:label                      "Merialuesuunnitelma"@fi ;
+        dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+        dcterms:created                 "2021-11-15T10:49:49.661Z"^^xsd:dateTime ;
+        dcterms:hasPart                  merialsuun:MerialuesuunnitelmanKohde , merialsuun:Lahtotietoaineisto , merialsuun:kohdenimi , merialsuun:koostuu ;
+        dcterms:identifier              "urn:uuid:b615f838-9d6f-46a7-ada1-ac768d527024" ;
+        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+        dcterms:language                ( "fi" "sv" "en" ) ;
+        dcterms:modified                "2022-08-30T06:14:04.896Z"^^xsd:dateTime ;
+        dcterms:references              <http://uri.suomi.fi/terminology/rytj/> , <http://uri.suomi.fi/terminology/geoinfsan/> ;
+        dcterms:relation                ( [ dcterms:title  "Ympäristöministerio/Merialuesuunnittelu"@fi ;
+                                            dcterms:description  "Test description"@fi ;
+                                            foaf:homepage  "https://ym.fi/merialuesuunnittelu"
+                                          ]
+                                          [ dcterms:title  "Suomen merialuesuunnitelma 2030"@fi ;
+                                            foaf:homepage  "https://www.merialuesuunnittelu.fi/merialuesuunnitelmaluonnos-2030/"
+                                          ]
+                                        ) ;
+        dcterms:requires                test_un: , <http://uri.suomi.fi/datamodel/ns/tihatos> , <http://uri.suomi.fi/datamodel/ns/rak> ;
+        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/merialsuun#" ;
+        dcap:preferredXMLNamespacePrefix
+                "merialsuun" ;
+        iow:codeLists                   <http://uri.suomi.fi/codelist/rytj/mspMerk> , <http://uri.suomi.fi/codelist/rytj/MSPprocessStep> ;
+        iow:contentModified             "2022-08-30T06:25:30.951Z"^^xsd:dateTime ;
+        iow:documentation               "Sample documentation..."@fi ;
+        iow:statusModified              "2021-11-15T10:49:49.661Z"^^xsd:dateTime ;
+        iow:useContext                  "InformationDescription" ;
+        owl:versionInfo                 "DRAFT" .
+
+
+# Classes
+merialsuun:MerialuesuunnitelmanKohde
+        rdf:type            rdfs:Class ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/merialsuun> ;
+        dcterms:created     "2021-11-23T10:28:18.642Z"^^xsd:dateTime ;
+        dcterms:identifier  "urn:uuid:4215ef51-98b3-427c-9f17-b5d1a66f9209" ;
+        dcterms:modified    "2022-08-30T06:25:30.612Z"^^xsd:dateTime ;
+        dcterms:subject     <http://uri.suomi.fi/terminology/geoinfsan/c37> ;
+        iow:statusModified  "2021-11-23T10:28:18.642Z"^^xsd:dateTime ;
+        owl:versionInfo     "DRAFT" ;
+        sh:description      "Merialuesuunnitelmaan sisältyvä maantieteellinen kohde, jolla on tietty sijainti. Kohde voi olla esim. alue-, yhteys- tai vyöhykemerkintä eli mikä tahansa muu kuin merialuesuunnitelman rajaukseen liittyvä merkintä."@fi ;
+        sh:name             "Merialuesuunnitelman kohde"@fi ;
+        sh:property         <urn:uuid:9716512a-1317-4473-8b20-43f24dbd8698> .
+
+# Class with an association Lahtotietoaineisto -> MerialuesuunnitelmanKohde
+merialsuun:Lahtotietoaineisto
+        rdf:type             rdfs:Class ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/merialsuun> ;
+        rdfs:subClassOf      rak:Lahtotietoaineisto ;
+        dcterms:created      "2022-08-30T05:18:00.949Z"^^xsd:dateTime ;
+        dcterms:identifier   "urn:uuid:0e8cf39d-e0cc-42e2-b42b-4155101022d7" ;
+        dcterms:modified     "2022-08-30T05:18:00.949Z"^^xsd:dateTime ;
+        dcterms:subject      <http://uri.suomi.fi/terminology/rytj-kaava/concept-13> ;
+        iow:statusModified   "2022-08-30T05:18:00.949Z"^^xsd:dateTime ;
+        owl:versionInfo      "DRAFT" ;
+        prov:wasDerivedFrom  <http://uri.suomi.fi/datamodel/ns/rytj-kaava#Lahtotietoaineisto> ;
+        sh:description       "Test description"@fi ;
+        sh:name              "Lähtötietoaineisto"@fi ;
+        skos:editorialNote   "Test editorial note" ;
+        sh:property          <urn:uuid:74ae03c9-62d4-4880-9ac0-c98aca1787f6> .
+
+# Attributes
+merialsuun:kohdenimi  rdf:type  owl:DatatypeProperty ;
+        rdfs:comment        "Kohteen nimi suomeksi."@fi ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/merialsuun> ;
+        rdfs:label          "Kohdenimi"@fi ;
+        rdfs:range          xsd:string ;
+        dcterms:created     "2021-11-18T11:47:55.876Z"^^xsd:dateTime ;
+        dcterms:identifier  "urn:uuid:f0d7a064-083c-4860-8e03-0c309599169b" ;
+        dcterms:modified    "2022-02-10T09:19:26.372Z"^^xsd:dateTime ;
+        iow:statusModified  "2021-11-18T11:47:55.876Z"^^xsd:dateTime ;
+        owl:versionInfo     "DRAFT" .
+
+# Associations
+merialsuun:koostuu  rdf:type  owl:ObjectProperty ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/merialsuun> ;
+        rdfs:label          "Koostuu"@fi ;
+        rdfs:range          merialsuun:MerialuesuunnitelmanKohde ;
+        dcterms:created     "2021-11-23T10:57:39.922Z"^^xsd:dateTime ;
+        dcterms:identifier  "urn:uuid:108e57bd-7473-4f27-95c8-b3955346a177" ;
+        dcterms:modified    "2021-11-23T10:57:39.922Z"^^xsd:dateTime ;
+        iow:statusModified  "2021-11-23T10:57:39.922Z"^^xsd:dateTime ;
+        owl:versionInfo     "DRAFT" .
+
+# Restrictions
+<urn:uuid:74ae03c9-62d4-4880-9ac0-c98aca1787f6>
+        rdf:type         sh:PropertyShape ;
+        dcterms:type     owl:ObjectProperty ;
+        iow:localName    "koostuu" ;
+        owl:versionInfo  "DRAFT" ;
+        sh:minCount      1 ;
+        sh:name          "Koostuu"@fi ;
+        sh:node          merialsuun:MerialuesuunnitelmanKohde ;
+        sh:order         2 ;
+        sh:path          tihatos:kohdistuu .
+
+<urn:uuid:9716512a-1317-4473-8b20-43f24dbd8698>
+        rdf:type         sh:PropertyShape ;
+        dcterms:type     owl:DatatypeProperty ;
+        iow:localName    "kohdenimi" ;
+        owl:versionInfo  "DRAFT" ;
+        sh:datatype      xsd:string ;
+        sh:description   "Kohteen nimi suomeksi."@fi ;
+        sh:maxCount      1 ;
+        sh:minCount      1 ;
+        sh:name          "Kohdenimi"@fi , "Object name"@en , "Objekts namn"@sv ;
+        sh:order         0 ;
+        sh:path          merialsuun:kohdenimi .
+
+# External namespace
+test_un:  rdf:type                      rdfs:Resource ;
+        rdfs:label                      "test un"@fi ;
+        dcap:preferredXMLNamespaceName  "https://vocabulary.uncefact.org/" ;
+        dcap:preferredXMLNamespacePrefix
+                "test_un" ;
+        iow:isResolved                  false .


### PR DESCRIPTION
- Endpoint for migration single models and its visualization positions
- Mapper from old model to dto classes in the new application
- Some optimizations for sparql queries (findResources)
- Increase memory limit in web client
- Fixes to terminology uri handling (remove trailing slash if present)