### PR TITLE
YTI-3563 indentifier and prefix validation

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
@@ -90,7 +90,7 @@ abstract class BaseResourceService {
             return true;
         }
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
-        return coreRepository.resourceExistsInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier);
+        return coreRepository.resourceExistsInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + identifier, false);
     }
 
     public URI renameResource(String prefix, String oldIdentifier, String newIdentifier) throws URISyntaxException {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -155,7 +155,7 @@ public class ClassService extends BaseResourceService {
     public URI create(String prefix, BaseDTO dto, boolean applicationProfile) throws URISyntaxException {
         var modelUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var classUri = modelUri + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier();
-        if(coreRepository.resourceExistsInGraph(modelUri, classUri)){
+        if(coreRepository.resourceExistsInGraph(modelUri, classUri, false)){
             throw new MappingError("Class already exists");
         }
         var model = coreRepository.fetch(modelUri);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -103,7 +103,7 @@ public class ResourceService extends BaseResourceService {
     public URI create(String prefix, BaseDTO dto, @Nonnull ResourceType resourceType, boolean applicationProfile) throws URISyntaxException {
         var graphUri = ModelConstants.SUOMI_FI_NAMESPACE + prefix;
         var resourceUri = graphUri + ModelConstants.RESOURCE_SEPARATOR + dto.getIdentifier();
-        if (coreRepository.resourceExistsInGraph(graphUri, resourceUri)){
+        if (coreRepository.resourceExistsInGraph(graphUri, resourceUri, false)){
             throw new MappingError("Already exists");
         }
         var model = coreRepository.fetch(graphUri);
@@ -163,7 +163,7 @@ public class ResourceService extends BaseResourceService {
         if(!coreRepository.resourceExistsInGraph(graphUri, graphUri + ModelConstants.RESOURCE_SEPARATOR + propertyShapeIdentifier)){
             throw new ResourceNotFoundException(propertyShapeIdentifier);
         }
-        if(coreRepository.resourceExistsInGraph(targetGraph, targetResource)){
+        if(coreRepository.resourceExistsInGraph(targetGraph, targetResource, false)){
             throw new MappingError("Identifier in use");
         }
 
@@ -241,5 +241,4 @@ public class ResourceService extends BaseResourceService {
         }
         return null;
      }
-
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -43,7 +43,6 @@ public abstract class BaseValidator implements Annotation{
         this.constraintViolationAdded = constraintViolationAdded;
     }
 
-
     public void checkLabel(ConstraintValidatorContext context, BaseDTO dto){
         checkRequiredLocalizedValue(context, dto.getLabel(), "label");
     }
@@ -74,33 +73,12 @@ public abstract class BaseValidator implements Annotation{
         }
     }
 
-    public void checkIdentifier(ConstraintValidatorContext context, final String value, String propertyName, final int maxLength, boolean update) {
-        if (!update && (value == null || value.trim().isBlank())) {
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
-        } else if (update && value != null) {
-            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
-        } else if (value != null && !value.matches(ValidationConstants.RESOURCE_IDENTIFIER_REGEX)) {
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, propertyName);
-        } else if (value != null && (value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > maxLength)) {
-            addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
-        }
+    public void checkIdentifier(ConstraintValidatorContext context, final String value, boolean update) {
+        checkPrefixOrIdentifier(context, value, "identifier", ValidationConstants.RESOURCE_IDENTIFIER_REGEX, update);
     }
 
-    public void checkPrefixOrIdentifier(ConstraintValidatorContext context, final String value, String propertyName, final int maxLength, boolean update) {
-        if (!update && (value == null || value.trim().isBlank())) {
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
-            return;
-        } else if (update && value != null) {
-            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
-            return;
-        } else if (value == null) {
-            //no need to check further if null
-            return;
-        }
-
-        if (value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > maxLength) {
-            addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
-        }
+    public void checkPrefix(ConstraintValidatorContext context, final String value, String propertyName, boolean update) {
+        checkPrefixOrIdentifier(context, value, propertyName, ValidationConstants.PREFIX_REGEX, update);
     }
 
     public void checkReservedIdentifier(ConstraintValidatorContext context, BaseDTO dto) {
@@ -149,6 +127,18 @@ public abstract class BaseValidator implements Annotation{
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, property);
         } else {
             value.forEach((lang, v) -> checkCommonTextField(context, v, property));
+        }
+    }
+
+    private void checkPrefixOrIdentifier(ConstraintValidatorContext context, String value, String propertyName, String regexp, boolean update) {
+        if (update && value != null) {
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
+        } else if (value == null || value.isBlank()) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
+        } else if (!value.matches(regexp)) {
+            addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, propertyName);
+        } else if (value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > ValidationConstants.PREFIX_MAX_LENGTH) {
+            addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -133,11 +133,13 @@ public abstract class BaseValidator implements Annotation{
     private void checkPrefixOrIdentifier(ConstraintValidatorContext context, String value, String propertyName, String regexp, boolean update) {
         if (update && value != null) {
             addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, propertyName);
-        } else if (value == null || value.isBlank()) {
+        } else if (!update && (value == null || value.isBlank())) {
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
-        } else if (!value.matches(regexp)) {
+        } else if (value != null && !value.matches(regexp)) {
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, propertyName);
-        } else if (value.length() < ValidationConstants.PREFIX_MIN_LENGTH || value.length() > ValidationConstants.PREFIX_MAX_LENGTH) {
+        } else if (value != null && (
+                value.length() < ValidationConstants.PREFIX_MIN_LENGTH
+                        || value.length() > ValidationConstants.PREFIX_MAX_LENGTH)) {
             addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ClassValidator.java
@@ -34,7 +34,7 @@ public class ClassValidator extends BaseValidator implements
         checkClassResolvable(context, classDTO.getSubClassOf(), "subClassOf");
         checkClassResolvable(context, classDTO.getDisjointWith(), "disjointWith");
         checkSubject(context, classDTO);
-        checkPrefixOrIdentifier(context, classDTO.getIdentifier(), "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, updateClass);
+        checkIdentifier(context, classDTO.getIdentifier(), updateClass);
         checkReservedIdentifier(context, classDTO);
 
         return !isConstraintViolationAdded();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -28,7 +28,7 @@ public class DataModelValidator extends BaseValidator implements
     @Override
     public boolean isValid(DataModelDTO dataModel, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
-        checkPrefix(context, dataModel);
+        checkModelPrefix(context, dataModel);
         checkLanguages(context, dataModel);
         checkLabels(context, dataModel);
         checkDescription(context, dataModel);
@@ -52,14 +52,16 @@ public class DataModelValidator extends BaseValidator implements
      * @param context Constraint validator context
      * @param dataModel DataModel
      */
-    private void checkPrefix(ConstraintValidatorContext context, DataModelDTO dataModel){
+    private void checkModelPrefix(ConstraintValidatorContext context, DataModelDTO dataModel){
         final var prefixPropertyLabel = "prefix";
         var prefix = dataModel.getPrefix();
-        checkPrefixOrIdentifier(context, prefix, prefixPropertyLabel, ValidationConstants.PREFIX_MAX_LENGTH, updateModel);
-        //Check prefix text content
+
+        checkPrefix(context, prefix, prefixPropertyLabel, updateModel);
+        // Check prefix text content
         checkPrefixContent(context, prefix, prefixPropertyLabel);
-        //Checking if in use is different for datamodels and its resources so it is not in the above function
-        if(coreRepository.graphExists(ModelConstants.SUOMI_FI_NAMESPACE + prefix)){
+
+        if (coreRepository.graphExists(ModelConstants.SUOMI_FI_NAMESPACE + prefix)) {
+            // Checking if in use is different for data models and its resources so it is not in the above function
             addConstraintViolation(context, "prefix-in-use", prefixPropertyLabel);
         }
     }
@@ -199,7 +201,7 @@ public class DataModelValidator extends BaseValidator implements
             if(namespace.getPrefix() == null || namespace.getNamespace() == null){
                 addConstraintViolation(context, "namespace-missing-value", externalNamespace);
             }else {
-                checkPrefixOrIdentifier(context, namespace.getPrefix(), externalNamespace, ValidationConstants.PREFIX_MAX_LENGTH, false);
+                checkPrefix(context, namespace.getPrefix(), externalNamespace, false);
                 if(namespace.getNamespace().startsWith(ModelConstants.SUOMI_FI_NAMESPACE)){
                     addConstraintViolation(context, "namespace-not-external", externalNamespace);
                 }
@@ -222,10 +224,6 @@ public class DataModelValidator extends BaseValidator implements
         if(ValidationConstants.RESERVED_WORDS.contains(prefix)
                 || ValidationConstants.RESERVED_NAMESPACES.containsKey(prefix)){
             addConstraintViolation(context, "prefix-is-reserved", property);
-        }
-
-        if(!prefix.matches(ValidationConstants.PREFIX_REGEX)){
-            addConstraintViolation(context, "prefix-not-matching-pattern", property);
         }
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
@@ -33,7 +33,7 @@ public class NodeShapeValidator extends BaseValidator implements
         checkNote(context, nodeShapeDTO);
         checkStatus(context, nodeShapeDTO.getStatus());
         checkSubject(context, nodeShapeDTO);
-        checkPrefixOrIdentifier(context, nodeShapeDTO.getIdentifier(), "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, updateNodeShape);
+        checkIdentifier(context, nodeShapeDTO.getIdentifier(), updateNodeShape);
         checkReservedIdentifier(context, nodeShapeDTO);
         checkTargetClass(context, nodeShapeDTO);
         checkTargetNode(context, nodeShapeDTO);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
@@ -34,7 +34,7 @@ public class PropertyShapeValidator extends BaseValidator implements ConstraintV
         checkEditorialNote(context, value);
         checkStatus(context, value.getStatus());
         checkNote(context, value);
-        checkPrefixOrIdentifier(context, value.getIdentifier(), "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, updateProperty);
+        checkIdentifier(context, value.getIdentifier(), updateProperty);
         checkPath(context, value);
         if(resourceType.equals(ResourceType.ASSOCIATION)){
             checkClassType(context, (AssociationRestriction) value);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceIdentifierValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceIdentifierValidator.java
@@ -9,7 +9,7 @@ public class ResourceIdentifierValidator extends BaseValidator implements
     @Override
     public boolean isValid(String identifier, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
-        checkIdentifier(context, identifier, "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, false);
+        checkIdentifier(context, identifier, false);
         return !isConstraintViolationAdded();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ResourceValidator.java
@@ -41,7 +41,7 @@ public class ResourceValidator extends BaseValidator implements ConstraintValida
         checkNote(context, value);
         checkEquivalentProperty(context, value);
         checkSubPropertyOf(context, value);
-        checkPrefixOrIdentifier(context, value.getIdentifier(), "identifier", ValidationConstants.RESOURCE_IDENTIFIER_MAX_LENGTH, updateProperty);
+        checkIdentifier(context, value.getIdentifier(), updateProperty);
         checkDomain(context, value);
         checkRange(context, value);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -21,7 +21,6 @@ public class ValidationConstants {
 
     public static final int PREFIX_MIN_LENGTH = 2;
     public static final int PREFIX_MAX_LENGTH = 32;
-    public static final int RESOURCE_IDENTIFIER_MAX_LENGTH = 32;
     public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
 
     public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]+";

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -123,7 +123,7 @@ class ClassServiceTest {
             mapper.verify(() -> ClassMapper.createOntologyClassAndMapToModel(anyString(), any(Model.class), any(ClassDTO.class), any(YtiUser.class)));
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verify(terminologyService).resolveConcept(anyString());
@@ -145,7 +145,7 @@ class ClassServiceTest {
             mapper.verify(() -> ClassMapper.createNodeShapeAndMapToModel(anyString(), any(Model.class), any(NodeShapeDTO.class), any(YtiUser.class)));
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verify(terminologyService).resolveConcept(anyString());
@@ -222,7 +222,7 @@ class ClassServiceTest {
         assertTrue(response);
 
         //exists
-        when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
+        when(coreRepository.resourceExistsInGraph(anyString(), anyString(), eq(false))).thenReturn(true);
         response = classService.exists("test", "Identifier");
         assertTrue(response);
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -132,7 +132,7 @@ class ResourceServiceTest {
             assertEquals("http://uri.suomi.fi/datamodel/ns/test/Identifier", uri.toString());
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verify(terminologyService).resolveConcept(anyString());
@@ -155,7 +155,7 @@ class ResourceServiceTest {
             assertEquals("http://uri.suomi.fi/datamodel/ns/test/Identifier", uri.toString());
         }
 
-        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
         verify(terminologyService).resolveConcept(anyString());
@@ -238,7 +238,8 @@ class ResourceServiceTest {
             var uri = resourceService.copyPropertyShape("test", "Identifier", "newTest", "newId");
             assertEquals("http://uri.suomi.fi/datamodel/ns/newTest/newId", uri.toString());
         }
-        verify(coreRepository, times(2)).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
+        verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository, times(2)).fetch(anyString());
         verify(authorizationManager, times(2)).hasRightToModel(anyString(), any(Model.class));
     }
@@ -251,7 +252,7 @@ class ResourceServiceTest {
     @Test
     void failCopyPropertyShapeIdInUse() {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
-
+        when(coreRepository.resourceExistsInGraph(anyString(), anyString(), eq(false))).thenReturn(true);
         var error = assertThrows(MappingError.class, () ->resourceService.copyPropertyShape("test", "Identifier", "newTest", "newId"));
         assertEquals("Error during mapping: Identifier in use", error.getMessage());
 
@@ -289,7 +290,7 @@ class ResourceServiceTest {
         assertTrue(result);
         result = resourceService.exists("test", "Free");
         assertFalse(result);
-        when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
+        when(coreRepository.resourceExistsInGraph(anyString(), anyString(), eq(false))).thenReturn(true);
         result = resourceService.exists("test", "NotFree");
         assertTrue(result);
     }


### PR DESCRIPTION
- case-insensitive check if resource exists, e.g. if resource with identifier 'test' exists, cannot create resource with identifier 'Test'
- create separate methods for prefix and identifier validation