### PR TITLE
YTI-3610: Include draft from from models query added

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ResourceSearchRequest.java
@@ -15,6 +15,7 @@ public class ResourceSearchRequest extends BaseSearchRequest{
     private String targetClass;
     private Set<String> additionalResources;
     private String fromVersion;
+    private Set<String> includeDraftFrom;
 
     public String getLimitToDataModel() {
         return limitToDataModel;
@@ -78,5 +79,13 @@ public class ResourceSearchRequest extends BaseSearchRequest{
 
     public void setFromVersion(String fromVersion) {
         this.fromVersion = fromVersion;
+    }
+
+    public Set<String> getIncludeDraftFrom() {
+        return includeDraftFrom;
+    }
+
+    public void setIncludeDraftFrom(Set<String> includeDraftFrom) {
+        this.includeDraftFrom = includeDraftFrom;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -39,9 +39,8 @@ public class ResourceQueryFactory {
             must.add(QueryFactoryUtils.labelQuery(query));
         }
 
-        if(request.getLimitToDataModel() != null || internalNamespaces != null || restrictedDataModels != null || externalNamespaces != null) {
-            must.add(getIncludedNamespacesQuery(request, externalNamespaces, internalNamespaces, restrictedDataModels));
-        }
+        must.add(getIncludedNamespacesQuery(request, externalNamespaces, internalNamespaces, restrictedDataModels));
+
 
         var types = request.getResourceTypes();
         if(types != null && !types.isEmpty()){
@@ -86,6 +85,10 @@ public class ResourceQueryFactory {
 
         if (restrictedDataModels == null || restrictedDataModels.contains(request.getLimitToDataModel())) {
             builder.should(addCurrentModelQuery(request));
+        }
+
+        if(request.getIncludeDraftFrom() != null && !request.getIncludeDraftFrom().isEmpty()) {
+            builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", request.getIncludeDraftFrom()));
         }
 
         builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", externalNamespaces))


### PR DESCRIPTION
Changelog:
- Remove if check on includedNamespacesQuery since restrictedDatamodels will never be null
- Add include draft from to resource query 
  - this is so that in case someone uses all datamodels filter and still wants to see the currently edited datamodel