### PR TITLE
YTI-3571 support version in uri resolving

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/UriResolveService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/UriResolveService.java
@@ -3,11 +3,13 @@ package fi.vm.yti.datamodel.api.v2.service;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.utils.SemVer;
 import org.apache.jena.iri.IRI;
 import org.apache.jena.iri.IRIFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -36,18 +38,38 @@ public class UriResolveService {
             return ResponseEntity.badRequest().build();
         }
 
-        String resourcePath = iri.substring(ModelConstants.SUOMI_FI_NAMESPACE.length());
-        var parts = resourcePath.split("\\W");
-        String resource = null;
+        String resourcePath = iri.substring(ModelConstants.SUOMI_FI_NAMESPACE.length())
+                .split("\\?")[0];
+        var parts = resourcePath.split("/");
 
         if (parts.length == 0) {
             return ResponseEntity.badRequest().build();
         }
 
-        var modelPrefix = parts[0];
-        if (parts.length == 2) {
-            // single resource
-            resource = parts[1];
+        var redirectURL = buildURL(parts, accept);
+        return ResponseEntity
+                .status(HttpStatus.SEE_OTHER)
+                .header(HttpHeaders.LOCATION, redirectURL)
+                .build();
+    }
+
+    @NotNull
+    private String buildURL(String[] parts, String accept) {
+        String modelPrefix = parts[0];
+        String resource = null;
+        String version = null;
+
+        for (var i = 1; i < parts.length; i++) {
+            var p = parts[i];
+            if (i == 1) {
+                if (p.matches(SemVer.VALID_REGEX)) {
+                    version = p;
+                } else {
+                    resource = p;
+                }
+            } else if (i == 2) {
+                resource = p;
+            }
         }
 
         var currentUrl = ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUri();
@@ -63,17 +85,16 @@ public class UriResolveService {
                     .append("/model/")
                     .append(modelPrefix);
             appendResource(redirectURL, modelPrefix, resource);
+            redirectURL.append(version != null ? "?ver=" + version : "");
         } else {
             // redirect to serialized resource
             redirectURL
                     .append("/datamodel-api/v2/export/")
                     .append(modelPrefix)
-                    .append(resource != null ? "/" + resource : "");
+                    .append(resource != null ? "/" + resource : "")
+                    .append(version != null ? "?version=" + version : "");
         }
-        return ResponseEntity
-                .status(HttpStatus.SEE_OTHER)
-                .header(HttpHeaders.LOCATION, redirectURL.toString())
-                .build();
+        return redirectURL.toString();
     }
 
     private void appendResource(StringBuilder redirectURL, String modelPrefix, String resource) {

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/UriResolveServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/UriResolveServiceTest.java
@@ -38,10 +38,10 @@ class UriResolveServiceTest {
     @Test
     void testRedirectSiteModel() {
         var accept = "text/html";
-        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test", accept);
+        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test/1.0.1", accept);
         assertTrue(response.getStatusCode().is3xxRedirection());
         assertNotNull(response.getHeaders().getLocation());
-        assertTrue(response.getHeaders().getLocation().toString().endsWith("/model/test"));
+        assertTrue(response.getHeaders().getLocation().toString().endsWith("/model/test?ver=1.0.1"));
     }
 
     @Test
@@ -49,11 +49,10 @@ class UriResolveServiceTest {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
         when(coreRepository.fetch(anyString())).thenReturn(model);
 
-
         var pathMap = Map.of(
-                "http://uri.suomi.fi/datamodel/ns/test/TestClass", "/model/test/class/TestClass",
-                "http://uri.suomi.fi/datamodel/ns/test/TestAttribute", "/model/test/attribute/TestAttribute",
-                "http://uri.suomi.fi/datamodel/ns/test/TestAssociation", "/model/test/association/TestAssociation"
+                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", "/model/test/class/TestClass?ver=1.0.1",
+                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAttribute", "/model/test/attribute/TestAttribute?ver=1.0.1",
+                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAssociation", "/model/test/association/TestAssociation?ver=1.0.1"
         );
         var accept = "text/html";
         for (var key : pathMap.keySet()) {
@@ -70,10 +69,10 @@ class UriResolveServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
 
         var accept = "text/turtle";
-        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test/TestClass", accept);
+        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", accept);
         assertTrue(response.getStatusCode().is3xxRedirection());
         assertNotNull(response.getHeaders().getLocation());
-        assertTrue(response.getHeaders().getLocation().toString().endsWith("/datamodel-api/v2/export/test/TestClass"));
+        assertTrue(response.getHeaders().getLocation().toString().endsWith("/datamodel-api/v2/export/test/TestClass?version=1.0.1"));
     }
 
     @Test


### PR DESCRIPTION
Extract version from uri if present and add required version parameter to generated url

Example
`http://uri.suomi.fi/datamodel/ns/testmodel/1.0.0` redirects to `/model/testmodel?ver=1.0.0` or `/datamodel-api/v2/export/testmodel?version=1.0.0` if accept header is something else than text/html
