### PR TITLE
YTI-3253: Remove unnecessary prefixes for export

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/VisualizationClassDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/VisualizationClassDTO.java
@@ -3,9 +3,7 @@ package fi.vm.yti.datamodel.api.v2.dto.visualization;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class VisualizationClassDTO extends VisualizationNodeDTO {
     private List<VisualizationAttributeDTO> attributes = new ArrayList<>();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -205,8 +205,6 @@ public class ClassMapper {
         var classResource = model.getResource(classUri);
         var modelResource = model.getResource(modelUri);
 
-        DataModelUtils.addPrefixesToModel(modelResource.getURI(), model);
-
         MapperUtils.addCommonResourceDtoInfo(dto, classResource, modelResource, orgModel, hasRightToModel);
         MapperUtils.mapCreationInfo(dto, classResource, userMapper);
 
@@ -230,8 +228,6 @@ public class ClassMapper {
         var nodeShapeURI = modelUri + ModelConstants.RESOURCE_SEPARATOR + identifier;
         var nodeShapeResource = model.getResource(nodeShapeURI);
         var modelResource = model.getResource(modelUri);
-
-        DataModelUtils.addPrefixesToModel(modelUri, model);
 
         MapperUtils.addCommonResourceDtoInfo(dto, nodeShapeResource, modelResource, orgModel, hasRightToModel);
         MapperUtils.mapCreationInfo(dto, nodeShapeResource, userMapper);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -5,7 +5,6 @@ import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.*;
 import fi.vm.yti.datamodel.api.v2.properties.Iow;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
-import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import fi.vm.yti.security.YtiUser;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.*;
@@ -365,8 +364,6 @@ public class ResourceMapper {
         var resourceUri = modelUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier;
         var resourceResource = model.getResource(resourceUri);
 
-        DataModelUtils.addPrefixesToModel(modelUri, model);
-
         MapperUtils.addCommonResourceDtoInfo(dto, resourceResource, model.getResource(modelUri), orgModel, hasRightToModel);
 
         if(MapperUtils.hasType(resourceResource, OWL.ObjectProperty)){
@@ -404,8 +401,6 @@ public class ResourceMapper {
         var dto = new PropertyShapeInfoDTO();
         var resourceUri = modelUri + ModelConstants.RESOURCE_SEPARATOR + identifier;
         var resource = model.getResource(resourceUri);
-
-        DataModelUtils.addPrefixesToModel(modelUri, model);
 
         MapperUtils.addCommonResourceDtoInfo(dto, resource, model.getResource(modelUri), orgModel, hasRightToModel);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JenaService.java
@@ -24,7 +24,6 @@ public class JenaService {
 
     public void setVersionNumber(int version) {
         var versionModel = ModelFactory.createDefaultModel().addLiteral(ResourceFactory.createResource(VERSION_NUMBER_GRAPH), OWL.versionInfo, version);
-        versionModel.setNsPrefix("owl", "http://www.w3.org/2002/07/owl#");
         coreRepository.put(VERSION_NUMBER_GRAPH, versionModel);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
@@ -25,6 +25,7 @@ public class DataModelUtils {
     }
 
     public static void addPrefixesToModel(String modelURI, Model model) {
+        model.clearNsPrefixMap();
         model.setNsPrefixes(ModelConstants.PREFIXES);
         model.setNsPrefix(MapperUtils.getModelIdFromNamespace(modelURI), modelURI + ModelConstants.RESOURCE_SEPARATOR);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -333,7 +333,6 @@ class ClassMapperTest {
     void testMapAndRemoveAnonymousRestrictions() {
 
         var model = MapperTestUtils.getModelFromFile("/model_with_owl_restrictions.ttl");
-        model.setNsPrefixes(ModelConstants.PREFIXES);
 
         var classResource1 = model.getResource("http://uri.suomi.fi/datamodel/ns/model/class-1");
         var classResource2 = model.getResource("http://uri.suomi.fi/datamodel/ns/model/class-2");
@@ -386,7 +385,6 @@ class ClassMapperTest {
     @Test
     void testMapUpdateClassRestriction() {
         var model = MapperTestUtils.getModelFromFile("/model_with_owl_restrictions.ttl");
-        model.setNsPrefixes(ModelConstants.PREFIXES);
 
         var classResource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "model/class-update-target");
         var restrictionURI = ModelConstants.SUOMI_FI_NAMESPACE + "model/association-1";
@@ -409,7 +407,6 @@ class ClassMapperTest {
     @Test
     void testMapUpdateClassRestrictionDuplicate() {
         var model = MapperTestUtils.getModelFromFile("/model_with_owl_restrictions.ttl");
-        model.setNsPrefixes(ModelConstants.PREFIXES);
 
         var classResource = model.getResource("http://uri.suomi.fi/datamodel/ns/model/class-update-target");
         var restrictionURI = "http://uri.suomi.fi/datamodel/ns/model/association-1";


### PR DESCRIPTION
Remove unnecessary prefixes on export
Remove setting of prefixes everywhere, these prefixes are not really used by code so they are only necessary when exporting the triplets. 