### PR TITLE
YTI-3328 check that identifier starts with letter

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -23,7 +23,7 @@ public class ValidationConstants {
     public static final int RESOURCE_IDENTIFIER_MAX_LENGTH = 32;
     public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
 
-    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z0-9-_]+";
+    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]+";
 
     public static final Map<String, String> RESERVED_NAMESPACES = Map.ofEntries(
             Map.entry("owl", "http://www.w3.org/2002/07/owl#"),


### PR DESCRIPTION
If identifier contains only numbers, resources getLocalname method doesn't work (returns empty string)