### PR TITLE
YTI-3416 link internal namespaces with version

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -13,6 +13,7 @@ public class ModelConstants {
     public static final String CODELIST_NAMESPACE = "http://uri.suomi.fi/codelist/";
     public static final String TERMINOLOGY_NAMESPACE = "http://uri.suomi.fi/terminology/";
     public static final String MODEL_POSITIONS_NAMESPACE = "http://uri.suomi.fi/datamodel/positions/";
+    public static final String SUOMI_FI_DOMAIN = "uri.suomi.fi";
 
     public static final String RESOURCE_SEPARATOR = "/";
     public static final String URN_UUID = "urn:uuid:";

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -34,8 +34,9 @@ public class MapperUtils {
         }
     }
 
-    public static String getModelIdFromNamespace(String namespace){
-        return namespace.substring(namespace.lastIndexOf("/") + 1);
+    public static String getModelIdFromNamespace(String namespace) {
+        var nsWithoutVersion = namespace.replaceAll("/[0-9.]+(.*)$", "");
+        return nsWithoutVersion.substring(nsWithoutVersion.lastIndexOf("/") + 1);
     }
 
     public static ModelType getModelTypeFromResource(Resource resource){
@@ -434,5 +435,13 @@ public class MapperUtils {
                     property, resource));
         }
         return model.getList(obj.asResource());
