### PR TITLE
Add validator for resource identifiers

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -6,6 +6,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.service.ClassService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidClass;
+import fi.vm.yti.datamodel.api.v2.validator.ValidResourceIdentifier;
 import fi.vm.yti.datamodel.api.v2.validator.ValidNodeShape;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -72,7 +73,7 @@ public class ClassController {
     })
     @PutMapping(value = "/library/{prefix}/{classIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateClass(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                            @PathVariable @Parameter(description = "Class identifier") String classIdentifier,
+                                            @PathVariable @Parameter(description = "Class identifier") @ValidResourceIdentifier String classIdentifier,
                                             @RequestBody @Parameter(description = "Class data") @ValidClass(updateClass = true) ClassDTO classDTO){
         classService.update(prefix, classIdentifier, classDTO);
         return ResponseEntity.noContent().build();
@@ -87,7 +88,7 @@ public class ClassController {
     })
     @PutMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateNodeShape(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                                @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier,
+                                                @PathVariable @Parameter(description = "Node shape identifier") @ValidResourceIdentifier String nodeShapeIdentifier,
                                                 @RequestBody @Parameter(description = "Node shape data") @ValidNodeShape(updateNodeShape = true) NodeShapeDTO nodeShapeDTO){
         classService.update(prefix, nodeShapeIdentifier, nodeShapeDTO);
         return ResponseEntity.noContent().build();
@@ -100,7 +101,7 @@ public class ClassController {
     })
     @GetMapping(value = "/library/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ClassInfoDTO getClass(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                 @PathVariable @Parameter(description = "Class identifier") String classIdentifier,
+                                 @PathVariable @Parameter(description = "Class identifier") @ValidResourceIdentifier String classIdentifier,
                                  @RequestParam(required = false) @Parameter(description = "Version") String version){
         return (ClassInfoDTO) classService.get(prefix, version, classIdentifier);
     }
@@ -111,7 +112,7 @@ public class ClassController {
             @ApiResponse(responseCode = "404", description = "Node shape not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
     })    @GetMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}", produces = APPLICATION_JSON_VALUE)
     public NodeShapeInfoDTO getNodeShape(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                         @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier,
+                                         @PathVariable @Parameter(description = "Node shape identifier") @ValidResourceIdentifier String nodeShapeIdentifier,
                                          @RequestParam(required = false) @Parameter(description = "Version") String version){
         return (NodeShapeInfoDTO) classService.get(prefix, version, nodeShapeIdentifier);
     }
@@ -121,7 +122,7 @@ public class ClassController {
     @ApiResponse(responseCode = "200", description = "Boolean value indicating whether a resource with given identifier exists")
     @GetMapping(value = "/{prefix}/{identifier}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean freeIdentifier(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                  @PathVariable @Parameter(description = "Resource identifier") String identifier) {
+                                  @PathVariable @Parameter(description = "Resource identifier") @ValidResourceIdentifier String identifier) {
         return classService.exists(prefix, identifier);
     }
 
@@ -133,7 +134,7 @@ public class ClassController {
     })
     @DeleteMapping(value = "/library/{prefix}/{classIdentifier}")
     public void deleteClass(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                            @PathVariable @Parameter(description = "Class identifier") String classIdentifier){
+                            @PathVariable @Parameter(description = "Class identifier") @ValidResourceIdentifier String classIdentifier){
         classService.delete(prefix, classIdentifier);
     }
 
@@ -145,7 +146,7 @@ public class ClassController {
     })
     @DeleteMapping(value = "/profile/{prefix}/{classIdentifier}")
     public void deleteNodeShape(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                @PathVariable @Parameter(description = "Class identifier") String classIdentifier){
+                                @PathVariable @Parameter(description = "Class identifier") @ValidResourceIdentifier String classIdentifier){
         classService.delete(prefix, classIdentifier);
     }
 
@@ -158,7 +159,7 @@ public class ClassController {
     @ApiResponse(responseCode = "200", description = "Property reference deleted successfully")
     @PutMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}/properties")
     public void addNodeShapePropertyReference(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                              @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier,
+                                              @PathVariable @Parameter(description = "Node shape identifier") @ValidResourceIdentifier String nodeShapeIdentifier,
                                               @RequestParam @Parameter(description = "Property shape ") String uri) {
         classService.handlePropertyShapeReference(prefix, nodeShapeIdentifier, uri, false);
     }
@@ -198,7 +199,7 @@ public class ClassController {
     })
     @DeleteMapping(value = "/profile/{prefix}/{nodeShapeIdentifier}/properties")
     public void deleteNodeShapePropertyReference(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                                 @PathVariable @Parameter(description = "Node shape identifier") String nodeShapeIdentifier,
+                                                 @PathVariable @Parameter(description = "Node shape identifier") @ValidResourceIdentifier String nodeShapeIdentifier,
                                                  @RequestParam @Parameter(description = "Property shape URI") String uri) {
         classService.handlePropertyShapeReference(prefix, nodeShapeIdentifier, uri, true);
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -78,19 +78,29 @@ public abstract class BaseValidator implements Annotation{
         }
     }
 
