### PR TITLE
Yti 3418 find resources with version checks

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
@@ -157,8 +157,8 @@ public class V1DataMigrationService {
                     targetRes = tempResource;
 
                 } else {
-                    // reference to external resource
-                    targetRes = resourceService.findResources(Set.of(path)).getResource(path);
+                    // reference to external resource, no need to specify namespaces
+                    targetRes = resourceService.findResources(Set.of(path), Set.of()).getResource(path);
                 }
 
                 LOG.info("add restriction {} to class {}", targetRes.getURI(), classResource.getURI());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimplePropertyShapeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimplePropertyShapeDTO.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public class SimplePropertyShapeDTO {
     private String identifier;
     private String uri;
+    private String version;
     private String modelId;
     private Map<String, String> label;
     private boolean deactivated;
@@ -56,5 +57,13 @@ public class SimplePropertyShapeDTO {
 
     public void setFromShNode(boolean fromShNode) {
         this.fromShNode = fromShNode;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public class SimpleResourceDTO {
 
     private String uri;
+    private String version;
     private Map<String, String> label;
     private String identifier;
     private String modelId;
@@ -66,5 +67,13 @@ public class SimpleResourceDTO {
 
     public void setNote(Map<String, String> note) {
         this.note = note;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -2,7 +2,6 @@ package fi.vm.yti.datamodel.api.v2.endpoint;
 
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ApiError;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.service.ClassService;
 import fi.vm.yti.datamodel.api.v2.validator.ValidClass;
@@ -219,13 +218,6 @@ public class ClassController {
     @GetMapping(value = "/nodeshapes", produces = APPLICATION_JSON_VALUE)
     public Collection<IndexResourceInfo> getNodeShapes(@RequestParam @Parameter(description = "Target class") String targetClass) throws IOException {
         return classService.getNodeShapes(targetClass);
-    }
-
-    @Operation(summary = "Get all node shapes properties based on sh:node reference")
-    @ApiResponse(responseCode = "200", description = "List of node shape's properties fetched successfully")
-    @GetMapping(value = "/nodeshape/properties", produces = APPLICATION_JSON_VALUE)
-    public Collection<IndexResource> getNodeShapeProperties(@RequestParam @Parameter(description = "Node shape URI") String nodeUri) throws IOException {
-        return classService.getNodeShapeProperties(nodeUri);
     }
 
     @Operation(summary = "Toggles deactivation of a single property shape")

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -86,7 +86,7 @@ public class VisualizationService {
             }
 
             if (!externalPropertyURIs.isEmpty()) {
-                var externalResources = resourceService.findResources(externalPropertyURIs);
+                var externalResources = resourceService.findResources(externalPropertyURIs, namespaces.keySet());
                 externalPropertyURIs.forEach(uri -> VisualizationMapper
                         .mapResource(classDTO, externalResources.getResource(uri), model, namespaces));
             }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
@@ -4,12 +4,15 @@ import fi.vm.yti.datamodel.api.v2.dto.DCAP;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DataModelUtils {
 
@@ -43,5 +46,29 @@ public class DataModelUtils {
                     }
                 })
         );
+    }
+
+    public static Set<String> getInternalReferenceModels(String versionUri, Resource modelResource) {
+        var includedNamespaces = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
+        includedNamespaces.addAll(MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires));
+        includedNamespaces.add(versionUri);
+
+        return includedNamespaces.stream()
+                .filter(ns -> ns.startsWith(ModelConstants.SUOMI_FI_NAMESPACE))
+                .collect(Collectors.toSet());
+    }
+
+    public static String removeTrailingSlash(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        return uri.replaceAll("/?$", "");
+    }
+
+    public static String removeVersionFromURI(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        return uri.replaceAll("/[\\d.]+(.*)/", "/");
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
@@ -1,6 +1,5 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.NodeShapeDTO;
 import fi.vm.yti.datamodel.api.v2.service.ResourceService;
 import jakarta.validation.ConstraintValidator;
@@ -44,21 +43,17 @@ public class NodeShapeValidator extends BaseValidator implements
 
     private void checkTargetClass(ConstraintValidatorContext context, NodeShapeDTO nodeShapeDTO){
         var targetClass = nodeShapeDTO.getTargetClass();
-        if(targetClass != null && !targetClass.isBlank()){
-            var checkImports = !targetClass.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if(!resourceService.checkIfResourceIsOneOfTypes(targetClass, List.of(RDFS.Class, OWL.Class), checkImports)){
-                addConstraintViolation(context, "not-class-or-doesnt-exist", "targetClass");
-            }
+        if(targetClass != null && !targetClass.isBlank()
+                && !resourceService.checkIfResourceIsOneOfTypes(targetClass, List.of(RDFS.Class, OWL.Class))) {
+            addConstraintViolation(context, "not-class-or-doesnt-exist", "targetClass");
         }
     }
 
     private void checkTargetNode(ConstraintValidatorContext context, NodeShapeDTO nodeShapeDTO){
         var targetNode = nodeShapeDTO.getTargetNode();
-        if(targetNode != null && !targetNode.isBlank()){
-            var checkImports = !targetNode.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if(!resourceService.checkIfResourceIsOneOfTypes(targetNode, List.of(SH.NodeShape), checkImports)){
-                addConstraintViolation(context, "not-node-shape-or-doesnt-exist", "targetNode");
-            }
+        if(targetNode != null && !targetNode.isBlank()
+                && !resourceService.checkIfResourceIsOneOfTypes(targetNode, List.of(SH.NodeShape))) {
+            addConstraintViolation(context, "not-node-shape-or-doesnt-exist", "targetNode");
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
@@ -61,21 +61,15 @@ public class PropertyShapeValidator extends BaseValidator implements ConstraintV
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "path");
         }
 
-        if (path != null && !path.isBlank()) {
-            var checkImports = !path.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if (!resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty), checkImports)) {
-                addConstraintViolation(context, "not-property-or-doesnt-exist", "path");
-            }
+        if (path != null && !path.isBlank() && !resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty))) {
+            addConstraintViolation(context, "not-property-or-doesnt-exist", "path");
         }
     }
 
     private void checkClassType(ConstraintValidatorContext context, AssociationRestriction dto) {
         var classType = dto.getClassType();
-        if (classType != null) {
-            var checkImports = !classType.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if(!resourceService.checkIfResourceIsOneOfTypes(classType, List.of(RDFS.Class, OWL.Class), checkImports)){
-                addConstraintViolation(context, "not-class-or-doesnt-exist", "path");
-            }
+        if (classType != null && !resourceService.checkIfResourceIsOneOfTypes(classType, List.of(RDFS.Class, OWL.Class))) {
+            addConstraintViolation(context, "not-class-or-doesnt-exist", "path");
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
@@ -79,11 +79,8 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
 
     private void checkDomain(ConstraintValidatorContext context, ResourceDTO resourceDTO){
         var domain = resourceDTO.getDomain();
-        if(domain != null && !domain.isBlank()){
-            var checkImports = !domain.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-            if(!resourceService.checkIfResourceIsOneOfTypes(domain, List.of(RDFS.Class, OWL.Class), checkImports)){
-                addConstraintViolation(context, "not-class-or-doesnt-exist", "domain");
-            }
+        if(domain != null && !domain.isBlank() && !resourceService.checkIfResourceIsOneOfTypes(domain, List.of(RDFS.Class, OWL.Class))){
+            addConstraintViolation(context, "not-class-or-doesnt-exist", "domain");
         }
     }
 
@@ -91,8 +88,7 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
         var range = resourceDTO.getRange();
         if(range != null && !range.isBlank()){
             if(resourceType.equals(ResourceType.ASSOCIATION)){
-                var checkImports = !range.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
-                if(!resourceService.checkIfResourceIsOneOfTypes(range, List.of(RDFS.Class, OWL.Class), checkImports)){
+                if(!resourceService.checkIfResourceIsOneOfTypes(range, List.of(RDFS.Class, OWL.Class))){
                     addConstraintViolation(context, "not-class-or-doesnt-exist", "range");
                 }
             }else{

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -285,7 +285,7 @@ class ClassMapperTest {
     }
 
     @Test
-    void testAddDomainAndRangeToClassDTO(){
+    void testAddAttributeAndAssociationRestrictionsToClassDTO(){
         var m = MapperTestUtils.getModelFromFile("/models/test_resource_query_model.ttl");
 
         var dto = new ClassInfoDTO();
@@ -299,6 +299,7 @@ class ClassMapperTest {
         assertEquals("test", attribute.getIdentifier());
         assertEquals("http://uri.suomi.fi/datamodel/ns/test/rangetest2", attribute.getUri());
         assertEquals("test", attribute.getModelId());
+        assertEquals("1.0.0", attribute.getVersion());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -84,7 +84,7 @@ class NodeShapeMapperTest {
         assertTrue(MapperUtils.hasType(propertyShapeAssociation, SH.PropertyShape));
         assertTrue(MapperUtils.hasType(propertyShapeAssociation, OWL.ObjectProperty));
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1",
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0/attribute-1",
                 propertyShapeAttribute.getProperty(SH.path).getObject().toString());
         assertEquals(Status.DRAFT.name(), propertyShapeAttribute.getProperty(OWL.versionInfo).getObject().toString());
         assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceControllerTest.java
@@ -62,7 +62,7 @@ class ResourceControllerTest {
     @CsvSource({"attribute", "association"})
     void shouldValidateAndCreate(String resourceType) throws Exception {
         var resourceDTO = createResourceDTO(false, resourceType);
-        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList(), anyBoolean())).thenReturn(true);
+        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList())).thenReturn(true);
 
         this.mvc
                 .perform(post("/v2/resource/library/test/{resourceType}", resourceType)
@@ -71,9 +71,9 @@ class ResourceControllerTest {
                 .andExpect(status().isCreated());
         //validator
         if (resourceType.equals("attribute")) {
-            verify(resourceService, times(1)).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());
+            verify(resourceService, times(1)).checkIfResourceIsOneOfTypes(anyString(), anyList());
         } else {
-            verify(resourceService, times(2)).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());
+            verify(resourceService, times(2)).checkIfResourceIsOneOfTypes(anyString(), anyList());
         }
         //controller
         verify(resourceService).create(anyString(), any(ResourceDTO.class), any(ResourceType.class), eq(false));
@@ -156,7 +156,7 @@ class ResourceControllerTest {
     @CsvSource({"attribute", "association"})
     void shouldValidateAndUpdate(String resourceType) throws Exception {
         var resourceDTO = createResourceDTO(true, resourceType);
-        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList(), anyBoolean())).thenReturn(true);
+        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList())).thenReturn(true);
 
         this.mvc
                 .perform(put("/v2/resource/library/test/{resourceType}/TestA{resourceType}", resourceType, resourceType.substring(1))
@@ -166,9 +166,9 @@ class ResourceControllerTest {
 
         //validator
         if (resourceType.equals("attribute")) {
-            verify(resourceService, times(1)).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());
+            verify(resourceService, times(1)).checkIfResourceIsOneOfTypes(anyString(), anyList());
         } else {
-            verify(resourceService, times(2)).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());
+            verify(resourceService, times(2)).checkIfResourceIsOneOfTypes(anyString(), anyList());
         }
         verify(resourceService).update(anyString(), anyString(), any(ResourceDTO.class));
         verifyNoMoreInteractions(resourceService);
@@ -213,8 +213,8 @@ class ResourceControllerTest {
     void shouldValidateAndCreatePropertyShape() throws Exception {
         var dto = createAttributeRestriction();
 
-        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList(),
-                anyBoolean())).thenReturn(true);
+        when(resourceService.checkIfResourceIsOneOfTypes(eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"), anyList()))
+                .thenReturn(true);
 
         this.mvc
                 .perform(post("/v2/resource/profile/test/attribute")
@@ -222,7 +222,7 @@ class ResourceControllerTest {
                         .content(EndpointUtils.convertObjectToJsonString(dto)))
                 .andExpect(status().isCreated());
 
-        verify(resourceService).checkIfResourceIsOneOfTypes(anyString(), anyList(), anyBoolean());
+        verify(resourceService).checkIfResourceIsOneOfTypes(anyString(), anyList());
         verify(resourceService).create(anyString(), any(PropertyShapeDTO.class), eq(ResourceType.ATTRIBUTE), eq(true));
         verifyNoMoreInteractions(resourceService);
     }
@@ -246,8 +246,7 @@ class ResourceControllerTest {
             String[] expectedResult) throws Exception {
         when(resourceService.checkIfResourceIsOneOfTypes(
                 eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"),
-                anyList(),
-                anyBoolean()))
+                anyList()))
                 .thenReturn(true);
         this.mvc
                 .perform(post("/v2/resource/profile/test/attribute")
@@ -277,8 +276,7 @@ class ResourceControllerTest {
             String[] expectedResult) throws Exception {
         when(resourceService.checkIfResourceIsOneOfTypes(
                 eq("http://uri.suomi.fi/datamodel/ns/int/FakeClass"),
-                anyList(),
-                anyBoolean()))
+                anyList()))
                 .thenReturn(true);
         this.mvc
                 .perform(post("/v2/resource/profile/test/association")

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -80,7 +80,7 @@ class ClassServiceTest {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
-        when(resourceService.mapUriLabels()).thenReturn(mock(Consumer.class));
+        when(resourceService.mapUriLabels(anySet())).thenReturn(mock(Consumer.class));
 
         try(var mapper = mockStatic(ClassMapper.class)) {
             classService.get("test", null, "TestClass");
@@ -97,7 +97,7 @@ class ClassServiceTest {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
-        when(resourceService.mapUriLabels()).thenReturn(mock(Consumer.class));
+        when(resourceService.mapUriLabels(anySet())).thenReturn(mock(Consumer.class));
 
         try(var mapper = mockStatic(ClassMapper.class)) {
             classService.get("test", "1.0.1", "TestClass");

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -308,7 +308,7 @@ class ResourceServiceTest {
         when(coreRepository.queryConstruct(any(Query.class))).thenReturn(model);
         when(importsRepository.queryConstruct(any(Query.class))).thenReturn(ModelFactory.createDefaultModel());
 
-        resourceService.mapUriLabels().accept(uris);
+        resourceService.mapUriLabels(Set.of()).accept(uris);
 
         var result1 = uris.stream()
                 .filter(u -> u.getCurie().equals("test_lib:attribute-1"))

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -77,7 +77,7 @@ class VisualizationServiceTest {
 
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "visuprof")).thenReturn(positionModel);
-        when(resourceService.findResources(anySet())).thenReturn(externalPropertiesModel);
+        when(resourceService.findResources(anySet(), anySet())).thenReturn(externalPropertiesModel);
 
         var visualizationData = visualizationService.getVisualizationData("visuprof", null);
 

--- a/src/test/resources/models/test_resource_query_model.ttl
+++ b/src/test/resources/models/test_resource_query_model.ttl
@@ -14,3 +14,6 @@
         rdfs:range           <http://uri.suomi.fi/datamodel/ns/testkirj/NewNewId> ;
         dcterms:identifier   "test"^^xsd:NCName ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> .
+
+<http://uri.suomi.fi/datamodel/ns/test>
+        owl:versionIRI       <http://uri.suomi.fi/datamodel/ns/test/1.0.0> .

--- a/src/test/resources/properties_result.ttl
+++ b/src/test/resources/properties_result.ttl
@@ -21,3 +21,6 @@
         rdfs:label          "Association association-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
         owl:versionInfo     "VALID" .
+
+<http://uri.suomi.fi/datamodel/ns/test_lib>
+        owl:versionIRI       <http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0> .

--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -17,7 +17,7 @@
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
         owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
-        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/codelist/test/testcodelist> ;
+        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/codelist/test/testcodelist> , <http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
         dcap:preferredXMLNamespacePrefix


### PR DESCRIPTION
Changes for fetching and adding resources with version information
- modify findResources query to limit only specified graphs (the namespaces added to the model)
- add versionIRI to the search results
- map version info to SimpleResourceDTO
- modify checking if resource is required type for validation

Other changes
- remove unused endpoint /datamodel-api/v2/class/nodeshape/properties
- add some utility methods for handling URIs with version