### PR TITLE
YTI-3406 automatically add reference namespaces

### DIFF
--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -233,7 +233,7 @@ class ModelMapperTest {
         assertEquals("http://uri.suomi.fi/datamodel/ns/int", modelResource.listProperties(OWL.imports).next().getObject().toString());
 
         var requires = MapperUtils.arrayPropertyToList(modelResource, DCTerms.requires);
-        assertEquals(2, requires.size());
+        assertEquals(3, requires.size());
         assertTrue(requires.containsAll(List.of("https://www.example.com/ns/ext", "http://uri.suomi.fi/terminology/test")));
 
         assertEquals("test@localhost", MapperUtils.propertyToString(modelResource, Iow.contact));
@@ -354,7 +354,10 @@ class ModelMapperTest {
         assertEquals("int", internalDTO.getPrefix());
         assertEquals("http://uri.suomi.fi/datamodel/ns/int", internalDTO.getNamespace());
 
-        var externalDTO = result.getExternalNamespaces().stream().findFirst().orElseThrow();
+        var externalDTO = result.getExternalNamespaces().stream()
+                .filter(ns -> ns.getNamespace().equals("https://www.example.com/ns/ext"))
+                .findFirst()
+                .orElseThrow();
         assertEquals("test resource", externalDTO.getName());
         assertEquals("extres", externalDTO.getPrefix());
         assertEquals("https://www.example.com/ns/ext", externalDTO.getNamespace());

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
@@ -28,7 +28,7 @@ class PropertyShapeMapperTest {
         dto.setStatus(Status.DRAFT);
         dto.setLabel(Map.of("fi", "PropertyShape label"));
         dto.setIdentifier("ps-1");
-        dto.setPath("http://uri.suomi.fi/datamodel/ns/test_attribute");
+        dto.setPath("http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0/test_attribute");
         dto.setAllowedValues(List.of("Value 1", "Value 2"));
         dto.setDataType("xsd:integer");
         dto.setDefaultValue("default");
@@ -49,7 +49,7 @@ class PropertyShapeMapperTest {
 
         assertEquals("PropertyShape label", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test_attribute", resource.getProperty(SH.path).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0/test_attribute", resource.getProperty(SH.path).getObject().toString());
         assertTrue(MapperUtils.hasType(resource, OWL.DatatypeProperty, SH.PropertyShape));
         assertTrue(allowedValues.containsAll(List.of("Value 1", "Value 2")));
         assertEquals("xsd:integer", MapperUtils.propertyToString(resource, SH.datatype));
@@ -75,7 +75,7 @@ class PropertyShapeMapperTest {
         dto.setStatus(Status.DRAFT);
         dto.setLabel(Map.of("fi", "PropertyShape label"));
         dto.setIdentifier("ps-1");
-        dto.setPath("http://uri.suomi.fi/datamodel/ns/test_attribute");
+        dto.setPath("http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0/test_attribute");
         dto.setMaxCount(10);
         dto.setMinCount(1);
         dto.setClassType("http://uri.suomi.fi/datamodel/ns/test/TestClass");
@@ -85,7 +85,7 @@ class PropertyShapeMapperTest {
 
         assertEquals("PropertyShape label", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test_attribute", resource.getProperty(SH.path).getObject().toString());
+        assertEquals("http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0/test_attribute", resource.getProperty(SH.path).getObject().toString());
         assertTrue(MapperUtils.hasType(resource, OWL.ObjectProperty, SH.PropertyShape));
         assertEquals(10, MapperUtils.getLiteral(resource, SH.maxCount, Integer.class));
         assertEquals(1, MapperUtils.getLiteral(resource, SH.minCount, Integer.class));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -731,6 +731,44 @@ class ResourceMapperTest {
         assertEquals(newRange, updated.get().asResource().getProperty(OWL.someValuesFrom).getObject().toString());
     }
 
+    @Test
+    void testMapReferenceResourceAndAddNamespace() {
+        var model = ModelFactory.createDefaultModel();
+        var modelURI = "http://uri.suomi.fi/datamodel/ns/test-library";
+        model.createResource(modelURI)
+                .addProperty(RDF.type, OWL.Ontology);
+
+        var attrDTO = new ResourceDTO();
+        attrDTO.setStatus(Status.DRAFT);
+        attrDTO.setIdentifier("attr-1");
+        attrDTO.setSubResourceOf(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "ns-int-1/sub"));
+        attrDTO.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "ns-int-2/eq"));
+
+        ResourceMapper.mapToResource(modelURI, model, attrDTO, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
+
+        assertEquals(2, model.getResource(modelURI).listProperties(OWL.imports).toList().size());
+    }
+
+    @Test
+    void testMapReferencePropertyShapeAndAddNamespace() {
+        var model = ModelFactory.createDefaultModel();
+
+        var modelURI = "http://uri.suomi.fi/datamodel/ns/test-profile";
+
+        model.createResource(modelURI)
+                .addProperty(RDF.type, Iow.ApplicationProfile);
+
+        var propertyShape = new AssociationRestriction();
+        propertyShape.setStatus(Status.DRAFT);
+        propertyShape.setIdentifier("ps-1");
+        propertyShape.setPath(ModelConstants.SUOMI_FI_NAMESPACE + "/test_lib_2/path");
+        propertyShape.setClassType(ModelConstants.SUOMI_FI_NAMESPACE + "test_lib_2/class");
+
+        ResourceMapper.mapToPropertyShapeResource(modelURI, model, propertyShape, ResourceType.ASSOCIATION, EndpointUtils.mockUser);
+
+        assertEquals(2, model.getResource(modelURI).listProperties(DCTerms.requires).toList().size());
+    }
+
     private Model getOrgModel(){
         var model = ModelFactory.createDefaultModel();
               model.createResource("urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -19,7 +19,7 @@
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
         owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
-        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/terminology/test> ;
+        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/terminology/test> , owl: ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
         dcap:preferredXMLNamespacePrefix


### PR DESCRIPTION
While saving references to other data modes (e.g. adding subClassOf), add namespace to the data model's metadata (owl:imports or dcterms:requires) if it's not already present.