+    }
+
+    public static Resource getModelResourceFromVersion(Model model) {
+        var typeStmt = model.listStatements(null, RDF.type, OWL.Ontology);
+        if (!typeStmt.hasNext()) {
+            throw new MappingError("Invalid datamodel added to internal namespaces");
+        }
+        return model.getResource(typeStmt.next().getSubject().getURI());
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -372,7 +372,7 @@ public class ModelMapper {
                 var dto = new InternalNamespaceDTO();
                 try {
                     var nsModel = coreRepository.fetch(ns);
-                    var nsResource = nsModel.getResource(ns);
+                    var nsResource = MapperUtils.getModelResourceFromVersion(nsModel);
                     dto.setNamespace(ns);
                     dto.setPrefix(MapperUtils.propertyToString(nsResource, DCAP.preferredXMLNamespacePrefix));
                     dto.setName(MapperUtils.localizedPropertyToMap(nsResource, RDFS.label));
@@ -399,11 +399,11 @@ public class ModelMapper {
     private void addInternalNamespaceToDatamodel(DataModelDTO modelDTO, Resource resource, Model model){
         modelDTO.getInternalNamespaces().forEach(namespace -> {
             var ns = coreRepository.fetch(namespace);
-            var nsRes = ns.getResource(namespace);
+            var nsRes = MapperUtils.getModelResourceFromVersion(ns);
             var prefix = MapperUtils.propertyToString(nsRes, DCAP.preferredXMLNamespacePrefix);
             var nsType = MapperUtils.getModelTypeFromResource(nsRes);
             var modelType = MapperUtils.getModelTypeFromResource(resource);
-            resource.addProperty(getNamespacePropertyFromType(modelType, nsType), nsRes);
+            resource.addProperty(getNamespacePropertyFromType(modelType, nsType), ResourceFactory.createResource(namespace));
             model.setNsPrefix(prefix, namespace);
         });
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -236,6 +236,7 @@ public class ResourceMapper {
         if(version != null){
             id = isDefinedBy + ModelConstants.RESOURCE_SEPARATOR + version + ModelConstants.RESOURCE_SEPARATOR + resource.getLocalName();
             indexResource.setFromVersion(version);
+            indexResource.setVersionIri(MapperUtils.propertyToString(model.getResource(isDefinedBy), OWL2.versionIRI));
         }
 
         indexResource.setId(id);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.v2.dto.*;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
@@ -10,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.vocabulary.SH;
 
-import java.net.URI;
 import java.util.*;
 
 public class VisualizationMapper {
@@ -265,16 +265,15 @@ public class VisualizationMapper {
 
     private static String getReferenceIdentifier(String uri, Map<String, String> namespaces) {
         try {
-            var uriPath = URI.create(uri).getPath();
-            var fragment = uriPath.substring(uriPath.lastIndexOf("/") + 1);
-            String prefix = namespaces.get(uri.substring(0, uri.lastIndexOf("/")));
+            var u = NodeFactory.createURI(uri);
+            String prefix = namespaces.get(u.getNameSpace().replaceAll("/?$", ""));
 
             if (prefix == null) {
                 // referenced class in the same model
-                return fragment;
+                return u.getLocalName();
             } else {
                 // referenced class in the external namespace or other model in Interoperability platform
-                return prefix + ":" + fragment;
+                return prefix + ":" + u.getLocalName();
             }
         } catch (Exception e) {
             LOG.warn("Invalid uri reference {}", uri);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexResource.java
@@ -17,6 +17,7 @@ public class IndexResource extends IndexBase {
     private String subject;
     private String targetClass;
     private String fromVersion;
+    private String versionIri;
 
     public ResourceType getResourceType() {
         return resourceType;
@@ -104,5 +105,13 @@ public class IndexResource extends IndexBase {
 
     public void setFromVersion(String fromVersion) {
         this.fromVersion = fromVersion;
+    }
+
+    public String getVersionIri() {
+        return versionIri;
+    }
+
+    public void setVersionIri(String versionIri) {
+        this.versionIri = versionIri;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
@@ -352,7 +352,8 @@ public class OpenSearchIndexer {
                 Map.entry("modified", getDateProperty()),
                 Map.entry("fromVersion", getKeywordProperty()),
                 Map.entry("resourceType", getKeywordProperty()),
-                Map.entry("targetClass", getKeywordProperty())
+                Map.entry("targetClass", getKeywordProperty()),
+                Map.entry("versionIri", getKeywordProperty())
         );
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -168,10 +168,9 @@ public class VisualizationService {
                 .forEach(prop -> modelResource.listProperties(prop).toList().forEach(ns -> {
                     var uri = ns.getObject().toString();
                     if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
-                        namespaces.put(uri, uri.replace(ModelConstants.SUOMI_FI_NAMESPACE, ""));
-                    } else if (!uri.startsWith(ModelConstants.TERMINOLOGY_NAMESPACE)
-                            && !uri.startsWith(ModelConstants.CODELIST_NAMESPACE)) {
-                        namespaces.put(uri, model.getResource(uri).getProperty(DCAP.preferredXMLNamespacePrefix).getString());
+                        namespaces.put(uri, MapperUtils.getModelIdFromNamespace(uri));
+                    } else if (!uri.contains(ModelConstants.SUOMI_FI_DOMAIN)) {
+                        namespaces.put(uri, MapperUtils.propertyToString(model.getResource(uri), DCAP.preferredXMLNamespacePrefix));
                     }
                 }));
         return namespaces;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
@@ -33,7 +33,7 @@ public class DataModelUtils {
                     if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
                         var prefix = MapperUtils.getModelIdFromNamespace(uri);
                         model.setNsPrefix(prefix, uri + ModelConstants.RESOURCE_SEPARATOR);
-                    } else if (!uri.contains("uri.suomi.fi")) {
+                    } else if (!uri.contains(ModelConstants.SUOMI_FI_DOMAIN)) {
                         // handle external namespaces, skip for now terminologies and code lists
                         var extResource = model.getResource(uri);
                         var extPrefix = MapperUtils.propertyToString(extResource, DCAP.preferredXMLNamespacePrefix);

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -75,6 +75,7 @@ class ModelMapperTest {
     void testMapToJenaModel(ModelType modelType) {
         var mockModel = ModelFactory.createDefaultModel();
         mockModel.createResource("http://uri.suomi.fi/datamodel/ns/newint")
+                        .addProperty(RDF.type, OWL.Ontology)
                         .addProperty(RDF.type, Iow.ApplicationProfile)
                         .addProperty(DCAP.preferredXMLNamespacePrefix, "test");
         when(coreRepository.fetch(anyString())).thenReturn(mockModel);

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -236,6 +236,7 @@ class ResourceMapperTest {
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
         assertEquals("1.0.1", indexClass.getFromVersion());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
     }
 
     @Test
@@ -257,6 +258,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
         assertEquals("rdf:Literal", indexClass.getRange());
         assertEquals("1.0.1", indexClass.getFromVersion());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
     }
 
     @Test
@@ -278,6 +280,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
         assertEquals("1.0.1", indexClass.getFromVersion());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -32,11 +32,13 @@ class ResourceQueryFactoryTest {
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
         var groupNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/groupNs", "http://uri.suomi.fi/datamodel/ns/addedNs");
-        var addedNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/addedNs", "http://external-data.com/test");
+        var internalNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/addedNs");
+        var externalNamespaces = List.of("http://external-data.com/test");
 
         var allowedIncompleteDatamodels = Set.of("http://uri.suomi.fi/datamodel/ns/test");
 
-        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, addedNamespaces, groupNamespaces, allowedIncompleteDatamodels);
+        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, externalNamespaces, internalNamespaces,
+                groupNamespaces, allowedIncompleteDatamodels);
 
         String expected = OpenSearchUtils.getJsonString("/es/classRequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(classQuery), JSONCompareMode.LENIENT);
@@ -55,17 +57,33 @@ class ResourceQueryFactoryTest {
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE));
         request.setAdditionalResources(Set.of("http://uri.suomi.fi/datamodel/ns/ext/some-property"));
 
-        var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(),
-                new ArrayList<>(), new HashSet<>());
+        var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(), new ArrayList<>(),
+                null, new HashSet<>());
         String expected = OpenSearchUtils.getJsonString("/es/attributeListRequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(attributeListQuery), JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    void listClassesByVersion() throws Exception {
+        var request = new ResourceSearchRequest();
+
+        request.setPageFrom(1);
+        request.setPageSize(100);
+        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setResourceTypes(Set.of(ResourceType.CLASS));
+        request.setFromVersion("1.2.3");
+
+        var query = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(), new ArrayList<>(),
+                null, new HashSet<>());
+        String expected = OpenSearchUtils.getJsonString("/es/classesByVersion.json");
+        JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(query), JSONCompareMode.LENIENT);
     }
 
     @Test
     void createInternalClassQueryDefaults() {
         var request = new ResourceSearchRequest();
 
-        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, Collections.emptyList(), Collections.emptyList(), Collections.emptySet());
+        var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptySet());
 
         assertEquals("Page from value not matching", QueryFactoryUtils.DEFAULT_PAGE_FROM, classQuery.from());
         assertEquals("Page size value not matching", QueryFactoryUtils.DEFAULT_PAGE_SIZE, classQuery.size());

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -1,6 +1,5 @@
 {
   "from": 1,
-  "size": 100,
   "query": {
     "bool": {
       "must": [
@@ -9,7 +8,8 @@
             "fields": [
               "label.*"
             ],
-            "fuzziness": "2"
+            "fuzziness": "2",
+            "query": "*test query*"
           }
         },
         {
@@ -18,25 +18,20 @@
           }
         },
         {
-          "term": {
-            "targetClass": {
-              "value": "http://uri.suomi.fi/datamodel/ns/test/TestClass"
-            }
-          }
-        },
-        {
-          "terms": {
-            "resourceType": ["ATTRIBUTE", "ASSOCIATION"]
-          }
-        },
-        {
           "bool": {
+            "minimum_should_match": "1",
             "should": [
               {
                 "terms": {
                   "isDefinedBy": [
-                    "http://uri.suomi.fi/datamodel/ns/addedNs",
                     "http://external-data.com/test"
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "versionIri": [
+                    "http://uri.suomi.fi/datamodel/ns/addedNs"
                   ]
                 }
               },
@@ -48,15 +43,27 @@
             ]
           }
         },
-        { "bool": {
-          "must_not": [{
-            "exists": {
-              "field": "fromVersion"
+        {
+          "terms": {
+            "resourceType": ["ASSOCIATION", "ATTRIBUTE"]
+          }
+        },
+        {
+          "term": {
+            "targetClass": {
+              "value": "http://uri.suomi.fi/datamodel/ns/test/TestClass"
             }
-          }]
-        } }
+          }
+        }
       ],
       "should": [
+        {
+          "terms": {
+            "isDefinedBy": [
+              "http://uri.suomi.fi/datamodel/ns/test"
+            ]
+          }
+        },
         {
           "bool": {
             "must_not": [
@@ -68,11 +75,6 @@
                 }
               }
             ]
-          }
-        },
-        {
-          "terms": {
-            "isDefinedBy": ["http://uri.suomi.fi/datamodel/ns/test"]
           }
         }
       ]

--- a/src/test/resources/es/classesByVersion.json
+++ b/src/test/resources/es/classesByVersion.json
@@ -18,14 +18,10 @@
                       }
                     },
                     {
-                      "bool": {
-                        "must_not": [
-                          {
-                            "exists": {
-                              "field": "fromVersion"
-                            }
-                          }
-                        ]
+                      "term": {
+                        "fromVersion": {
+                          "value": "1.2.3"
+                        }
                       }
                     }
                   ]
@@ -43,9 +39,7 @@
               },
               {
                 "terms": {
-                  "id": [
-                    "http://uri.suomi.fi/datamodel/ns/ext/some-property"
-                  ]
+                  "id": []
                 }
               }
             ]
@@ -54,7 +48,7 @@
         {
           "terms": {
             "resourceType": [
-              "ATTRIBUTE"
+              "CLASS"
             ]
           }
         }
@@ -76,6 +70,7 @@
       ]
     }
   },
+  "size": 100,
   "sort": [
     {
       "label.fi.keyword": {

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -26,7 +26,8 @@ dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-owl:versionInfo                 "VALID", "1.0.1".
+owl:versionInfo                 "VALID", "1.0.1" ;
+owl:versionIRI                  <http://uri.suomi.fi/datamodel/ns/test/1.0.1> .
 
 <https://www.example.com/ns/ext>
 dcterms:type                        rdfs:Resource ;


### PR DESCRIPTION
Add internal namespcaes to model
- fetch referenced model's prefix without version
- fix displaying prefix in visualization data (strip version)

Logic changes in resource search
- If no data models found by searching with e.g. groups, return empty set
- Split namespaces to internal and external. Internal namespaces are searched by `versionIRI` (added also to indexed resource), external resources are searched by `isDefinedBy`. Version parameter is affected only to current model (limitToDataModel)

Example: Querying classes for draft model `test` with added internal namespace `ext` (version 1.0.0) and external namespace `owl`

```
{
  "from": 0,
  "query": {
    "bool": {
      "must": [
        { "terms": { "status": ["VALID", "SUGGESTED"] } },
        {
          "bool": {
            "minimum_should_match": "1",
            "should": [
              {
                "bool": {
                  "must": [
                    {
                      "terms": {
                        "isDefinedBy": ["http://uri.suomi.fi/datamodel/ns/test"]
                      }
                    },
                    {
                      "bool": {
                        "must_not": [{ "exists": { "field": "fromVersion" } }]
                      }
                    }
                  ]
                }
              },
              {
                "terms": { "isDefinedBy": ["http://www.w3.org/2002/07/owl#"] }
              },
              {
                "terms": {
                  "versionIri": ["http://uri.suomi.fi/datamodel/ns/ext/1.0.0"]
                }
              },
              { "terms": { "id": [] } }
            ]
          }
        },
        { "terms": { "resourceType": ["CLASS"] } }
      ],
      "should": [
        {
          "bool": {
            "must_not": [{ "term": { "status": { "value": "DRAFT" } } }]
          }
        }
      ]
    }
  }
}
```