### PR TITLE
YTI-3223: Added audit logging to user callable functions

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -4,7 +4,10 @@ import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
 import fi.vm.yti.datamodel.api.v2.dto.UriDTO;
-import fi.vm.yti.datamodel.api.v2.opensearch.dto.*;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountSearchResponse;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
+import fi.vm.yti.datamodel.api.v2.opensearch.dto.SearchResponseDTO;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
@@ -18,8 +21,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.jena.graph.NodeFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,8 +39,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RequestMapping("v2/frontend")
 @Tag(name = "Frontend")
 public class FrontendController {
-
-    private static final Logger logger = LoggerFactory.getLogger(FrontendController.class);
     private final SearchIndexService searchIndexService;
     private final FrontendService frontendService;
     private final AuthenticatedUserProvider userProvider;
@@ -62,7 +61,6 @@ public class FrontendController {
     })
     @GetMapping(path = "/counts", produces = MediaType.APPLICATION_JSON_VALUE)
     public CountSearchResponse getCounts(@Parameter(description = "Count request parameters") ModelSearchRequest request) {
-        logger.info("GET /counts requested");
         return searchIndexService.getCounts(request, userProvider.getUser());
     }
 
@@ -72,7 +70,6 @@ public class FrontendController {
     public Collection<OrganizationDTO> getOrganizations(
             @RequestParam(required = false, defaultValue = ModelConstants.DEFAULT_LANGUAGE) @Parameter(description = "Alphabetical sorting language") String sortLang,
             @RequestParam(required = false) @Parameter(description = "Include child organizations in response") boolean includeChildOrganizations) {
-        logger.info("GET /organizations requested");
         return frontendService.getOrganizations(sortLang, includeChildOrganizations);
     }
 
@@ -80,7 +77,6 @@ public class FrontendController {
     @ApiResponse(responseCode = "200", description = "Service categories as JSON")
     @GetMapping(path = "/service-categories", produces = MediaType.APPLICATION_JSON_VALUE)
     public Collection<ServiceCategoryDTO> getServiceCategories(@RequestParam(required = false, defaultValue = ModelConstants.DEFAULT_LANGUAGE) @Parameter(description = "Alphabetical sorting language") String sortLang) {
-        logger.info("GET /serviceCategories requested");
         return frontendService.getServiceCategories(sortLang);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/AuditService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/AuditService.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import fi.vm.yti.security.YtiUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuditService {
+
+    private final Logger logger = LoggerFactory.getLogger(AuditService.class);
+    private final String entityType;
+
+
+    public AuditService(String entity) {
+        this.entityType = entity;
+    }
+
+    public void log(ActionType type, String uri, YtiUser user) {
+        if(user.isAnonymous()) {
+            return;
+        }
+        logger.info("{} {}: <{}>, User[email={}, id={}]", entityType, type, uri, user.getEmail(), user.getId());
+    }
+
+    public enum ActionType {
+        CREATE,
+        UPDATE,
+        DELETE,
+        SAVE,
+    }
+
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/AuditService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/AuditService.java
@@ -18,7 +18,7 @@ public class AuditService {
         if(user.isAnonymous()) {
             return;
         }
-        logger.info("{} {}: <{}>, User[email={}, id={}]", entityType, type, uri, user.getEmail(), user.getId());
+        logger.info("{} {}: <{}>, User[id={}]", entityType, type, uri, user.getId());
     }
 
     public enum ActionType {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -24,6 +24,7 @@ import static fi.vm.yti.security.AuthorizationException.check;
 @Service
 public class NamespaceResolver {
 
+    private final AuditService auditService = new AuditService("NAMESPACE");
     private final Logger logger = LoggerFactory.getLogger(NamespaceResolver.class);
 
     private final ImportsRepository importsRepository;
@@ -40,6 +41,7 @@ public class NamespaceResolver {
 
     public boolean resolve(String namespace, boolean force) {
         check(!userProvider.getUser().getOrganizations(Role.DATA_MODEL_EDITOR, Role.ADMIN).isEmpty());
+        auditService.log(AuditService.ActionType.UPDATE, namespace, userProvider.getUser());
         if(!force && namespaceAlreadyResolved(namespace)){
             throw new ResolvingException("Already resolved", "Use force parameter to force resolving");
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -37,6 +37,7 @@ import static fi.vm.yti.security.AuthorizationException.check;
 @Service
 public class ResourceService extends BaseResourceService {
 
+    private static final AuditService AUDIT_SERVICE = new AuditService("RESOURCE");
     private final CoreRepository coreRepository;
     private final ImportsRepository importsRepository;
     private final AuthorizationManager authorizationManager;
@@ -54,7 +55,7 @@ public class ResourceService extends BaseResourceService {
                            CodeListService codeListService,
                            AuthenticatedUserProvider userProvider,
                            OpenSearchIndexer openSearchIndexer){
-        super(coreRepository, importsRepository, authorizationManager, openSearchIndexer);
+        super(coreRepository, importsRepository, authorizationManager, openSearchIndexer, AUDIT_SERVICE, userProvider);
         this.coreRepository = coreRepository;
         this.importsRepository = importsRepository;
         this.authorizationManager = authorizationManager;
@@ -126,6 +127,7 @@ public class ResourceService extends BaseResourceService {
         }
 
         saveResource(model, graphUri, resourceUri, false);
+        AUDIT_SERVICE.log(AuditService.ActionType.CREATE, resourceUri, userProvider.getUser());
         return new URI(resourceUri);
     }
 
@@ -157,6 +159,7 @@ public class ResourceService extends BaseResourceService {
         terminologyService.resolveConcept(dto.getSubject());
 
         saveResource(model, graphUri, resourceUri, true);
+        AUDIT_SERVICE.log(AuditService.ActionType.UPDATE, resourceUri, userProvider.getUser());
     }
 
     public URI copyPropertyShape(String prefix, String propertyShapeIdentifier, String targetPrefix, String newIdentifier) throws URISyntaxException {
@@ -183,6 +186,7 @@ public class ResourceService extends BaseResourceService {
         ResourceMapper.mapToCopyToLocalPropertyShape(graphUri, model, propertyShapeIdentifier, targetModel, targetGraph, newIdentifier, userProvider.getUser());
 
         saveResource(targetModel, targetGraph, targetResource, false);
+        AUDIT_SERVICE.log(AuditService.ActionType.CREATE, targetResource, userProvider.getUser());
         return new URI(targetResource);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
 import fi.vm.yti.datamodel.api.v2.endpoint.error.*;
+import fi.vm.yti.security.AuthorizationException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.hibernate.validator.internal.engine.path.PathImpl;
@@ -38,6 +39,13 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
             @NotNull HttpStatusCode status,
             @NotNull WebRequest request) {
         return buildResponseEntity(new ApiError(HttpStatus.BAD_REQUEST, "Malformed JSON request", ex));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    protected ResponseEntity<Object> handleAuthorizationException(AuthorizationException ex) {
+        var apiError = new ApiError(HttpStatus.UNAUTHORIZED);
+        apiError.setMessage(ex.getMessage());
+        return buildResponseEntity(apiError);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/OpenSearchIndexerTest.java
@@ -8,6 +8,7 @@ import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.OpenSearchIndexer;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import fi.vm.yti.datamodel.api.v2.repository.ImportsRepository;
+import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResIterator;
@@ -46,6 +47,9 @@ class OpenSearchIndexerTest {
 
     @MockBean
     AuthorizationManager authorizationManager;
+
+    @MockBean
+    AuthenticatedUserProvider userProvider;
 
     @MockBean
     OpenSearchClient client;

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -203,6 +203,7 @@ class ClassServiceTest {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         classService.delete("test", "Identifier");
 
         verify(coreRepository).fetch(anyString());
@@ -235,6 +236,7 @@ class ClassServiceTest {
     void handlePropertyShapeReferencePut(){
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         try(var mapper = mockStatic(ClassMapper.class)) {
             classService.handlePropertyShapeReference("test", "node-shape-1", "http://uri.suomi.fi/datamodel/ns/test/ref-1", false);
             mapper.verify(() -> ClassMapper.mapAppendNodeShapeProperty( any(Resource.class), anyString(), anySet()));
@@ -249,6 +251,7 @@ class ClassServiceTest {
     void handlePropertyShapeReferenceDelete(){
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         try(var mapper = mockStatic(ClassMapper.class)) {
             classService.handlePropertyShapeReference("test", "node-shape-1", "http://uri.suomi.fi/datamodel/ns/test/ref-1", true);
             mapper.verify(() -> ClassMapper.mapRemoveNodeShapeProperty(any(Model.class), any(Resource.class), anyString(), anySet()));
@@ -264,6 +267,7 @@ class ClassServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         try(var mapper = mockStatic(ClassMapper.class)) {
             classService.togglePropertyShape("test", "http://uri.suomi.fi/datamodel/ns/test/Uri");
             mapper.verify(() -> ClassMapper.toggleAndMapDeactivatedProperty( any(Model.class), anyString(), anyBoolean()));
@@ -288,6 +292,7 @@ class ClassServiceTest {
                 .addProperty(RDFS.range, XSD.integer);
 
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.queryConstruct(any(Query.class))).thenReturn(restrictionQueryResult);
@@ -322,6 +327,7 @@ class ClassServiceTest {
                 .addProperty(RDF.type, OWL.Class);
 
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(classService.findResources(eq(Set.of(modelURI + "/association-1")), anySet())).thenReturn(restrictionQueryResult);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -248,6 +248,7 @@ class DataModelServiceTest {
         when(modelMapper.mapReleaseProperties(any(Model.class), anyString(), anyString(), any(Status.class)))
                 .thenReturn("http://uri.suomi.fi/datamodel/ns/test/1.0.1");
         when(modelMapper.mapToIndexModel(anyString(), any(Model.class))).thenReturn(mock(IndexModel.class));
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
 
         dataModelService.createRelease("test", "1.0.1", Status.VALID);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolverTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolverTest.java
@@ -21,8 +21,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @Import({
@@ -51,7 +50,7 @@ class NamespaceResolverTest {
     @Test
     void shouldTryToResolve() {
         namespaceResolver.resolve("notrealaddress", false);
-        verify(userProvider).getUser();
+        verify(userProvider, times(2)).getUser();
         verify(importsRepository).graphExists(anyString());
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -9,7 +9,9 @@ import fi.vm.yti.datamodel.api.v2.dto.visualization.VisualizationNodeDTO;
 import fi.vm.yti.datamodel.api.v2.dto.visualization.VisualizationNodeType;
 import fi.vm.yti.datamodel.api.v2.properties.Iow;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.security.YtiUser;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.vocabulary.DCTerms;
@@ -44,6 +46,8 @@ class VisualizationServiceTest {
     private CoreRepository coreRepository;
     @MockBean
     private AuthorizationManager authorizationManager;
+    @MockBean
+    private AuthenticatedUserProvider userProvider;
     @Captor
     private ArgumentCaptor<Model> modelCaptor;
 
@@ -94,6 +98,7 @@ class VisualizationServiceTest {
         when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "visuprof")).thenReturn(positionModel);
         when(resourceService.findResources(anySet(), anySet())).thenReturn(externalPropertiesModel);
 
+
         var visualizationData = visualizationService.getVisualizationData("visuprof", null);
 
         assertEquals(3, visualizationData.getNodes().size());
@@ -126,6 +131,7 @@ class VisualizationServiceTest {
         when(coreRepository.graphExists(graphURI)).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
 
         var positionData = new PositionDataDTO();
         positionData.setX(1.0);
@@ -147,6 +153,7 @@ class VisualizationServiceTest {
         when(coreRepository.graphExists(graphURI)).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(YtiUser.ANONYMOUS_USER);
 
         var positionData = new PositionDataDTO();
         positionData.setX(1.0);


### PR DESCRIPTION
Changelog:
- Remove unneccessary logging on frontend controller
- Exception handler for AuthorizationException
  - Removes unneccessary error message when someone does not have permissions
 - Added audit logging 
Example log:
`2023-11-24T12:26:58.831+02:00  INFO 65518 --- [nio-9004-exec-8] f.v.y.d.api.v2.service.AuditService      : VISUALIZATION SAVE: <http://uri.suomi.fi/datamodel/ns/all_models>, User[email=admin@localhost, id=4ce70937-6fa4-49af-a229-b5f10328adb8]
`