-    public void checkPrefixOrIdentifier(ConstraintValidatorContext context, final String value, String propertyName, final int maxLength, boolean update){
-        if(!update && (value == null || value.isBlank())){
+    public void checkIdentifier(ConstraintValidatorContext context, final String value, String propertyName, final int maxLength, boolean update) {
+        if (!update && (value == null || value.trim().isBlank())) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
+        } else if (update && value != null) {
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
+        } else if (value != null && !value.matches(ValidationConstants.RESOURCE_IDENTIFIER_REGEX)) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, propertyName);
+        }
+    }
+
+    public void checkPrefixOrIdentifier(ConstraintValidatorContext context, final String value, String propertyName, final int maxLength, boolean update) {
+        if (!update && (value == null || value.trim().isBlank())) {
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
             return;
-        }else if(update && value != null){
+        } else if (update && value != null) {
             addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
             return;
-        }else if(value == null){
+        } else if (value == null) {
             //no need to check further if null
             return;
         }
 
-        if(value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > maxLength){
+        if (value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > maxLength) {
             addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceIdentifierValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceIdentifierValidator.java
@@ -1,0 +1,15 @@
+package fi.vm.yti.datamodel.api.v2.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ResourceIdentifierValidator extends BaseValidator implements
+        ConstraintValidator<ValidResourceIdentifier, String> {
+
+    @Override
+    public boolean isValid(String identifier, ConstraintValidatorContext context) {
+        setConstraintViolationAdded(false);
+        checkIdentifier(context, identifier, "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, false);
+        return !isConstraintViolationAdded();
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidResourceIdentifier.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidResourceIdentifier.java
@@ -1,0 +1,27 @@
+package fi.vm.yti.datamodel.api.v2.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ResourceIdentifierValidator.class)
+public @interface ValidResourceIdentifier {
+
+            String message() default "Invalid data";
+
+            Class<?>[] groups() default {};
+
+            Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -5,11 +5,12 @@ import java.util.Map;
 
 public class ValidationConstants {
 
-    private ValidationConstants(){
+    private ValidationConstants() {
         //Utility class
     }
 
     public static final String MSG_VALUE_MISSING = "should-have-value";
+    public static final String MSG_VALUE_INVALID = "invalid-value";
     public static final String MSG_NOT_ALLOWED_UPDATE =  "not-allowed-update";
     public static final String MSG_OVER_CHARACTER_LIMIT = "value-over-character-limit.";
 
@@ -21,6 +22,8 @@ public class ValidationConstants {
     public static final int PREFIX_MAX_LENGTH = 32;
     public static final int RESOURCE_IDENTIFIER_MAX_LENGTH = 32;
     public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
+
+    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z0-9-_]+";
 
     public static final Map<String, String> RESERVED_NAMESPACES = Map.ofEntries(
             Map.entry("owl", "http://www.w3.org/2002/07/owl#"),

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -217,6 +218,22 @@ class ClassControllerTest {
                 .andExpect(content().string(containsString("false")));
     }
 
+    @Test
+    void shouldThrowValidationErrorWithInvalidIdentifier() throws Exception {
+        when(classService.exists(anyString(), anyString())).thenReturn(true);
+
+        this.mvc
+                .perform(get("/v2/class/test/test /exists")
+                        .contentType("application/json"))
+                .andExpect(status().isBadRequest())
+                .andExpect(result -> {
+                    assertEquals(
+                            "freeIdentifier.identifier.identifier: invalid-value",
+                            result.getResolvedException() != null ?
+                                    result.getResolvedException().getMessage() :
+                                    "");
+                });
+    }
 
     private static ClassDTO createClassDTO(boolean update){
         var dto = new ClassDTO();


### PR DESCRIPTION
The identifier is checked for valid format using regex.

Previously the free identifier check would throw Internal Server Error if the identifier had spaces in it (e.g. "asd "):
```json
{
    "timestamp": "2023-10-03T07:50:53.425+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "path": "/datamodel-api/v2/class/urhotest1/asd%20/exists"
}
```

With spaces, the generated sparql query would be invalid:

```sparql
ASK
WHERE
  { GRAPH <http://uri.suomi.fi/datamodel/ns/urhotest1>
      { <http://uri.suomi.fi/datamodel/ns/urhotest1/asd  >
                  ?p  ?o}}
```

This PR adds a new validator to every endpoint where the identifier is used. After this, we get a Bad Request with validation error details:

```json
{
    "status": "BAD_REQUEST",
    "timestamp": "03-10-2023 11:00:07",
    "message": "Object validation failed",
    "details": [
        {
            "field": "identifier",
            "rejectedValue": "asd ",
            "message": "invalid-value"
        }
    ]
}
```