### PR TITLE
YTI-3571 iri.suomi.fi

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V10_RenameURIs.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V10_RenameURIs.java
@@ -1,0 +1,156 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.properties.DCAP;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
+import fi.vm.yti.migration.MigrationTask;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.OWL2;
+import org.apache.jena.vocabulary.RDFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+
+@SuppressWarnings("java:S101")
+@Component
+public class V10_RenameURIs implements MigrationTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(V10_RenameURIs.class);
+
+    private final CoreRepository coreRepository;
+
+    static final String OLD_NS = "http://uri.suomi.fi/datamodel/ns/";
+
+    static final String OLD_POSITION_NS = "http://uri.suomi.fi/datamodel/positions/";
+
+    static final List<Property> GRAPH_PROPERTIES = List.of(
+            RDFS.isDefinedBy,
+            OWL2.versionIRI,
+            OWL2.priorVersion,
+            OWL2.imports,
+            DCTerms.requires,
+            DCAP.preferredXMLNamespace
+    );
+
+    public V10_RenameURIs(CoreRepository coreRepository) {
+        this.coreRepository = coreRepository;
+    }
+
+    @Override
+    public void migrate() {
+        var graphNameQuery = """
+                SELECT ?g {
+                    FILTER strstarts(str(?g), "http://uri.suomi.fi/datamodel/")
+                    GRAPH ?g {  }
+                }
+                """;
+        var oldGraphs = new HashSet<String>();
+        coreRepository.querySelect(graphNameQuery, (var row) -> oldGraphs.add(row.get("g").toString()));
+
+        oldGraphs.forEach(oldGraph -> {
+            var oldData = coreRepository.fetch(oldGraph);
+            String modelURI;
+            if (oldGraph.matches("(.*)\\d+.\\d+.\\d+$")) {
+                modelURI = oldGraph.substring(0, oldGraph.lastIndexOf("/"));
+            } else {
+                modelURI = oldGraph;
+            }
+
+            String newGraphURI;
+            String prefix;
+            String version = null;
+
+            if (oldGraph.startsWith(OLD_NS)) {
+                // data models
+                var modelResource = oldData.getResource(modelURI);
+                prefix = MapperUtils.getLiteral(modelResource, DCAP.preferredXMLNamespacePrefix, String.class);
+                version = MapperUtils.propertyToString(modelResource, OWL2.versionInfo);
+
+                newGraphURI = DataModelURI.createModelURI(prefix, version).getGraphURI();
+            } else if (oldGraph.startsWith(OLD_POSITION_NS)) {
+                // positions
+                try {
+                    var uri = new URI(oldGraph);
+                    var path = uri.getPath().split("/");
+                    prefix = path[3];
+                    if (path.length == 5) {
+                        version = path[4];
+                    }
+                    newGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + prefix;
+
+                    if (version != null) {
+                        newGraphURI += "/" + version;
+                    }
+                    newGraphURI += "/";
+                } catch (Exception e) {
+                    LOG.warn("Invalid graph name {}", oldGraph);
+                    return;
+                }
+            } else {
+                LOG.warn("Invalid graph name {}", oldGraph);
+                return;
+            }
+
+            var newData = ModelFactory.createDefaultModel();
+
+            var iterator = oldData.listStatements();
+            while (iterator.hasNext()) {
+                var s = iterator.next();
+
+                var subj = getNewSubject(modelURI, s.getSubject(), prefix);
+                var pred = getNewPredicate(s.getPredicate());
+                var obj = getNewObject(s);
+
+                newData.add(ResourceFactory.createStatement(subj, pred, obj));
+            }
+
+            LOG.info("PUT new data: {}", newGraphURI);
+            LOG.info("DELETE old data: {}", oldGraph);
+            coreRepository.put(newGraphURI, newData);
+            coreRepository.delete(oldGraph);
+        });
+    }
+
+    private static RDFNode getNewObject(Statement s) {
+        String newObject = null;
+        var obj = s.getObject().toString();
+        if (obj.startsWith(OLD_NS)) {
+            newObject = obj.replace(OLD_NS, ModelConstants.SUOMI_FI_NAMESPACE);
+
+            // add trailing slash if object is another graph
+            if (GRAPH_PROPERTIES.contains(s.getPredicate())) {
+                newObject += "/";
+            }
+        }
+        return newObject != null ? ResourceFactory.createResource(newObject) : s.getObject();
+    }
+
+    private static Property getNewPredicate(Property p) {
+        String newPred = null;
+        if (p.toString().startsWith(OLD_NS)) {
+            newPred = p.toString().replace(OLD_NS, ModelConstants.SUOMI_FI_NAMESPACE);
+        }
+        return newPred != null ? ResourceFactory.createProperty(newPred) : p;
+    }
+
+    private static Resource getNewSubject(String modelURI, Resource res, String prefix) {
+        String newSubject = null;
+        var subj = res.toString();
+
+        if (subj.equals(modelURI)) {
+            newSubject = DataModelURI.createModelURI(prefix, null).getModelURI();
+        } else if (subj.startsWith(OLD_NS)) {
+            newSubject = subj.replace(OLD_NS, ModelConstants.SUOMI_FI_NAMESPACE);
+        } else if (subj.startsWith(OLD_POSITION_NS)) {
+            newSubject = subj.replace(OLD_POSITION_NS, ModelConstants.MODEL_POSITIONS_NAMESPACE);
+        }
+        return newSubject != null ? ResourceFactory.createResource(newSubject) : res;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -9,10 +9,10 @@ public class ModelConstants {
         //utility class
     }
 
-    public static final String SUOMI_FI_NAMESPACE = "http://uri.suomi.fi/datamodel/ns/";
+    public static final String SUOMI_FI_NAMESPACE = "https://iri.suomi.fi/model/";
     public static final String CODELIST_NAMESPACE = "http://uri.suomi.fi/codelist/";
     public static final String TERMINOLOGY_NAMESPACE = "http://uri.suomi.fi/terminology/";
-    public static final String MODEL_POSITIONS_NAMESPACE = "http://uri.suomi.fi/datamodel/positions/";
+    public static final String MODEL_POSITIONS_NAMESPACE = "https://iri.suomi.fi/model-positions/";
     public static final String SUOMI_FI_DOMAIN = "uri.suomi.fi";
 
     public static final String RESOURCE_SEPARATOR = "/";
@@ -28,8 +28,8 @@ public class ModelConstants {
             "owl", "http://www.w3.org/2002/07/owl#",
             "dcap", "http://purl.org/ws-mmi-dc/terms/",
             "xsd", "http://www.w3.org/2001/XMLSchema#",
-            "iow", "http://uri.suomi.fi/datamodel/ns/iow/",
-            "suomi-meta", "http://uri.suomi.fi/datamodel/ns/suomi-meta/",
+            "iow", "https://iri.suomi.fi/model/iow/",
+            "suomi-meta", "https://iri.suomi.fi/model/suomi-meta/",
             "skos", "http://www.w3.org/2004/02/skos/core#",
             "sh", "http://www.w3.org/ns/shacl#"
     );

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceCommonDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceCommonDTO.java
@@ -5,6 +5,7 @@ public class ResourceCommonDTO {
     private String modified;
     private UserDTO modifier;
     private UserDTO creator;
+    private String uri;
 
     public String getCreated() {
         return created;
@@ -36,5 +37,13 @@ public class ResourceCommonDTO {
 
     public void setCreator(UserDTO creator) {
         this.creator = creator;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceInfoBaseDTO.java
@@ -10,7 +10,6 @@ public class ResourceInfoBaseDTO extends ResourceCommonDTO {
     private ConceptDTO subject;
     private String identifier;
     private Map<String, String> note;
-    private String uri;
     private String curie;
     private Set<OrganizationDTO> contributor;
     private String contact;
@@ -61,14 +60,6 @@ public class ResourceInfoBaseDTO extends ResourceCommonDTO {
 
     public void setNote(Map<String, String> note) {
         this.note = note;
-    }
-
-    public String getUri() {
-        return uri;
-    }
-
-    public void setUri(String uri) {
-        this.uri = uri;
     }
 
     public String getCurie() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -14,6 +14,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 @RestController
 @RequestMapping("v2/export")
 @Tag(name = "Export" )
@@ -33,9 +36,16 @@ public class ExportController {
     @GetMapping(value = {"{prefix}", "/{prefix}/{resourceIdentifier}"},
             produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8"})
     public ResponseEntity<String> export(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                         @PathVariable(required = false) @Parameter(description = "Resource identifier") String resourceIdentifier,
                                          @RequestParam(required = false) @Parameter(description = "Version") @ValidSemanticVersion String version,
+                                         @RequestParam(required = false) @Parameter(description = "Content type") String contentType,
                                          @RequestHeader(value = HttpHeaders.ACCEPT) String accept){
-        return dataModelService.export(prefix, version, resourceIdentifier, accept);
+        var showAsFile = false;
+        var type = accept;
+
+        if (contentType != null) {
+            type = URLDecoder.decode(contentType, StandardCharsets.UTF_8);
+            showAsFile = true;
+        }
+        return dataModelService.export(prefix, version, type, showAsFile);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -3,7 +3,6 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.visualization.*;
 import fi.vm.yti.datamodel.api.v2.properties.Iow;
-import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.DCTerms;
@@ -189,14 +188,14 @@ public class VisualizationMapper {
         }
     }
 
-    public static Model mapPositionDataToModel(String positionGraphURI, List<PositionDataDTO> positions) {
+    public static Model mapPositionDataToModel(String positionBaseURI, List<PositionDataDTO> positions) {
         var positionModel = ModelFactory.createDefaultModel();
-        positions.forEach(node -> mapPosition(positionModel, positionGraphURI, node));
+        positions.forEach(node -> mapPosition(positionModel, positionBaseURI, node));
         return positionModel;
     }
 
-    public static void mapPosition(Model positionModel, String positionGraphURI, PositionDataDTO node) {
-        var resource = positionModel.createResource(positionGraphURI + ModelConstants.RESOURCE_SEPARATOR + node.getIdentifier());
+    public static void mapPosition(Model positionModel, String positionBaseURI, PositionDataDTO node) {
+        var resource = positionModel.createResource(positionBaseURI + node.getIdentifier());
         resource.addLiteral(Iow.posX, node.getX());
         resource.addLiteral(Iow.posY, node.getY());
         resource.addProperty(DCTerms.identifier, node.getIdentifier());
@@ -357,7 +356,7 @@ public class VisualizationMapper {
         }
         try {
             var u = NodeFactory.createURI(uri);
-            String prefix = namespaces.get(DataModelUtils.removeTrailingSlash(u.getNameSpace()));
+            String prefix = namespaces.get(u.getNameSpace());
 
             if (prefix == null) {
                 // referenced class in the same model

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/properties/Iow.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/properties/Iow.java
@@ -9,7 +9,7 @@ public class Iow {
         //property class
     }
 
-    public static final String URI ="http://uri.suomi.fi/datamodel/ns/iow/";
+    public static final String URI = "https://iri.suomi.fi/model/iow/";
 
     public static final Property contentModified = ResourceFactory.createProperty(URI, "contentModified");
     public static final Property documentation = ResourceFactory.createProperty(URI, "documentation");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
@@ -10,7 +10,7 @@ public class SuomiMeta {
         //property class
     }
 
-    public static final String URI ="http://uri.suomi.fi/datamodel/ns/suomi-meta/";
+    public static final String URI ="https://iri.suomi.fi/model/suomi-meta/";
 
     public static final Property publicationStatus = ResourceFactory.createProperty(URI, "publicationStatus");
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURI.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURI.java
@@ -1,0 +1,190 @@
+package fi.vm.yti.datamodel.api.v2.utils;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.shared.PrefixMapping;
+
+import java.util.regex.Pattern;
+
+public class DataModelURI {
+
+    /**
+     * Pattern for model, resource and serialization URIs
+     * /model/test-model/
+     * /model/test-model/1.0.0/
+     * /model/test-model
+     * /model/test-model/1.0.0
+     * /model/test-model/some-resources
+     * /model/test-model/1.0.0/some-resource
+     * /model/test-model/1.0.0/test-model.ttl
+     */
+    private static final Pattern iriPattern = Pattern.compile("https?://iri.suomi.fi/model/" +
+            "(?<modelId>[\\w-]+)/?" +
+            "(/(?<version>\\d+\\.\\d+\\.\\d+)/?)?" +
+            "(/(?<resource>[\\w-.]+))?");
+
+    private final String modelId;
+    private final String resourceId;
+    private final String version;
+    private final String namespace;
+    private final String fileName;
+
+    public static DataModelURI createModelURI(String modelId, String version) {
+        return new DataModelURI(modelId, version, null);
+    }
+
+    public static DataModelURI createModelURI(String modelId) {
+        return new DataModelURI(modelId, null, null);
+    }
+
+    public static DataModelURI createResourceURI(String modelId, String resourceId, String version) {
+        return new DataModelURI(modelId, version, resourceId);
+    }
+
+    public static DataModelURI createResourceURI(String modelId, String resourceId) {
+        return new DataModelURI(modelId, null, resourceId);
+    }
+
+    public static DataModelURI fromURI(String resourceURI) {
+        return new DataModelURI(resourceURI);
+    }
+
+    private DataModelURI(String modelId, String version, String resourceId) {
+        this.modelId = modelId;
+        this.resourceId = resourceId;
+        this.version = version;
+        this.namespace = getModelURI();
+        this.fileName = null;
+    }
+
+    private DataModelURI(String uri) {
+        var matcher = iriPattern.matcher(uri);
+        if (matcher.matches()) {
+            this.modelId = matcher.group("modelId");
+            this.version = matcher.group("version");
+            var res = matcher.group("resource");
+            if (res != null && res.contains(".")) {
+                this.fileName = res;
+                this.resourceId = null;
+            } else {
+                this.fileName = null;
+                this.resourceId = res;
+            }
+            this.namespace = getModelURI();
+        } else {
+            var u = NodeFactory.createURI(uri);
+            this.namespace = u.getNameSpace();
+            this.resourceId = u.getLocalName();
+            this.modelId = null;
+            this.version = null;
+            this.fileName = null;
+        }
+    }
+
+    /**
+       Resource's URI as stored in Fuseki
+     */
+    public String getResourceURI() {
+        if (this.resourceId == null) {
+            return null;
+        }
+
+        if (this.modelId == null) {
+            return this.getNamespace() + this.resourceId;
+        }
+        return getModelURI() + this.resourceId;
+    }
+
+    /**
+     * Resource's URI with version
+     */
+    public String getResourceVersionURI() {
+        if (this.resourceId == null) {
+            return null;
+        }
+        return getGraphURI() + this.resourceId;
+    }
+
+    /**
+     * Model resource. Used when fetching model's metadata, e.g. status, languages etc.
+     */
+    public String getModelURI() {
+        return ModelConstants.SUOMI_FI_NAMESPACE + this.modelId + ModelConstants.RESOURCE_SEPARATOR;
+    }
+
+    /**
+     * TODO: is this needed (should model resource be saved with or without trailing slash)?
+     */
+    public String getDraftGraphURI() {
+        return ModelConstants.SUOMI_FI_NAMESPACE + this.modelId + ModelConstants.RESOURCE_SEPARATOR;
+    }
+
+    /**
+     * Graph's URI, used when fetching and putting data to Fuseki
+     */
+    public String getGraphURI() {
+        var uri = getModelURI();
+        if (this.version != null) {
+            return uri + this.version + ModelConstants.RESOURCE_SEPARATOR;
+        }
+        return uri;
+    }
+
+    public String getResourceId() {
+        return this.resourceId;
+    }
+
+    public String getModelId() {
+        return this.modelId;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    public String getContentType() {
+        if (this.fileName == null) {
+            return null;
+        }
+
+        var suffix = this.fileName.split("\\.")[1];
+
+        return switch (suffix) {
+            case "ttl" -> "text/turtle";
+            case "rdf", "xml" -> "application/rdf+xml";
+            case "jsonld", "json" -> "application/ld+json";
+            default -> null;
+        };
+    }
+
+    public String getCurie(PrefixMapping prefixMapping) {
+        var prefix = prefixMapping.getNsURIPrefix(this.namespace);
+        var template = "%s:%s";
+
+        if (prefix != null) {
+            return String.format(template, prefix, this.resourceId);
+        } else if (isDataModelURI()) {
+            return String.format(template, this.modelId, this.resourceId);
+        } else {
+            // use last element of the path as a prefix, if it could not determine
+            var parts = this.namespace.split("\\W");
+            return String.format(template, parts[parts.length - 1], this.resourceId);
+        }
+    }
+
+    public boolean isDataModelURI() {
+        return this.namespace.startsWith(ModelConstants.SUOMI_FI_NAMESPACE);
+    }
+
+    public boolean isCodeListURI() {
+        return this.namespace.startsWith(ModelConstants.CODELIST_NAMESPACE);
+    }
+
+    public boolean isTerminologyURI() {
+        return this.namespace.startsWith(ModelConstants.TERMINOLOGY_NAMESPACE);
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -9,6 +9,7 @@ import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.properties.Iow;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFList;
@@ -36,28 +37,29 @@ class ResourceMapperTest {
         var dto = new ResourceDTO();
         dto.setIdentifier("Resource");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/SubRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
         dto.setDomain("http://www.w3.org/2002/07/owl#Class");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/RangeClass");
+        dto.setRange(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass");
         dto.setFunctionalProperty(true);
         dto.setReflexiveProperty(true);
         dto.setTransitiveProperty(true);
 
-        ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, ResourceType.ASSOCIATION, mockUser);
+        var uri = DataModelURI.createResourceURI("test", dto.getIdentifier());
+        ResourceMapper.mapToResource(uri, m, dto, ResourceType.ASSOCIATION, mockUser);
 
-        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
+        Resource modelResource = m.getResource(uri.getModelURI());
+        Resource resourceResource = m.getResource(uri.getResourceURI());
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertTrue(MapperUtils.hasType(resourceResource, OWL.ObjectProperty));
 
@@ -66,7 +68,7 @@ class ResourceMapperTest {
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
@@ -77,12 +79,12 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals("https://www.example.com/ns/ext/SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals(mockUser.getId().toString(), resourceResource.getProperty(Iow.creator).getObject().toString());
         assertEquals(mockUser.getId().toString(), resourceResource.getProperty(Iow.modifier).getObject().toString());
 
         assertEquals("http://www.w3.org/2002/07/owl#Class", MapperUtils.propertyToString(resourceResource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
 
         assertTrue(MapperUtils.hasType(resourceResource, OWL.FunctionalProperty));
         assertTrue(MapperUtils.hasType(resourceResource, OWL2.ReflexiveProperty));
@@ -96,22 +98,23 @@ class ResourceMapperTest {
         var dto = new ResourceDTO();
         dto.setIdentifier("Resource");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
 
-        ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, ResourceType.ASSOCIATION, EndpointUtils.mockUser);
+        var uri = DataModelURI.createResourceURI("test", dto.getIdentifier());
+        ResourceMapper.mapToResource(uri, m, dto, ResourceType.ASSOCIATION, EndpointUtils.mockUser);
 
-        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
+        Resource modelResource = m.getResource(uri.getModelURI());
+        Resource resourceResource = m.getResource(uri.getResourceURI());
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.ObjectProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -120,7 +123,7 @@ class ResourceMapperTest {
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
@@ -131,7 +134,7 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topObjectProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
     }
 
     @Test
@@ -141,22 +144,23 @@ class ResourceMapperTest {
         var dto = new ResourceDTO();
         dto.setIdentifier("Resource");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
 
-        ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
+        var uri = DataModelURI.createResourceURI("test", dto.getIdentifier());
+        ResourceMapper.mapToResource(uri, m, dto, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
 
-        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
+        Resource modelResource = m.getResource(uri.getModelURI());
+        Resource resourceResource = m.getResource(uri.getResourceURI());
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals(uri.getResourceURI(), modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertEquals(OWL.DatatypeProperty, resourceResource.getProperty(RDF.type).getResource());
 
@@ -165,7 +169,7 @@ class ResourceMapperTest {
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
@@ -176,7 +180,7 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals(OWL2.topDataProperty, resourceResource.getProperty(RDFS.subPropertyOf).getResource());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
     }
 
     @Test
@@ -186,26 +190,27 @@ class ResourceMapperTest {
         var dto = new ResourceDTO();
         dto.setIdentifier("Resource");
         dto.setSubject("http://uri.suomi.fi/terminology/test/test1");
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/EqRes"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/SubRes"));
         dto.setEditorialNote("comment");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setStatus(Status.DRAFT);
         dto.setNote(Map.of("fi", "test note"));
         dto.setDomain("http://www.w3.org/2002/07/owl#Class");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/RangeClass");
+        dto.setRange(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass");
         dto.setFunctionalProperty(true);
 
-        ResourceMapper.mapToResource("http://uri.suomi.fi/datamodel/ns/test", m, dto, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
+        var uri = DataModelURI.createResourceURI("test", dto.getIdentifier());
+        ResourceMapper.mapToResource(uri, m, dto, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
 
-        Resource modelResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test");
-        Resource resourceResource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/Resource");
+        Resource modelResource = m.getResource(uri.getModelURI());
+        Resource resourceResource = m.getResource(uri.getResourceURI());
 
         assertNotNull(modelResource);
         assertNotNull(resourceResource);
 
         assertEquals(1, modelResource.listProperties(DCTerms.hasPart).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/Resource", modelResource.getProperty(DCTerms.hasPart).getObject().toString());
+        assertEquals(uri.getResourceURI(), modelResource.getProperty(DCTerms.hasPart).getObject().toString());
 
         assertTrue(MapperUtils.hasType(resourceResource, OWL.DatatypeProperty));
 
@@ -214,7 +219,7 @@ class ResourceMapperTest {
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
         assertEquals("Resource", resourceResource.getProperty(DCTerms.identifier).getLiteral().getString());
@@ -225,10 +230,10 @@ class ResourceMapperTest {
         assertEquals(1, resourceResource.listProperties(RDFS.subPropertyOf).toList().size());
         assertEquals("https://www.example.com/ns/ext/SubRes", resourceResource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(1, resourceResource.listProperties(OWL.equivalentProperty).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/EqRes", resourceResource.getProperty(OWL.equivalentProperty).getObject().toString());
 
         assertEquals("http://www.w3.org/2002/07/owl#Class", MapperUtils.propertyToString(resourceResource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass", MapperUtils.propertyToString(resourceResource, RDFS.range));
 
         assertTrue(MapperUtils.hasType(resourceResource, OWL.FunctionalProperty));
     }
@@ -237,19 +242,19 @@ class ResourceMapperTest {
     void testMapToIndexResourceClass(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        var indexClass = ResourceMapper.mapToIndexResource(m, ModelConstants.SUOMI_FI_NAMESPACE + "test/TestClass");
 
         assertEquals(ResourceType.CLASS, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", indexClass.getId());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestClass", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestClass", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getIsDefinedBy());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
         assertEquals("1.0.1", indexClass.getFromVersion());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/", indexClass.getVersionIri());
     }
 
     @Test
@@ -257,21 +262,21 @@ class ResourceMapperTest {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
+        var indexClass = ResourceMapper.mapToIndexResource(m, ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute");
 
         assertEquals(ResourceType.ATTRIBUTE, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAttribute", indexClass.getId());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestAttribute", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAttribute", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getIsDefinedBy());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test attribute", indexClass.getLabel().get("fi"));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", indexClass.getDomain());
         assertEquals("http://www.w3.org/2000/01/rdf-schema#Literal", indexClass.getRange());
         assertEquals("1.0.1", indexClass.getFromVersion());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/", indexClass.getVersionIri());
     }
 
     @Test
@@ -279,35 +284,36 @@ class ResourceMapperTest {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
+        var indexClass = ResourceMapper.mapToIndexResource(m, ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAssociation");
 
         assertEquals(ResourceType.ASSOCIATION, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAssociation", indexClass.getId());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestAssociation", indexClass.getId());
         assertEquals("test note fi", indexClass.getNote().get("fi"));
         assertEquals(Status.VALID, indexClass.getStatus());
         assertEquals("TestAssociation", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getIsDefinedBy());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/", indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test association", indexClass.getLabel().get("fi"));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", indexClass.getDomain());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", indexClass.getRange());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", indexClass.getDomain());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass", indexClass.getRange());
         assertEquals("1.0.1", indexClass.getFromVersion());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/1.0.1", indexClass.getVersionIri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/", indexClass.getVersionIri());
     }
 
     @Test
     void testMapToIndexResourceMinimalClass(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-        var indexClass = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        var uri = DataModelURI.createResourceURI("test", "TestClass");
+        var indexClass = ResourceMapper.mapToIndexResource(m, uri.getResourceURI());
 
         assertEquals(ResourceType.CLASS, indexClass.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", indexClass.getId());
+        assertEquals(uri.getResourceURI(), indexClass.getId());
         assertEquals(Status.VALID, indexClass.getStatus());
-        assertEquals("TestClass", indexClass.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexClass.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexClass.getNamespace());
+        assertEquals(uri.getResourceId(), indexClass.getIdentifier());
+        assertEquals(uri.getModelURI(), indexClass.getIsDefinedBy());
+        assertEquals(uri.getModelURI(), indexClass.getNamespace());
         assertEquals(1, indexClass.getLabel().size());
         assertEquals("test label", indexClass.getLabel().get("fi"));
         assertNull(indexClass.getNote());
@@ -316,15 +322,15 @@ class ResourceMapperTest {
     @Test
     void testMapToIndexResourceMinimalAttribute(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
-
-        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
+        var uri = DataModelURI.createResourceURI("test", "TestAttribute");
+        var indexResource = ResourceMapper.mapToIndexResource(m, uri.getResourceURI());
 
         assertEquals(ResourceType.ATTRIBUTE, indexResource.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", indexResource.getId());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute", indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
-        assertEquals("TestAttribute", indexResource.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexResource.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexResource.getNamespace());
+        assertEquals(uri.getResourceId(), indexResource.getIdentifier());
+        assertEquals(uri.getModelURI(), indexResource.getIsDefinedBy());
+        assertEquals(uri.getModelURI(), indexResource.getNamespace());
         assertEquals(1, indexResource.getLabel().size());
         assertEquals("test attribute", indexResource.getLabel().get("fi"));
         assertNull(indexResource.getNote());
@@ -333,15 +339,15 @@ class ResourceMapperTest {
     @Test
     void testMapToIndexResourceMinimalAssociation(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
-
-        var indexResource = ResourceMapper.mapToIndexResource(m, "http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
+        var indexResource = ResourceMapper.mapToIndexResource(m, uri.getResourceURI());
 
         assertEquals(ResourceType.ASSOCIATION, indexResource.getResourceType());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", indexResource.getId());
+        assertEquals(uri.getResourceURI(), indexResource.getId());
         assertEquals(Status.VALID, indexResource.getStatus());
-        assertEquals("TestAssociation", indexResource.getIdentifier());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", indexResource.getIsDefinedBy());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/", indexResource.getNamespace());
+        assertEquals(uri.getResourceId(), indexResource.getIdentifier());
+        assertEquals(uri.getModelURI(), indexResource.getIsDefinedBy());
+        assertEquals(uri.getModelURI(), indexResource.getNamespace());
         assertEquals(1, indexResource.getLabel().size());
         assertEquals("test association", indexResource.getLabel().get("fi"));
         assertNull(indexResource.getNote());
@@ -351,7 +357,8 @@ class ResourceMapperTest {
     void mapToResourceInfoDTOAttribute() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var dto = ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestAttribute", MapperTestUtils.getMockOrganizations(), true, null);
+        var uri = DataModelURI.createResourceURI("test", "TestAttribute");
+        var dto = ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null);
 
         assertEquals(ResourceType.ATTRIBUTE, dto.getType());
         assertEquals(1, dto.getLabel().size());
@@ -359,9 +366,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAttribute", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -371,8 +378,8 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("Yhteentoimivuusalustan yllapito", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals(MapperTestUtils.TEST_ORG_ID.toString(), dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain().getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute", dto.getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", dto.getDomain().getUri());
         assertEquals("test:DomainClass", dto.getDomain().getCurie());
         assertEquals("http://www.w3.org/2000/01/rdf-schema#Literal", dto.getRange().getUri());
         assertEquals("rdfs:Literal", dto.getRange().getCurie());
@@ -385,7 +392,8 @@ class ResourceMapperTest {
     void mapToResourceInfoDTOAssociation() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var dto = ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestAssociation", MapperTestUtils.getMockOrganizations(), true, null);
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
+        var dto = ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null);
 
         assertEquals(ResourceType.ASSOCIATION, dto.getType());
         assertEquals(1, dto.getLabel().size());
@@ -393,9 +401,9 @@ class ResourceMapperTest {
         assertEquals("comment visible for admin", dto.getEditorialNote());
         assertEquals(Status.VALID, dto.getStatus());
         assertEquals(1, dto.getSubResourceOf().size());
-        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource"), dto.getSubResourceOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getEquivalentResource().size());
-        assertEquals(new UriDTO("http://uri.suomi.fi/datamodel/ns/test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource"), dto.getEquivalentResource().stream().findFirst().orElse(null));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());
         assertEquals("TestAssociation", dto.getIdentifier());
         assertEquals(2, dto.getNote().size());
@@ -405,9 +413,9 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("Yhteentoimivuusalustan yllapito", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals(MapperTestUtils.TEST_ORG_ID.toString(), dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", dto.getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", dto.getDomain().getUri());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", dto.getRange().getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAssociation", dto.getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", dto.getDomain().getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass", dto.getRange().getUri());
         assertTrue(dto.getFunctionalProperty());
         assertFalse(dto.getTransitiveProperty());
         assertFalse(dto.getReflexiveProperty());
@@ -417,7 +425,8 @@ class ResourceMapperTest {
     void mapToResourceInfoDTOAttributeMinimal() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-        var dto = ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestAttribute", MapperTestUtils.getMockOrganizations(), true, null);
+        var uri = DataModelURI.createResourceURI("test", "TestAttribute");
+        var dto = ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null);
 
         assertEquals(ResourceType.ATTRIBUTE, dto.getType());
         assertEquals(1, dto.getLabel().size());
@@ -433,15 +442,15 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("Yhteentoimivuusalustan yllapito", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals(MapperTestUtils.TEST_ORG_ID.toString(), dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAttribute", dto.getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute", dto.getUri());
     }
 
     @Test
     void mapToResourceInfoDTOAssociationMinimal() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
 
-
-        var dto = ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestAssociation", MapperTestUtils.getMockOrganizations(), true, null);
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
+        var dto = ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null);
 
         assertEquals(ResourceType.ASSOCIATION, dto.getType());
         assertEquals(1, dto.getLabel().size());
@@ -457,7 +466,7 @@ class ResourceMapperTest {
         assertEquals("2023-02-03T11:46:36.404Z", dto.getCreated());
         assertEquals("Yhteentoimivuusalustan yllapito", dto.getContributor().stream().findFirst().orElseThrow().getLabel().get("fi"));
         assertEquals(MapperTestUtils.TEST_ORG_ID.toString(), dto.getContributor().stream().findFirst().orElseThrow().getId());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestAssociation", dto.getUri());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAssociation", dto.getUri());
     }
 
 
@@ -465,13 +474,15 @@ class ResourceMapperTest {
     @Test
     void failMapToResourceInfoDTOClass(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestClass", MapperTestUtils.getMockOrganizations(), true, null));
+        var uri = DataModelURI.createResourceURI("test", "TestClass");
+        assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null));
     }
 
     @Test
     void failMapToResourceInfoDTOClassMinimal(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_with_minimal_resources.ttl");
-        assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestClass", MapperTestUtils.getMockOrganizations(), true, null));
+        var uri = DataModelURI.createResourceURI("test", "TestClass");
+        assertThrowsExactly(MappingError.class, () -> ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, null));
     }
 
     @Test
@@ -486,7 +497,8 @@ class ResourceMapperTest {
             dto.setCreator(creator);
             dto.setModifier(modifier);
         };
-        var dto = ResourceMapper.mapToResourceInfoDTO(m, "http://uri.suomi.fi/datamodel/ns/test", "TestAssociation", MapperTestUtils.getMockOrganizations(), true, userMapper);
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
+        var dto = ResourceMapper.mapToResourceInfoDTO(m, uri, MapperTestUtils.getMockOrganizations(), true, userMapper);
 
         assertEquals("creator fake-user", dto.getCreator().getName());
         assertEquals("modifier fake-user", dto.getModifier().getName());
@@ -494,47 +506,48 @@ class ResourceMapperTest {
 
     @Test
     void mapToUpdateModelAttribute() {
+        var uri = DataModelURI.createResourceURI("test", "TestAttribute");
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
+        var resource = m.getResource(uri.getResourceURI());
         var mockUser = EndpointUtils.mockUser;
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
         dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/NewEq"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
-        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass");
+        dto.setDomain(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewDomainClass");
         dto.setRange("xsd:integer");
         dto.setFunctionalProperty(true);
 
-        assertEquals(OWL.DatatypeProperty, resource.getProperty(RDF.type).getResource());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertTrue(MapperUtils.hasType(resource, OWL.DatatypeProperty));
+        assertEquals(uri.getModelURI(), resource.getProperty(RDFS.isDefinedBy).getObject().toString());
         assertEquals("test attribute", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
-        assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
+        assertEquals(uri.getResourceId(), resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
         assertEquals("http://www.w3.org/2000/01/rdf-schema#Literal", MapperUtils.propertyToString(resource, RDFS.range));
         assertFalse(MapperUtils.hasType(resource, OWL.FunctionalProperty));
 
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", dto, mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, dto, mockUser);
 
-        assertEquals(OWL.DatatypeProperty, resource.getProperty(RDF.type).getResource());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertTrue(MapperUtils.hasType(resource, OWL.DatatypeProperty));
+        assertEquals(uri.getModelURI(), resource.getProperty(RDFS.isDefinedBy).getObject().toString());
         assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAttribute", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.RETIRED, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
@@ -543,7 +556,7 @@ class ResourceMapperTest {
         assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
         assertEquals(mockUser.getId().toString(), resource.getProperty(Iow.modifier).getObject().toString());
         assertEquals("2a5c075f-0d0e-4688-90e0-29af1eebbf6d", resource.getProperty(Iow.creator).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
         assertEquals("xsd:integer", MapperUtils.propertyToString(resource, RDFS.range));
         assertTrue(MapperUtils.hasType(resource, OWL.FunctionalProperty));
     }
@@ -551,56 +564,57 @@ class ResourceMapperTest {
     @Test
     void mapToUpdateModelAssociation() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
+        var resource = m.getResource(uri.getResourceURI());
 
         var dto = new ResourceDTO();
         dto.setLabel(Map.of("fi", "new label"));
         dto.setStatus(Status.RETIRED);
         dto.setNote(Map.of("fi", "new note"));
-        dto.setEquivalentResource(Set.of("http://uri.suomi.fi/datamodel/ns/int/NewEq"));
+        dto.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "int/NewEq"));
         dto.setSubResourceOf(Set.of("https://www.example.com/ns/ext/NewSub"));
         dto.setSubject("http://uri.suomi.fi/terminology/qwe");
         dto.setEditorialNote("new editorial note");
-        dto.setDomain("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass");
-        dto.setRange("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass");
+        dto.setDomain(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewDomainClass");
+        dto.setRange(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewRangeClass");
         dto.setFunctionalProperty(true);
         dto.setTransitiveProperty(true);
         dto.setReflexiveProperty(true);
 
-        assertEquals(OWL.ObjectProperty, resource.getProperty(RDF.type).getResource());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertTrue(MapperUtils.hasType(resource, OWL.ObjectProperty));
+        assertEquals(uri.getModelURI(), resource.getProperty(RDFS.isDefinedBy).getObject().toString());
         assertEquals("test association", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/RangeClass", MapperUtils.propertyToString(resource, RDFS.range));
         assertTrue(MapperUtils.hasType(resource, OWL.FunctionalProperty));
         assertFalse(MapperUtils.hasType(resource, OWL2.ReflexiveProperty));
         assertFalse(MapperUtils.hasType(resource, OWL2.TransitiveProperty));
 
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAssociation", dto, EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, dto, EndpointUtils.mockUser);
 
-        assertEquals(OWL.ObjectProperty, resource.getProperty(RDF.type).getResource());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test", resource.getProperty(RDFS.isDefinedBy).getObject().toString());
+        assertTrue(MapperUtils.hasType(resource, OWL.ObjectProperty));
+        assertEquals(uri.getModelURI(), resource.getProperty(RDFS.isDefinedBy).getObject().toString());
         assertEquals("new label", resource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.label).getLiteral().getLanguage());
         assertEquals("TestAssociation", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertEquals("http://uri.suomi.fi/terminology/qwe", resource.getProperty(DCTerms.subject).getObject().toString());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "int/NewEq", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals("https://www.example.com/ns/ext/NewSub", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
         assertEquals(Status.RETIRED, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("new editorial note", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(1, resource.listProperties(RDFS.comment).toList().size());
         assertEquals("new note", resource.getProperty(RDFS.comment).getLiteral().getString());
         assertEquals("fi", resource.getProperty(RDFS.comment).getLiteral().getLanguage());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewDomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewRangeClass", MapperUtils.propertyToString(resource, RDFS.range));
         assertTrue(MapperUtils.hasType(resource, OWL.FunctionalProperty));
         assertTrue(MapperUtils.hasType(resource, OWL2.ReflexiveProperty));
         assertTrue(MapperUtils.hasType(resource, OWL.TransitiveProperty));
@@ -609,40 +623,42 @@ class ResourceMapperTest {
     @Test
     void mapToUpdateAttributeEmptySubResource(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
+        var resource = m.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute");
 
+        var uri = DataModelURI.createResourceURI("test", "TestAttribute");
         //null values get removed, so it will change to topObjectProperty
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", new ResourceDTO(), EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, new ResourceDTO(), EndpointUtils.mockUser);
         assertEquals(OWL2.topDataProperty, resource.getProperty(RDFS.subPropertyOf).getResource());
 
         var dto = new ResourceDTO();
         dto.setSubResourceOf(Set.of());
 
         m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAttribute");
+        resource = m.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttribute");
 
         //should change if empty
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAttribute", dto, EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, dto, EndpointUtils.mockUser);
         assertEquals(OWL2.topDataProperty, resource.getProperty(RDFS.subPropertyOf).getResource());
     }
 
     @Test
     void mapToUpdateAssociationEmptySubResource(){
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
+        var resource = m.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAssociation");
 
+        var uri = DataModelURI.createResourceURI("test", "TestAssociation");
         //null values get removed, so it will change to topObjectProperty
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAssociation", new ResourceDTO(), EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, new ResourceDTO(), EndpointUtils.mockUser);
         assertEquals(OWL2.topObjectProperty, resource.getProperty(RDFS.subPropertyOf).getResource());
 
         var dto = new ResourceDTO();
         dto.setSubResourceOf(Set.of());
 
         m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
-        resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestAssociation");
+        resource = m.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAssociation");
 
         //should change if empty
-        ResourceMapper.mapToUpdateResource("http://uri.suomi.fi/datamodel/ns/test", m, "TestAssociation", dto, EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, m, dto, EndpointUtils.mockUser);
         assertEquals(OWL2.topObjectProperty, resource.getProperty(RDFS.subPropertyOf).getResource());
     }
 
@@ -657,7 +673,7 @@ class ResourceMapperTest {
 
     @Test
     void mapIndexResourceInfo() {
-        var modelURI = "http://uri.suomi.fi/datamodel/ns/test";
+        var modelURI = ModelConstants.SUOMI_FI_NAMESPACE + "test";
         var indexResource = new IndexResource();
         indexResource.setId(modelURI + "/class-1");
         indexResource.setNamespace("test");
@@ -744,25 +760,24 @@ class ResourceMapperTest {
     void testUpdateRestrictionsAfterRangeChange() {
         var model = MapperTestUtils.getModelFromFile("/model_with_owl_restrictions.ttl");
 
-        var graphUri = "http://uri.suomi.fi/datamodel/ns/model";
-        var identifier = "attribute-1";
+        var uri = DataModelURI.createResourceURI("model", "attribute-1");
         var newRange = XSD.integer.getURI();
 
         // update range to xsd:integer
         var dto = new ResourceDTO();
-        dto.setIdentifier(identifier);
+        dto.setIdentifier(uri.getResourceId());
         dto.setLabel(Map.of("fi", "test label"));
         dto.setRange(newRange);
 
-        ResourceMapper.mapToUpdateResource(graphUri, model, identifier, dto, EndpointUtils.mockUser);
+        ResourceMapper.mapToUpdateResource(uri, model, dto, EndpointUtils.mockUser);
 
-        var classResource = model.getResource(graphUri + "/class-1");
+        var classResource = model.getResource(uri.getModelURI() + "class-1");
         var list = classResource.getProperty(OWL.equivalentClass).getObject()
                 .asResource().getProperty(OWL.intersectionOf).getObject().as(RDFList.class);
 
         var updated = list.asJavaList().stream()
                 .filter(r -> r.asResource().getProperty(OWL.onProperty).getObject().toString()
-                        .equals("http://uri.suomi.fi/datamodel/ns/model/attribute-1"))
+                        .equals(ModelConstants.SUOMI_FI_NAMESPACE + "model/attribute-1"))
                 .findFirst();
         assertTrue(updated.isPresent());
         assertEquals(newRange, updated.get().asResource().getProperty(OWL.someValuesFrom).getObject().toString());
@@ -771,8 +786,8 @@ class ResourceMapperTest {
     @Test
     void testMapReferenceResourceAndAddNamespace() {
         var model = ModelFactory.createDefaultModel();
-        var modelURI = "http://uri.suomi.fi/datamodel/ns/test-library";
-        model.createResource(modelURI)
+        var uri = DataModelURI.createResourceURI("test-library", "attr-1");
+        model.createResource(uri.getModelURI())
                 .addProperty(RDF.type, OWL.Ontology);
 
         var attrDTO = new ResourceDTO();
@@ -781,18 +796,18 @@ class ResourceMapperTest {
         attrDTO.setSubResourceOf(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "ns-int-1/sub"));
         attrDTO.setEquivalentResource(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "ns-int-2/eq"));
 
-        ResourceMapper.mapToResource(modelURI, model, attrDTO, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
+        ResourceMapper.mapToResource(uri, model, attrDTO, ResourceType.ATTRIBUTE, EndpointUtils.mockUser);
 
-        assertEquals(2, model.getResource(modelURI).listProperties(OWL.imports).toList().size());
+        assertEquals(2, model.getResource(uri.getModelURI()).listProperties(OWL.imports).toList().size());
     }
 
     @Test
     void testMapReferencePropertyShapeAndAddNamespace() {
         var model = ModelFactory.createDefaultModel();
 
-        var modelURI = "http://uri.suomi.fi/datamodel/ns/test-profile";
+        var uri = DataModelURI.createResourceURI("test-profile", "ps-1");
 
-        model.createResource(modelURI)
+        model.createResource(uri.getModelURI())
                 .addProperty(RDF.type, Iow.ApplicationProfile);
 
         var propertyShape = new AssociationRestriction();
@@ -801,10 +816,8 @@ class ResourceMapperTest {
         propertyShape.setPath(ModelConstants.SUOMI_FI_NAMESPACE + "/test_lib_2/path");
         propertyShape.setClassType(ModelConstants.SUOMI_FI_NAMESPACE + "test_lib_2/class");
 
-        ResourceMapper.mapToPropertyShapeResource(modelURI, model, propertyShape, ResourceType.ASSOCIATION, EndpointUtils.mockUser);
+        ResourceMapper.mapToPropertyShapeResource(uri, model, propertyShape, ResourceType.ASSOCIATION, EndpointUtils.mockUser);
 
-        assertEquals(2, model.getResource(modelURI).listProperties(DCTerms.requires).toList().size());
+        assertEquals(2, model.getResource(uri.getModelURI()).listProperties(DCTerms.requires).toList().size());
     }
-
-
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
@@ -5,6 +5,7 @@ import fi.vm.yti.datamodel.api.v2.dto.visualization.*;
 import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
 import fi.vm.yti.datamodel.api.v2.properties.Iow;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
@@ -17,19 +18,20 @@ import static org.junit.jupiter.api.Assertions.*;
 class VisualizationDataMapperTest {
 
     private final Map<String, String> libraryNamespaces = Map.of(
-            "http://uri.suomi.fi/datamodel/ns/yti-model", "yti-model",
-            "https://www.example.com/ns/external", "ext");
+            ModelConstants.SUOMI_FI_NAMESPACE + "yti-model/", "yti-model",
+            "https://www.example.com/ns/external/", "ext");
 
     private final Map<String, String> profileNamespaces = Map.of(
-            "http://uri.suomi.fi/datamodel/ns/personprof", "personprof",
-            "http://uri.suomi.fi/datamodel/ns/ytm", "ytm"
+            ModelConstants.SUOMI_FI_NAMESPACE + "personprof/", "personprof",
+            ModelConstants.SUOMI_FI_NAMESPACE + "ytm/", "ytm"
     );
 
     @Test
     void mapClassWithParent() {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_visualization.ttl");
 
-        var classDTO = VisualizationMapper.mapClass("http://uri.suomi.fi/datamodel/ns/visu/natural-person", model, libraryNamespaces);
+        var uri = DataModelURI.createResourceURI("visu", "natural-person");
+        var classDTO = VisualizationMapper.mapClass(uri.getResourceURI(), model, libraryNamespaces);
 
         assertEquals("Luonnollinen henkilö", classDTO.getLabel().get("fi"));
 
@@ -157,7 +159,7 @@ class VisualizationDataMapperTest {
     @Test
     void mapApplicationProfileClass() {
         var model = MapperTestUtils.getModelFromFile("/models/test_application_profile_visualization.ttl");
-        var classURI = ModelConstants.SUOMI_FI_NAMESPACE + "visuprof" + ModelConstants.RESOURCE_SEPARATOR + "person";
+        var classURI = DataModelURI.createResourceURI("visuprof", "person").getResourceURI();
         var externalResources = new HashSet<Resource>();
 
         var classDTO = (VisualizationNodeShapeDTO) VisualizationMapper
@@ -170,7 +172,7 @@ class VisualizationDataMapperTest {
 
         assertEquals(2, classDTO.getAttributes().size());
         assertEquals(1, classDTO.getAssociations().size());
-        assertEquals("http://uri.suomi.fi/datamodel/ns/personprof/ext-attr", externalResources.iterator().next().getURI());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "personprof/ext-attr", externalResources.iterator().next().getURI());
 
         var mappedAttribute = findItem(classDTO.getAttributes(), "age", VisualizationPropertyShapeAttributeDTO.class);
         var mappedAssociation = findItem(classDTO.getAssociations(), "is-address", VisualizationPropertyShapeAssociationDTO.class);
@@ -194,7 +196,7 @@ class VisualizationDataMapperTest {
 
     @Test
     void mapPositionDataToGraph() {
-        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model" + ModelConstants.RESOURCE_SEPARATOR;
 
         var position = new PositionDataDTO();
         position.setIdentifier("class-1");
@@ -204,7 +206,7 @@ class VisualizationDataMapperTest {
 
         var positionModel = VisualizationMapper.mapPositionDataToModel(positionGraphURI, List.of(position));
 
-        var resource = positionModel.getResource(positionGraphURI + ModelConstants.RESOURCE_SEPARATOR + position.getIdentifier());
+        var resource = positionModel.getResource(positionGraphURI + position.getIdentifier());
 
         assertEquals("class-1", resource.getProperty(DCTerms.identifier).getString());
         assertEquals(3.0, resource.getProperty(Iow.posX).getLiteral().getDouble());
@@ -215,7 +217,7 @@ class VisualizationDataMapperTest {
     @Test
     void mapPositionDataWithParentClasses() {
         var modelPrefix = "test-model";
-        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix + ModelConstants.RESOURCE_SEPARATOR;
 
         var node1 = new PositionDataDTO();
         node1.setIdentifier("class-1");
@@ -256,7 +258,7 @@ class VisualizationDataMapperTest {
     @Test
     void mapPositionDataWithParentClassesAndHiddenNode() {
         var modelPrefix = "test-model";
-        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix + ModelConstants.RESOURCE_SEPARATOR;
 
         var node1 = new PositionDataDTO();
         node1.setIdentifier("class-1");
@@ -304,7 +306,7 @@ class VisualizationDataMapperTest {
     @Test
     void mapPositionDataWithParentClassesAndAssociationsAndHiddenNodes() {
         var modelPrefix = "test-model";
-        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix + ModelConstants.RESOURCE_SEPARATOR;
 
         // class-1 has parent class reference to class-2 via corner-1 and corner-2
         // class-1 has association to class-3 via corner-3
@@ -414,7 +416,7 @@ class VisualizationDataMapperTest {
     @Test
     void mapPositionDataAssociationRecursive() {
         var modelPrefix = "test-model";
-        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix;
+        var positionGraphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + modelPrefix + ModelConstants.RESOURCE_SEPARATOR;
 
         var association = new VisualizationReferenceDTO();
         association.setReferenceTarget("class-1");

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -176,7 +176,7 @@ class DataModelControllerTest {
         dataModelDTO.setGroups(Set.of("P11"));
         dataModelDTO.setLanguages(Set.of("fi"));
         dataModelDTO.setOrganizations(Set.of(MapperTestUtils.TEST_ORG_ID));
-        dataModelDTO.setInternalNamespaces(Set.of("http://uri.suomi.fi/datamodel/ns/test"));
+        dataModelDTO.setInternalNamespaces(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "test"));
         var extNs = new ExternalNamespaceDTO();
         extNs.setName(Map.of("fi", "test external namespace"));
         extNs.setPrefix("testprefix");
@@ -308,7 +308,7 @@ class DataModelControllerTest {
         invalidExtRes.setName(Map.of("fi", "this is invalid"));
         //uri.suomi.fi cannot be set as external namespace
         invalidExtRes.setPrefix("test");
-        invalidExtRes.setNamespace("http://uri.suomi.fi/datamodel/ns/test");
+        invalidExtRes.setNamespace(ModelConstants.SUOMI_FI_NAMESPACE + "test");
         dataModelDTO.setExternalNamespaces(Set.of(invalidExtRes));
         args.add(dataModelDTO);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/EndpointUtils.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/EndpointUtils.java
@@ -48,7 +48,7 @@ public class EndpointUtils {
 
     public static Model getMockModel(Resource type) {
         var mockModel = ModelFactory.createDefaultModel();
-        mockModel.createResource("http://uri.suomi.fi/datamodel/ns/test")
+        mockModel.createResource("https://iri.suomi.fi/model/test/")
                 .addProperty(RDF.type, type);
         return mockModel;
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportControllerTest.java
@@ -45,7 +45,7 @@ class ExportControllerTest {
         mvc.perform(get("/v2/export/test")
                 .header("Accept", "application/ld+json"))
                 .andExpect(status().isOk());
-        verify(dataModelService).export("test", null, null, "application/ld+json");
+        verify(dataModelService).export("test", null, "application/ld+json", false);
     }
 
     @Test
@@ -54,15 +54,7 @@ class ExportControllerTest {
                         .header("Accept", "application/ld+json")
                         .param("version", "1.0.0"))
                 .andExpect(status().isOk());
-        verify(dataModelService).export("test", "1.0.0", null, "application/ld+json");
-    }
-
-    @Test
-    void shouldCallDataModelServiceWithResource() throws Exception {
-        mvc.perform(get("/v2/export/test/Resource")
-                        .header("Accept", "application/ld+json"))
-                .andExpect(status().isOk());
-        verify(dataModelService).export("test", null, "Resource", "application/ld+json");
+        verify(dataModelService).export("test", "1.0.0","application/ld+json", false);
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtilsTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtilsTest.java
@@ -1,8 +1,12 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.vocabulary.DCTerms;
 import org.junit.jupiter.api.Test;
+
+import javax.xml.crypto.Data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,14 +16,15 @@ class MapperUtilsTest {
     void renameResource() {
         var m = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
 
-        var resource = m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        var uri = DataModelURI.createResourceURI("test", "TestClass");
+        var resource = m.getResource(uri.getResourceURI());
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/TestClass", resource.getURI());
-        assertEquals("TestClass", MapperUtils.getLiteral(resource, DCTerms.identifier, String.class));
+        assertEquals(uri.getResourceURI(), resource.getURI());
+        assertEquals(uri.getResourceId(), MapperUtils.getLiteral(resource, DCTerms.identifier, String.class));
 
-        resource = MapperUtils.renameResource(m.getResource("http://uri.suomi.fi/datamodel/ns/test/TestClass"), "NewClass");
+        resource = MapperUtils.renameResource(m.getResource(uri.getResourceURI()), "NewClass");
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/test/NewClass", resource.getURI());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewClass", resource.getURI());
         assertEquals("NewClass", MapperUtils.getLiteral(resource, DCTerms.identifier, String.class));
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/GraphNameMigrationTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/GraphNameMigrationTest.java
@@ -1,0 +1,130 @@
+package fi.vm.yti.datamodel.api.v2.migration;
+
+import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.migration.task.V10_RenameURIs;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        V10_RenameURIs.class
+})
+class GraphNameMigrationTest {
+
+    @MockBean
+    CoreRepository coreRepository;
+
+    @Captor
+    ArgumentCaptor<Model> captor;
+
+    @Autowired
+    V10_RenameURIs uriMigration;
+
+    static final String OLD_NS = "http://uri.suomi.fi/datamodel/ns/";
+    static final String OLD_POSITION_URI = "http://uri.suomi.fi/datamodel/positions/";
+
+    @Test
+    void moveDraftGraphs() {
+        var oldGraphURI = OLD_NS + "test";
+
+        var oldData = MapperTestUtils.getModelFromFile("/migration/old-identifiers.ttl");
+
+        mockConsumer(oldGraphURI);
+        when(coreRepository.fetch(oldGraphURI)).thenReturn(oldData);
+
+        uriMigration.migrate();
+
+        verify(coreRepository).put(eq(ModelConstants.SUOMI_FI_NAMESPACE + "test/"), captor.capture());
+        verify(coreRepository).delete(oldGraphURI);
+
+        // there should not exist any subject, predicate or object in the model containing old namespace
+        var model = captor.getValue();
+        var containsOldNS = model.listStatements().toList().stream().noneMatch(s ->
+                s.getSubject().toString().contains(OLD_NS)
+                        || !s.getPredicate().toString().contains(OLD_NS)
+                        || !s.getObject().toString().contains(OLD_NS));
+        // model resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/").listProperties().hasNext());
+        // class resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestClass").listProperties().hasNext());
+        // Attribute resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttributeRestriction").listProperties().hasNext());
+        // No resources with old namespace
+        assertFalse(containsOldNS);
+    }
+
+    @Test
+    void moveVersionGraphs() {
+        var oldGraphURI = OLD_NS + "test/1.0.0";
+
+        var oldData = MapperTestUtils.getModelFromFile("/migration/old-identifiers-version.ttl");
+
+        mockConsumer(oldGraphURI);
+        when(coreRepository.fetch(oldGraphURI)).thenReturn(oldData);
+
+        uriMigration.migrate();
+
+        verify(coreRepository).put(eq(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.0/"), captor.capture());
+        verify(coreRepository).delete(oldGraphURI);
+
+        // there should not exist any subject, predicate or object in the model containing old namespace
+        var model = captor.getValue();
+        var containsOldNS = model.listStatements().toList().stream().noneMatch(s ->
+                s.getSubject().toString().contains(OLD_NS)
+                        || !s.getPredicate().toString().contains(OLD_NS)
+                        || !s.getObject().toString().contains(OLD_NS));
+
+        // model resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/").listProperties().hasNext());
+        // class resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestClass").listProperties().hasNext());
+        // Attribute resource
+        assertTrue(model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestAttributeRestriction").listProperties().hasNext());
+        // No resources with old namespace
+        assertFalse(containsOldNS);
+    }
+
+    @Test
+    void movePositions() {
+        var oldPositionURI = OLD_POSITION_URI + "test";
+        var oldPositions = MapperTestUtils.getModelFromFile("/migration/old-positions.ttl");
+
+        when(coreRepository.fetch(oldPositionURI)).thenReturn(oldPositions);
+        mockConsumer(oldPositionURI);
+
+        uriMigration.migrate();
+
+        verify(coreRepository).put(eq(ModelConstants.MODEL_POSITIONS_NAMESPACE + "test/"), captor.capture());
+        verify(coreRepository).delete(oldPositionURI);
+    }
+
+    private void mockConsumer(String oldPositionURI) {
+        var solution = mock(QuerySolution.class);
+        var redNode = mock(RDFNode.class);
+        when(redNode.toString()).thenReturn(oldPositionURI);
+        when(solution.get(anyString())).thenReturn(redNode);
+
+        doAnswer(a -> {
+            var arg = a.getArgument(1, Consumer.class);
+            arg.accept(solution);
+            return null;
+        }).when(coreRepository).querySelect(anyString(), any(Consumer.class));
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -1,11 +1,13 @@
 package fi.vm.yti.datamodel.api.v2.opensearch;
 
 import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.QueryFactoryUtils;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.ResourceQueryFactory;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -17,28 +19,30 @@ import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 class ResourceQueryFactoryTest {
 
+    static String modelURI = DataModelURI.createModelURI("test").getModelURI();
+
     @Test
     void createInternalClassQueryValues() throws Exception {
         var request = new ResourceSearchRequest();
         request.setQuery("test query");
         request.setGroups(Set.of("P11", "P1"));
-        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setLimitToDataModel(modelURI);
         request.setFromAddedNamespaces(true);
         request.setPageFrom(1);
         request.setPageSize(100);
         request.setStatus(Set.of(Status.SUGGESTED, Status.VALID));
         request.setSortLang("en");
-        request.setTargetClass("http://uri.suomi.fi/datamodel/ns/test/TestClass");
+        request.setTargetClass(modelURI + "TestClass");
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
-        var groupNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/groupNs", "http://uri.suomi.fi/datamodel/ns/addedNs");
-        var internalNamespaces = List.of("http://uri.suomi.fi/datamodel/ns/addedNs");
+        var groupNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "groupNs/", ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/");
+        var internalNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/");
         var externalNamespaces = List.of("http://external-data.com/test");
 
-        var allowedIncompleteDatamodels = Set.of("http://uri.suomi.fi/datamodel/ns/test");
+        var allowedIncompleteDataModels = Set.of(modelURI);
 
         var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, externalNamespaces, internalNamespaces,
-                groupNamespaces, allowedIncompleteDatamodels);
+                groupNamespaces, allowedIncompleteDataModels);
 
         String expected = OpenSearchUtils.getJsonString("/es/classRequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(classQuery), JSONCompareMode.LENIENT);
@@ -53,9 +57,9 @@ class ResourceQueryFactoryTest {
 
         request.setPageFrom(1);
         request.setPageSize(100);
-        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setLimitToDataModel(modelURI);
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE));
-        request.setAdditionalResources(Set.of("http://uri.suomi.fi/datamodel/ns/ext/some-property"));
+        request.setAdditionalResources(Set.of(ModelConstants.SUOMI_FI_NAMESPACE + "ext/some-property"));
 
         var attributeListQuery = ResourceQueryFactory.createInternalResourceQuery(request, new ArrayList<>(), new ArrayList<>(),
                 null, new HashSet<>());
@@ -69,7 +73,7 @@ class ResourceQueryFactoryTest {
 
         request.setPageFrom(1);
         request.setPageSize(100);
-        request.setLimitToDataModel("http://uri.suomi.fi/datamodel/ns/test");
+        request.setLimitToDataModel(modelURI);
         request.setResourceTypes(Set.of(ResourceType.CLASS));
         request.setFromVersion("1.2.3");
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexServiceTest.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
@@ -16,6 +17,7 @@ import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import fi.vm.yti.security.YtiUser;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,7 +71,7 @@ class SearchIndexServiceTest {
     @Autowired
     SearchIndexService searchIndexService;
 
-    private static final String DATA_MODEL_URI = "http://uri.suomi.fi/datamodel/ns/profile";
+    private static final String DATA_MODEL_URI = ModelConstants.SUOMI_FI_NAMESPACE + "profile" + ModelConstants.RESOURCE_SEPARATOR;
 
     private static final UUID ORGANIZATION_ID = UUID.randomUUID();
 
@@ -115,7 +117,7 @@ class SearchIndexServiceTest {
 
         doSearch(request);
 
-        assertEquals("http://uri.suomi.fi/datamodel/ns/model", internalNamespaceCaptor.getValue().iterator().next());
+        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "model", internalNamespaceCaptor.getValue().iterator().next());
         assertEquals("http://ext.org/datamodel", externalNamespaceCaptor.getValue().iterator().next());
     }
 
@@ -153,8 +155,9 @@ class SearchIndexServiceTest {
         // model's namespaces
         var model = ModelFactory.createDefaultModel();
         model.createResource(DATA_MODEL_URI)
-                .addProperty(OWL.imports, ResourceFactory.createResource("http://uri.suomi.fi/datamodel/ns/model"))
-                .addProperty(OWL.imports, ResourceFactory.createResource("http://ext.org/datamodel"));
+                .addProperty(OWL.imports, ResourceFactory.createResource(ModelConstants.SUOMI_FI_NAMESPACE + "model"))
+                .addProperty(OWL.imports, ResourceFactory.createResource("http://ext.org/datamodel"))
+                .addProperty(DCTerms.requires, ResourceFactory.createResource("http://uri.suomi.fi/terminology/test-123"));
         when(coreRepository.fetch(DATA_MODEL_URI)).thenReturn(model);
 
         var allowedModel = new IndexModel();

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/UriResolveServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/UriResolveServiceTest.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ class UriResolveServiceTest {
     @Test
     void testRedirectSiteModel() {
         var accept = "text/html";
-        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test/1.0.1", accept);
+        var response = service.resolve(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/", accept);
         assertTrue(response.getStatusCode().is3xxRedirection());
         assertNotNull(response.getHeaders().getLocation());
         assertTrue(response.getHeaders().getLocation().toString().endsWith("/model/test?ver=1.0.1"));
@@ -50,9 +51,9 @@ class UriResolveServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
 
         var pathMap = Map.of(
-                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", "/model/test/class/TestClass?ver=1.0.1",
-                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAttribute", "/model/test/attribute/TestAttribute?ver=1.0.1",
-                "http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestAssociation", "/model/test/association/TestAssociation?ver=1.0.1"
+                ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestClass", "/model/test/class/TestClass?ver=1.0.1",
+                ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestAttribute", "/model/test/attribute/TestAttribute?ver=1.0.1",
+                ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestAssociation", "/model/test/association/TestAssociation?ver=1.0.1"
         );
         var accept = "text/html";
         for (var key : pathMap.keySet()) {
@@ -69,10 +70,8 @@ class UriResolveServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
 
         var accept = "text/turtle";
-        var response = service.resolve("http://uri.suomi.fi/datamodel/ns/test/1.0.1/TestClass", accept);
-        assertTrue(response.getStatusCode().is3xxRedirection());
-        assertNotNull(response.getHeaders().getLocation());
-        assertTrue(response.getHeaders().getLocation().toString().endsWith("/datamodel-api/v2/export/test/TestClass?version=1.0.1"));
+        var response = service.resolve(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/TestClass", accept);
+        assertTrue(response.getStatusCode().is4xxClientError());
     }
 
     @Test
@@ -80,5 +79,13 @@ class UriResolveServiceTest {
         var accept = "text/turtle";
         var response = service.resolve("http://invalid.com", accept);
         assertEquals("400 BAD_REQUEST", response.getStatusCode().toString());
+    }
+
+    @Test
+    void testFile() {
+        var response = service.resolve(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.0/test.ttl", null);
+        assertTrue(response.getStatusCode().is3xxRedirection());
+        assertNotNull(response.getHeaders().getLocation());
+        assertTrue(response.getHeaders().getLocation().toString().contains("contentType=text/turtle"));
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/VisualizationServiceTest.java
@@ -93,9 +93,10 @@ class VisualizationServiceTest {
         var model = MapperTestUtils.getModelFromFile("/models/test_application_profile_visualization.ttl");
         var positionModel = MapperTestUtils.getModelFromFile("/positions.ttl");
         var externalPropertiesModel = getExternalPropertiesResult();
+        var graph = ModelConstants.MODEL_POSITIONS_NAMESPACE + "visuprof" + ModelConstants.RESOURCE_SEPARATOR;
 
         when(coreRepository.fetch(anyString())).thenReturn(model);
-        when(coreRepository.fetch(ModelConstants.MODEL_POSITIONS_NAMESPACE + "visuprof")).thenReturn(positionModel);
+        when(coreRepository.fetch(graph)).thenReturn(positionModel);
         when(resourceService.findResources(anySet(), anySet())).thenReturn(externalPropertiesModel);
 
 
@@ -127,7 +128,7 @@ class VisualizationServiceTest {
 
     @Test
     void savePositions() {
-        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model" + ModelConstants.RESOURCE_SEPARATOR;
         when(coreRepository.graphExists(graphURI)).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
@@ -142,14 +143,14 @@ class VisualizationServiceTest {
 
         verify(coreRepository).put(eq(graphURI), modelCaptor.capture());
 
-        var resourceURI = graphURI + ModelConstants.RESOURCE_SEPARATOR + positionData.getIdentifier();
+        var resourceURI = graphURI + positionData.getIdentifier();
         var resource = modelCaptor.getValue().getResource(resourceURI);
         assertEquals("pos-1", resource.getProperty(DCTerms.identifier).getString());
     }
 
     @Test
     void savePositionsVersion() {
-        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model/1.2.3";
+        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model/1.2.3" + ModelConstants.RESOURCE_SEPARATOR;
         when(coreRepository.graphExists(graphURI)).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
@@ -173,26 +174,26 @@ class VisualizationServiceTest {
 
     @Test
     void saveVersionedPositions() {
-        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model";
+        var graphURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test-model" + ModelConstants.RESOURCE_SEPARATOR;
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
         visualizationService.saveVersionedPositions("test-model", "1.0.0");
 
         verify(coreRepository).fetch(graphURI);
-        verify(coreRepository).put(eq(graphURI + ModelConstants.RESOURCE_SEPARATOR + "1.0.0"), any(Model.class));
+        verify(coreRepository).put(eq(graphURI + "1.0.0" + ModelConstants.RESOURCE_SEPARATOR), any(Model.class));
     }
 
     @Test
     void testAddDefaultPosition() {
-        var positionURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test";
+        var positionURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + "test" + ModelConstants.RESOURCE_SEPARATOR;
         var positionModel = ModelFactory.createDefaultModel();
 
-        positionModel.createResource(positionURI + ModelConstants.RESOURCE_SEPARATOR + "res1")
+        positionModel.createResource(positionURI + "res1")
                         .addLiteral(Iow.posX, 10.0)
                         .addLiteral(Iow.posY, 20.0);
 
-        positionModel.createResource(positionURI + ModelConstants.RESOURCE_SEPARATOR + "res2")
+        positionModel.createResource(positionURI + "res2")
                 .addLiteral(Iow.posX, 120.0)
                 .addLiteral(Iow.posY, -10.0);
 
@@ -201,7 +202,7 @@ class VisualizationServiceTest {
         visualizationService.addNewResourceDefaultPosition("test", "test-id");
         verify(coreRepository).put(anyString(), modelCaptor.capture());
 
-        var positionResource = modelCaptor.getValue().getResource(positionURI + ModelConstants.RESOURCE_SEPARATOR + "test-id");
+        var positionResource = modelCaptor.getValue().getResource(positionURI + "test-id");
 
         // new position x = 0, y = existing minimum y coordinate - 50
         assertEquals(0.0, positionResource.getProperty(Iow.posX).getDouble());
@@ -211,12 +212,12 @@ class VisualizationServiceTest {
     private static Model getExternalPropertiesResult() {
         var externalPropertiesModel = ModelFactory.createDefaultModel();
 
-        var resource1 = externalPropertiesModel.createResource("http://uri.suomi.fi/datamodel/ns/personprof/street");
+        var resource1 = externalPropertiesModel.createResource(ModelConstants.SUOMI_FI_NAMESPACE + "personprof/street");
         resource1.addProperty(DCTerms.identifier, "street");
         resource1.addProperty(RDF.type, OWL.DatatypeProperty);
         resource1.addProperty(RDF.type, SH.PropertyShape);
 
-        var resource2 = externalPropertiesModel.createResource("http://uri.suomi.fi/datamodel/ns/personprof/zipcode");
+        var resource2 = externalPropertiesModel.createResource(ModelConstants.SUOMI_FI_NAMESPACE + "personprof/zipcode");
         resource2.addProperty(DCTerms.identifier, "zipcode");
         resource2.addProperty(RDF.type, OWL.DatatypeProperty);
         resource2.addProperty(RDF.type, SH.PropertyShape);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURITest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURITest.java
@@ -1,0 +1,124 @@
+package fi.vm.yti.datamodel.api.v2.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataModelURITest {
+
+    @Test
+    void modelVersionURI() {
+        var uri = DataModelURI.createModelURI("test", "1.0.0");
+
+        String modelURI = "https://iri.suomi.fi/model/test/";
+        String modelVersionURI = "https://iri.suomi.fi/model/test/1.0.0/";
+        assertEquals(modelURI, uri.getModelURI());
+        assertEquals(modelVersionURI, uri.getGraphURI());
+        assertEquals("1.0.0", uri.getVersion());
+        assertEquals("test", uri.getModelId());
+        assertEquals(modelURI, uri.getNamespace());
+    }
+
+    @Test
+    void modelURI() {
+        var uri = DataModelURI.createModelURI("test");
+
+        String expected = "https://iri.suomi.fi/model/test/";
+        assertEquals(expected, uri.getModelURI());
+        assertNull(uri.getVersion());
+        assertEquals("test", uri.getModelId());
+        assertEquals(expected, uri.getNamespace());
+    }
+
+    @Test
+    void resourceVersionURI() {
+        var uri = DataModelURI.createResourceURI("test", "class-1", "1.0.0");
+
+        String modelURI = "https://iri.suomi.fi/model/test/";
+        String modelVersionURI = "https://iri.suomi.fi/model/test/1.0.0/";
+        String resourceURI = "https://iri.suomi.fi/model/test/class-1";
+        String resourceVersionURI = "https://iri.suomi.fi/model/test/1.0.0/class-1";
+        assertEquals(resourceURI, uri.getResourceURI());
+        assertEquals(resourceVersionURI, uri.getResourceVersionURI());
+        assertEquals(modelVersionURI, uri.getGraphURI());
+        assertEquals(modelURI, uri.getModelURI());
+        assertEquals("1.0.0", uri.getVersion());
+        assertEquals("test", uri.getModelId());
+        assertEquals("class-1", uri.getResourceId());
+        assertEquals(modelURI, uri.getNamespace());
+    }
+
+    @Test
+    void resourceURI() {
+        var uri = DataModelURI.createResourceURI("test", "class-1");
+
+        String modelURI = "https://iri.suomi.fi/model/test/";
+        String resourceURI = "https://iri.suomi.fi/model/test/class-1";
+        assertEquals(resourceURI, uri.getResourceURI());
+        assertEquals(resourceURI, uri.getResourceVersionURI());
+        assertEquals(modelURI, uri.getGraphURI());
+        assertEquals(modelURI, uri.getModelURI());
+        assertNull(uri.getVersion());
+        assertEquals("test", uri.getModelId());
+        assertEquals("class-1", uri.getResourceId());
+        assertEquals(modelURI, uri.getNamespace());
+    }
+
+    @Test
+    void createFromResourceVersionURI() {
+        var uri = DataModelURI.fromURI("https://iri.suomi.fi/model/test/1.2.3/class-1");
+
+        assertEquals("test", uri.getModelId());
+        assertEquals("1.2.3", uri.getVersion());
+        assertEquals("class-1", uri.getResourceId());
+    }
+
+    @Test
+    void createFromResourceURI() {
+        var uri = DataModelURI.fromURI("https://iri.suomi.fi/model/test/class-1");
+
+        assertEquals("test", uri.getModelId());
+        assertNull(uri.getVersion());
+        assertEquals("class-1", uri.getResourceId());
+    }
+
+    @Test
+    void createFromModelURI() {
+        var uri = DataModelURI.fromURI("https://iri.suomi.fi/model/test/");
+
+        assertEquals("test", uri.getModelId());
+        assertNull(uri.getVersion());
+        assertNull(uri.getResourceId());
+    }
+
+    @Test
+    void createFromModelVersionURI() {
+        var uri = DataModelURI.fromURI("https://iri.suomi.fi/model/test/14.10.12/");
+
+        assertEquals("test", uri.getModelId());
+        assertEquals("14.10.12", uri.getVersion());
+        assertNull(uri.getResourceId());
+    }
+
+    @Test
+    void modelURIWithContentType() {
+        var url = DataModelURI.fromURI("https://iri.suomi.fi/model/test/1.0.3/test2.ttl");
+
+        assertEquals("test", url.getModelId());
+        assertEquals("text/turtle", url.getContentType());
+        assertEquals("application/rdf+xml", DataModelURI.fromURI("https://iri.suomi.fi/model/test/14.10.12/test.rdf").getContentType());
+        assertEquals("application/ld+json", DataModelURI.fromURI("https://iri.suomi.fi/model/test/14.10.12/test.json").getContentType());
+        assertNull(DataModelURI.fromURI("https://iri.suomi.fi/model/test/14.10.12/test").getContentType());
+        assertNull(DataModelURI.fromURI("https://iri.suomi.fi/model/test.foo").getContentType());
+    }
+
+    @Test
+    void externalURI() {
+        var uri = DataModelURI.fromURI("http://www.w3.org/2000/01/rdf-schema#Literal");
+
+        assertEquals("http://www.w3.org/2000/01/rdf-schema#", uri.getNamespace());
+        assertEquals("Literal", uri.getResourceId());
+        assertNull(uri.getVersion());
+        assertNull(uri.getModelId());
+    }
+}

--- a/src/test/resources/codelist.ttl
+++ b/src/test/resources/codelist.ttl
@@ -2,7 +2,7 @@
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
 <http://uri.suomi.fi/codelist/test/testcodelist>
     a               iow:CodeScheme ;

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -13,7 +13,7 @@
                     {
                       "terms": {
                         "isDefinedBy": [
-                          "http://uri.suomi.fi/datamodel/ns/test"
+                          "https://iri.suomi.fi/model/test/"
                         ]
                       }
                     },
@@ -44,7 +44,7 @@
               {
                 "terms": {
                   "id": [
-                    "http://uri.suomi.fi/datamodel/ns/ext/some-property"
+                    "https://iri.suomi.fi/model/ext/some-property"
                   ]
                 }
               }

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -26,7 +26,7 @@
               {
                 "terms": {
                   "versionIri": [
-                    "http://uri.suomi.fi/datamodel/ns/addedNs"
+                    "https://iri.suomi.fi/model/addedNs/"
                   ]
                 }
               },
@@ -46,7 +46,7 @@
         {
           "term": {
             "targetClass": {
-              "value": "http://uri.suomi.fi/datamodel/ns/test/TestClass"
+              "value": "https://iri.suomi.fi/model/test/TestClass"
             }
           }
         }
@@ -55,7 +55,7 @@
         {
           "terms": {
             "isDefinedBy": [
-              "http://uri.suomi.fi/datamodel/ns/test"
+              "https://iri.suomi.fi/model/test/"
             ]
           }
         },

--- a/src/test/resources/es/classesByVersion.json
+++ b/src/test/resources/es/classesByVersion.json
@@ -13,7 +13,7 @@
                     {
                       "terms": {
                         "isDefinedBy": [
-                          "http://uri.suomi.fi/datamodel/ns/test"
+                          "https://iri.suomi.fi/model/test/"
                         ]
                       }
                     },

--- a/src/test/resources/migration/old-identifiers-version.ttl
+++ b/src/test/resources/migration/old-identifiers-version.ttl
@@ -1,0 +1,60 @@
+@prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#>
+@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+
+<http://uri.suomi.fi/datamodel/ns/test>
+    a                               iow:ApplicationProfile , owl:Ontology ;
+    rdfs:comment                    "test desc"@fi ;
+    rdfs:label                      "testlabel"@fi ;
+    dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+    dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    dcterms:hasPart                 test:TestAttribute, test:TestClass, test:TestAssociation ;
+    dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
+    dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+    dcterms:language                "fi" ;
+    owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+    dcterms:requires                <https://www.example.com/ns/ext> ;
+    dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+    dcap:preferredXMLNamespacePrefix
+    "test" ;
+    iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    owl:versionInfo                 "1.0.0" ;
+    owl:versionIRI                  test:1.0.0 ;
+    suomi-meta:publicationStatus    "VALID" .
+
+test:TestClass  rdf:type     sh:NodeShape ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:label           "test label"@fi ;
+        dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        dcterms:identifier   "TestClass"^^xsd:NCName ;
+        dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
+        suomi-meta:publicationStatus      "VALID" ;
+        skos:editorialNote   "comment visible for admin" ;
+        rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
+        iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
+        sh:property          <http://uri.suomi.fi/datamodel/ns/test/TestPropertyShape> , <http://uri.suomi.fi/datamodel/ns/test/DeactivatedPropertyShape> ;
+        sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target/Class> .
+
+test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
+        rdf:type             owl:DatatypeProperty ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
+        dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
+        dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
+        rdfs:label           "test property shape"@fi ;
+        suomi-meta:publicationStatus      "DRAFT" ;
+        sh:defaultValue      "foo" ;
+        iow:codeList         <http://uri.suomi.fi/codelist/Test> ;
+        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .

--- a/src/test/resources/migration/old-identifiers.ttl
+++ b/src/test/resources/migration/old-identifiers.ttl
@@ -1,42 +1,42 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <https://iri.suomi.fi/model/iow/> .
+@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <https://iri.suomi.fi/model/test/> .
+@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#>
-@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
 
-
-<https://iri.suomi.fi/model/test/>
-a                               iow:ApplicationProfile , owl:Ontology ;
-rdfs:comment                    "test desc"@fi ;
-rdfs:label                      "testlabel"@fi ;
-dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
-dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-dcterms:hasPart                 test:TestAttribute, test:TestClass, test:TestAssociation ;
-dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
-dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
-dcterms:language                "fi" ;
-owl:imports                     <https://iri.suomi.fi/model/int> ;
-dcterms:requires                <https://www.example.com/ns/ext> ;
-dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
-dcap:preferredXMLNamespacePrefix
-"test" ;
-iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-suomi-meta:publicationStatus                 "VALID" .
+<http://uri.suomi.fi/datamodel/ns/test>
+    a                               iow:ApplicationProfile , owl:Ontology ;
+    rdfs:comment                    "test desc"@fi ;
+    rdfs:label                      "testlabel"@fi ;
+    dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+    dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    dcterms:hasPart                 test:TestAttribute, test:TestClass, test:TestAssociation ;
+    dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
+    dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+    dcterms:language                "fi" ;
+    owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+    dcterms:requires                <https://www.example.com/ns/ext> ;
+    dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+    dcap:preferredXMLNamespacePrefix
+    "test" ;
+    iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
+    owl:priorVersion                test:1.0.0 ;
+    suomi-meta:publicationStatus    "VALID" .
 
 <https://www.example.com/ns/ext>
-dcterms:type                        rdfs:Resource ;
-rdfs:label                          "test resource"@fi;
-dcap:preferredXMLNamespacePrefix    "extres" .
+    dcterms:type                        rdfs:Resource ;
+    rdfs:label                          "test resource"@fi;
+    dcap:preferredXMLNamespacePrefix    "extres" .
 
 test:TestClass  rdf:type     sh:NodeShape ;
-        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         rdfs:label           "test label"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
@@ -47,12 +47,12 @@ test:TestClass  rdf:type     sh:NodeShape ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         iow:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        sh:property          <https://iri.suomi.fi/model/test/TestPropertyShape> , <https://iri.suomi.fi/model/test/DeactivatedPropertyShape> ;
-        sh:targetClass       <https://iri.suomi.fi/model/target/Class> .
+        sh:property          <http://uri.suomi.fi/datamodel/ns/test/TestPropertyShape> , <http://uri.suomi.fi/datamodel/ns/test/DeactivatedPropertyShape> ;
+        sh:targetClass       <http://uri.suomi.fi/datamodel/ns/target/Class> .
 
 test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         rdf:type             owl:DatatypeProperty ;
-        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
         dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
@@ -60,23 +60,12 @@ test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         rdfs:label           "test property shape"@fi ;
         suomi-meta:publicationStatus      "DRAFT" ;
         sh:defaultValue      "foo" ;
-        sh:hasValue          "hasValue" ;
-        sh:datatype          "xsd:integer" ;
-        sh:in                "bar" , "foo" ;
-        sh:maxCount          10 ;
-        sh:maxLength         100 ;
-        sh:minCount          1 ;
-        sh:minLength         2 ;
-        sh:minInclusive      5 ;
-        sh:maxInclusive      7 ;
-        sh:minExclusive      6 ;
-        sh:maxExclusive      8 ;
         iow:codeList         <http://uri.suomi.fi/codelist/Test> ;
-        sh:path              <https://iri.suomi.fi/model/ytm/some-attribute> .
+        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .
 
 test:TestAssociationRestriction  rdf:type  sh:PropertyShape ;
         rdf:type             owl:ObjectProperty ;
-        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
         dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
@@ -85,12 +74,12 @@ test:TestAssociationRestriction  rdf:type  sh:PropertyShape ;
         suomi-meta:publicationStatus      "DRAFT" ;
         sh:maxCount          10 ;
         sh:minCount          1 ;
-        sh:path              <https://iri.suomi.fi/model/ytm/some-attribute> ;
-        sh:class             <https://iri.suomi.fi/model/ytm/some-class> .
+        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> ;
+        sh:class             <http://uri.suomi.fi/datamodel/ns/ytm/some-class> .
 
 test:DeactivatedPropertyShape  rdf:type  sh:PropertyShape ;
         rdf:type             owl:DatatypeProperty ;
-        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
+        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
         dcterms:identifier   "DeactivatedPropertyShape"^^xsd:NCName ;
         sh:deactivated       true ;
         rdfs:label           "deactivated property shape"@fi .

--- a/src/test/resources/migration/old-positions.ttl
+++ b/src/test/resources/migration/old-positions.ttl
@@ -1,6 +1,6 @@
 @prefix dcterms:    <http://purl.org/dc/terms/> .
-@prefix iow:        <https://iri.suomi.fi/model/iow/> .
-@prefix visuprof:   <https://iri.suomi.fi/model-positions/visuprof/> .
+@prefix iow:        <http://uri.suomi.fi/datamomodel/ns/iow/> .
+@prefix visuprof:   <http://uri.suomi.fi/datamodel/positions/visuprof/> .
 
 visuprof:person
         dcterms:identifier      "person" ;

--- a/src/test/resources/model_with_owl_restrictions.ttl
+++ b/src/test/resources/model_with_owl_restrictions.ttl
@@ -3,40 +3,40 @@
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
-<http://uri.suomi.fi/datamodel/ns/model/>
+<https://iri.suomi.fi/model/model/>
     a           owl:Ontology .
 
-<http://uri.suomi.fi/datamodel/ns/model/attribute-1>
+<https://iri.suomi.fi/model/model/attribute-1>
     a          owl:DatatypeProperty ;
     rdfs:range xsd:anyURI .
 
-<http://uri.suomi.fi/datamodel/ns/model/class-1>
+<https://iri.suomi.fi/model/model/class-1>
     a                   owl:Class ;
-    owl:equivalentClass <http://uri.suomi.fi/datamodel/ns/model/class-2> ;
+    owl:equivalentClass <https://iri.suomi.fi/model/model/class-2> ;
     owl:equivalentClass [ a                  owl:Class ;
                           owl:intersectionOf ( [ a                  owl:Restriction ;
-                                                 owl:onProperty     <http://uri.suomi.fi/datamodel/ns/model/attribute-1> ;
+                                                 owl:onProperty     <https://iri.suomi.fi/model/model/attribute-1> ;
                                                  owl:someValuesFrom xsd:anyURI ]
                                                [ a                  owl:Restriction ;
-                                                 owl:onProperty     <http://uri.suomi.fi/datamodel/ns/model/attribute-2> ;
+                                                 owl:onProperty     <https://iri.suomi.fi/model/model/attribute-2> ;
                                                  owl:someValuesFrom xsd:anyURI ] ) ] .
 
-<http://uri.suomi.fi/datamodel/ns/model/class-update-target>
+<https://iri.suomi.fi/model/model/class-update-target>
     a                   owl:Class ;
     owl:equivalentClass [ a                  owl:Class ;
                           owl:intersectionOf ( [ a                  owl:Restriction ;
-                                                 owl:onProperty     <http://uri.suomi.fi/datamodel/ns/model/association-1> ;
-                                                 owl:someValuesFrom <http://uri.suomi.fi/datamodel/ns/model/class-2> ]
+                                                 owl:onProperty     <https://iri.suomi.fi/model/model/association-1> ;
+                                                 owl:someValuesFrom <https://iri.suomi.fi/model/model/class-2> ]
                                                [ a                  owl:Restriction ;
-                                                 owl:onProperty     <http://uri.suomi.fi/datamodel/ns/model/association-1> ;
-                                                 owl:someValuesFrom <http://uri.suomi.fi/datamodel/ns/model/class-3> ]) ] .
+                                                 owl:onProperty     <https://iri.suomi.fi/model/model/association-1> ;
+                                                 owl:someValuesFrom <https://iri.suomi.fi/model/model/class-3> ]) ] .
 
-<http://uri.suomi.fi/datamodel/ns/model/attribute-2>
+<https://iri.suomi.fi/model/model/attribute-2>
     a          owl:DatatypeProperty ;
     rdfs:range xsd:anyURI .
 
-<http://uri.suomi.fi/datamodel/ns/model/association-1>
+<https://iri.suomi.fi/model/model/association-1>
     a owl:DatatypeProperty .
 
-<http://uri.suomi.fi/datamodel/ns/model/class-2>
+<https://iri.suomi.fi/model/model/class-2>
     a owl:Class .

--- a/src/test/resources/models/test_application_profile_visualization.ttl
+++ b/src/test/resources/models/test_application_profile_visualization.ttl
@@ -1,18 +1,18 @@
 @prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms:    <http://purl.org/dc/terms/> .
-@prefix iow:        <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:        <https://iri.suomi.fi/model/iow/> .
 @prefix owl:        <http://www.w3.org/2002/07/owl#> .
-@prefix personprof: <http://uri.suomi.fi/datamodel/ns/personprof/> .
+@prefix personprof: <https://iri.suomi.fi/model/personprof/> .
 @prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:         <http://www.w3.org/ns/shacl#> .
 @prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
-@prefix visuprof:   <http://uri.suomi.fi/datamodel/ns/visuprof/> .
+@prefix visuprof:   <https://iri.suomi.fi/model/visuprof/> .
 @prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
-@prefix ytm:        <http://uri.suomi.fi/datamodel/ns/ytm/> .
+@prefix ytm:        <https://iri.suomi.fi/model/ytm/> .
 
 visuprof:age  rdf:type      sh:PropertyShape , owl:DatatypeProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/visuprof> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/visuprof/> ;
         rdfs:label          "Ikä"@fi ;
         dcterms:identifier  "age"^^xsd:NCName ;
         sh:datatype         "xsd:integer" ;
@@ -20,18 +20,18 @@ visuprof:age  rdf:type      sh:PropertyShape , owl:DatatypeProperty ;
         sh:minCount         1 ;
         sh:path             ytm:age .
 
-<http://uri.suomi.fi/datamodel/ns/visuprof>
+<https://iri.suomi.fi/model/visuprof/>
         rdf:type                    owl:Ontology , iow:ApplicationProfile ;
         rdfs:label                  "Soveltamisprofiili visu"@fi ;
         dcterms:identifier          "1ff6db8a-78fa-4411-9cd9-21df40ef4418" ;
         dcterms:language            "fi" ;
-        dcterms:requires            <http://uri.suomi.fi/datamodel/ns/ytm> ;
-        dcap:preferredXMLNamespace  "http://uri.suomi.fi/datamodel/ns/visuprof" ;
+        dcterms:requires            <https://iri.suomi.fi/model/ytm> ;
+        dcap:preferredXMLNamespace  "https://iri.suomi.fi/model/visuprof" ;
         dcap:preferredXMLNamespacePrefix  "visuprof" ;
-        owl:imports                 <http://uri.suomi.fi/datamodel/ns/personprof> .
+        owl:imports                 <https://iri.suomi.fi/model/personprof> .
 
 visuprof:name  rdf:type     sh:PropertyShape , owl:DatatypeProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/visuprof> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/visuprof/> ;
         rdfs:label          "Nimi"@fi ;
         dcterms:identifier  "name"^^xsd:NCName ;
         sh:datatype         "xsd:string" ;
@@ -40,7 +40,7 @@ visuprof:name  rdf:type     sh:PropertyShape , owl:DatatypeProperty ;
         sh:path             ytm:name .
 
 visuprof:is-address  rdf:type  sh:PropertyShape , owl:ObjectProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/visuprof> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/visuprof/> ;
         rdfs:label          "onOsoite"@fi ;
         dcterms:identifier  "is-address"^^xsd:NCName ;
         sh:class            ytm:address ;
@@ -49,7 +49,7 @@ visuprof:is-address  rdf:type  sh:PropertyShape , owl:ObjectProperty ;
         sh:path             ytm:is-address .
 
 visuprof:address  rdf:type  sh:NodeShape ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/visuprof> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/visuprof/> ;
         rdfs:label          "Osoite"@fi ;
         dcterms:identifier  "address"^^xsd:NCName ;
         sh:node             personprof:address ;
@@ -57,7 +57,7 @@ visuprof:address  rdf:type  sh:NodeShape ;
         sh:targetClass      ytm:address .
 
 visuprof:person  rdf:type   sh:NodeShape ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/visuprof> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/visuprof/> ;
         rdfs:label          "Henkilö"@fi ;
         dcterms:identifier  "person"^^xsd:NCName ;
         sh:property         visuprof:age , visuprof:name , visuprof:is-address , personprof:ext-attr ;

--- a/src/test/resources/models/test_datamodel_library_version.ttl
+++ b/src/test/resources/models/test_datamodel_library_version.ttl
@@ -1,15 +1,15 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix ext:     <https://www.example.com/ns/ext> .
-@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
+@prefix int:     <https://iri.suomi.fi/model/int> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
+<https://iri.suomi.fi/model/test/>
         a                               owl:Ontology ;
         rdfs:comment                    "test desc"@fi ;
         rdfs:label                      "testlabel"@fi ;
@@ -18,10 +18,10 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        owl:imports                     <https://iri.suomi.fi/model/int> ;
         dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/terminology/test> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
@@ -36,5 +36,5 @@
                                             dcterms:title       "link title"@fi ;
                                             foaf:homepage       "https://example.com"
                                         ] ;
-        owl:versionIRI                  "http://uri.suomi.fi/datamodel/ns/test/1.0.1" ;
-        owl:priorVersion                "http://uri.suomi.fi/datamodel/ns/test/1.0.0" .
+        owl:versionIRI                  "https://iri.suomi.fi/model/test/1.0.1/" ;
+        owl:priorVersion                "https://iri.suomi.fi/model/test/1.0.0/" .

--- a/src/test/resources/models/test_datamodel_library_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_library_visualization.ttl
@@ -1,37 +1,37 @@
 @prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms:    <http://purl.org/dc/terms/> .
-@prefix iow:        <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:        <https://iri.suomi.fi/model/iow/> .
 @prefix owl:        <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:         <http://www.w3.org/ns/shacl#> .
 @prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
-@prefix visu:       <http://uri.suomi.fi/datamodel/ns/visu/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix visu:       <https://iri.suomi.fi/model/visu/> .
 @prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
 @prefix ext:        <https://www.example.com/ns/external/> .
 
 visu:city  rdf:type                   owl:Class ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         dcterms:identifier            "city"^^xsd:NCName ;
         rdfs:label                    "Kaupunki"@fi .
 
 visu:name  rdf:type                   owl:DatatypeProperty ;
         rdfs:domain                   visu:person ;
         dcterms:identifier            "name"^^xsd:NCName ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "Nimi"@fi ;
         rdfs:range                    xsd:string .
 
 visu:is-city  rdf:type                owl:ObjectProperty ;
         rdfs:domain                   visu:address ;
         dcterms:identifier            "is-city"^^xsd:NCName ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "onKaupunki"@fi ;
         rdfs:range                    visu:city .
 
 visu:address  rdf:type                owl:Class ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "Osoite"@fi ;
         dcterms:identifier            "address"^^xsd:NCName ;
         owl:equivalentClass           [ rdf:type            owl:Class ;
@@ -43,7 +43,7 @@ visu:address  rdf:type                owl:Class ;
                                       ] .
 
 visu:person  rdf:type                 owl:Class ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "Henkilö"@fi ;
         rdfs:subClassOf               ext:Person ;
         dcterms:identifier            "person"^^xsd:NCName ;
@@ -68,40 +68,40 @@ visu:person  rdf:type                 owl:Class ;
                                       ] .
 
 visu:natural-person  rdf:type         owl:Class ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "Luonnollinen henkilö"@fi ;
         dcterms:identifier            "natural-person"^^xsd:NCName ;
         rdfs:subClassOf               visu:person .
 
-<http://uri.suomi.fi/datamodel/ns/visu>
+<https://iri.suomi.fi/model/visu/>
         rdf:type                      owl:Ontology ;
         rdfs:label                    "Visualisaatio"@fi ;
         dcterms:contributor           <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
         dcterms:language              "fi" ;
-        dcap:preferredXMLNamespace    "http://uri.suomi.fi/datamodel/ns/visu" ;
+        dcap:preferredXMLNamespace    "https://iri.suomi.fi/model/visu/" ;
         dcap:preferredXMLNamespacePrefix
                 "visu" ;
-        owl:imports                   <https://www.example.com/ns/external> ;
+        owl:imports                   <https://www.example.com/ns/external/> ;
         suomi-meta:publicationStatus  "DRAFT" .
 
 visu:is-address  rdf:type             owl:ObjectProperty ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         dcterms:identifier            "is-address"^^xsd:NCName ;
         rdfs:label                    "onOsoite"@fi .
 
 visu:street  rdf:type                 owl:DatatypeProperty ;
-        rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+        rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
         rdfs:label                    "Street"@fi ;
         dcterms:identifier            "street"^^xsd:NCName ;
         rdfs:range                    xsd:string .
 
  visu:age  rdf:type                    owl:DatatypeProperty ;
-         rdfs:isDefinedBy              <http://uri.suomi.fi/datamodel/ns/visu> ;
+         rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;
          dcterms:identifier            "age"^^xsd:NCName ;
          rdfs:label                    "Ikä"@fi ;
          rdfs:range                    xsd:integer .
 
-<https://www.example.com/ns/external>
+<https://www.example.com/ns/external/>
  dcterms:type                        rdfs:Resource ;
  rdfs:label                          "External"@fi;
  dcap:preferredXMLNamespacePrefix    "ext" .

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -1,15 +1,15 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
+@prefix test:    <https://iri.suomi.fi/model/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
+<https://iri.suomi.fi/model/test/>
 a                               owl:Ontology ;
 rdfs:comment                    "test desc"@fi ;
 rdfs:label                      "testlabel"@fi ;
@@ -19,16 +19,16 @@ dcterms:hasPart                 test:TestAttribute, test:TestClass, test:TestAss
 dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
 dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
 dcterms:language                "fi" ;
-owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+owl:imports                     <https://iri.suomi.fi/model/int> ;
 dcterms:requires                <https://www.example.com/ns/ext> ;
 dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
 suomi-meta:publicationStatus    "VALID" ;
 owl:versionInfo                 "1.0.1" ;
-owl:versionIRI                  <http://uri.suomi.fi/datamodel/ns/test/1.0.1> .
+owl:versionIRI                  <https://iri.suomi.fi/model/test/1.0.1/> .
 
 <https://www.example.com/ns/ext>
 dcterms:type                        rdfs:Resource ;
@@ -36,14 +36,14 @@ rdfs:label                          "test resource"@fi;
 dcap:preferredXMLNamespacePrefix    "extres" .
 
 test:TestClass  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         rdfs:label           "test label"@fi ;
-        rdfs:subClassOf      <http://uri.suomi.fi/datamodel/ns/test/SubClass> ;
+        rdfs:subClassOf      <https://iri.suomi.fi/model/test/SubClass> ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentClass  <http://uri.suomi.fi/datamodel/ns/test/EqClass> ;
+        owl:equivalentClass  <https://iri.suomi.fi/model/test/EqClass> ;
         suomi-meta:publicationStatus      "VALID" ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test note fi"@fi, "test note en"@en ;
@@ -60,38 +60,38 @@ test:TestClass  rdf:type     owl:Class ;
                 ] .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
-        rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy        <https://iri.suomi.fi/model/test/> ;
         rdfs:label              "test attribute"@fi ;
-        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test/SubResource> ;
+        rdfs:subPropertyOf      <https://iri.suomi.fi/model/test/SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAttribute"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test/EqResource> ;
+        owl:equivalentProperty  <https://iri.suomi.fi/model/test/EqResource> ;
         suomi-meta:publicationStatus         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test/DomainClass> ;
+        rdfs:domain             <https://iri.suomi.fi/model/test/DomainClass> ;
         rdfs:range              rdfs:Literal .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty, owl:FunctionalProperty ;
-        rdfs:isDefinedBy        <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy        <https://iri.suomi.fi/model/test/> ;
         rdfs:label              "test association"@fi ;
-        rdfs:subPropertyOf      <http://uri.suomi.fi/datamodel/ns/test/SubResource> ;
+        rdfs:subPropertyOf      <https://iri.suomi.fi/model/test/SubResource> ;
         dcterms:created         "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier      "TestAssociation"^^xsd:NCName ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
-        owl:equivalentProperty  <http://uri.suomi.fi/datamodel/ns/test/EqResource> ;
+        owl:equivalentProperty  <https://iri.suomi.fi/model/test/EqResource> ;
         suomi-meta:publicationStatus         "VALID" ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         iow:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         iow:modifier            "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        rdfs:domain             <http://uri.suomi.fi/datamodel/ns/test/DomainClass> ;
-        rdfs:range              <http://uri.suomi.fi/datamodel/ns/test/RangeClass>
+        rdfs:domain             <https://iri.suomi.fi/model/test/DomainClass> ;
+        rdfs:range              <https://iri.suomi.fi/model/test/RangeClass>
 
 
 

--- a/src/test/resources/models/test_datamodel_prior_versions.ttl
+++ b/src/test/resources/models/test_datamodel_prior_versions.ttl
@@ -1,22 +1,22 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
+@prefix test:    <https://iri.suomi.fi/model/test/> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test/1.0.0>
+<https://iri.suomi.fi/model/test/1.0.0/>
         suomi-meta:publicationStatus "VALID" ;
         owl:versionInfo       "1.0.0" ;
         rdfs:label            "Test"@fi ;
-        owl:versionIRI        <http://uri.suomi.fi/datamodel/ns/test/1.0.0> .
+        owl:versionIRI        <https://iri.suomi.fi/model/test/1.0.0/> .
 
-<http://uri.suomi.fi/datamodel/ns/test/2.0.0>
+<https://iri.suomi.fi/model/test/2.0.0/>
         suomi-meta:publicationStatus "VALID" ;
         owl:versionInfo       "2.0.0";
         rdfs:label            "Test"@fi ;
-        owl:versionIRI        <http://uri.suomi.fi/datamodel/ns/test/2.0.0> .
+        owl:versionIRI        <https://iri.suomi.fi/model/test/2.0.0/> .

--- a/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
+++ b/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
@@ -1,15 +1,15 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix test:    <http://uri.suomi.fi/datamodel/ns/test/> .
+@prefix test:    <https://iri.suomi.fi/model/test/> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
+<https://iri.suomi.fi/model/test/>
         a                               iow:ApplicationProfile , owl:Ontology ;
         rdfs:comment                    "test desc"@fi ;
         rdfs:label                      "testlabel"@fi ;
@@ -19,10 +19,10 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        owl:imports                     <https://iri.suomi.fi/model/int> ;
         dcterms:requires                <https://www.example.com/ns/ext> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test/" ;
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
@@ -34,7 +34,7 @@
         dcap:preferredXMLNamespacePrefix    "extres" .
 
 test:TestClass  rdf:type     owl:Class ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         rdfs:label           "test label"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
@@ -42,7 +42,7 @@ test:TestClass  rdf:type     owl:Class ;
         suomi-meta:publicationStatus      "VALID" .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         rdfs:label           "test attribute"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAttribute"^^xsd:NCName ;
@@ -50,7 +50,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         suomi-meta:publicationStatus      "VALID" .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         rdfs:label           "test association"@fi ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAssociation"^^xsd:NCName ;

--- a/src/test/resources/models/test_resource_query_model.ttl
+++ b/src/test/resources/models/test_resource_query_model.ttl
@@ -1,4 +1,4 @@
-@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:   <https://iri.suomi.fi/model/iow/> .
 @prefix dcap:  <http://purl.org/ws-mmi-dc/terms/> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
@@ -8,12 +8,12 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://uri.suomi.fi/datamodel/ns/test/rangetest2>
+<https://iri.suomi.fi/model/test/rangetest2>
         a                    owl:DatatypeProperty ;
         rdfs:label           "test label"@fi ;
         rdfs:range           xsd:integer ;
         dcterms:identifier   "test"^^xsd:NCName ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> .
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
-        owl:versionIRI       <http://uri.suomi.fi/datamodel/ns/test/1.0.0> .
+<https://iri.suomi.fi/model/test/>
+        owl:versionIRI       <https://iri.suomi.fi/model/test/1.0.0/> .

--- a/src/test/resources/organizations.ttl
+++ b/src/test/resources/organizations.ttl
@@ -6,17 +6,17 @@
 <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09>
         a                    <http://xmlns.com/foaf/0.1/Organization> ;
         dcterms:description  "kuvaus"@fi ;
-        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> "" ;
+        <https://iri.suomi.fi/model/iow/parentOrganization> "" ;
         skos:prefLabel       "Testiorganisaatio"@fi , "Test organization"@en  ;
         <http://xmlns.com/foaf/0.1/homepage> "http://testi.fi" .
 
 <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63>
         a               <http://xmlns.com/foaf/0.1/Organization> ;
-        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> "" ;
+        <https://iri.suomi.fi/model/iow/parentOrganization> "" ;
         skos:prefLabel  "Yhteentoimivuusalustan yllapito"@fi , "Interoperability platform developers"@en , "Utvecklare av interoperabilitetsplattform"@sv ;
         <http://xmlns.com/foaf/0.1/homepage> "https://yhteentoimiva.suomi.fi/" .
 
 <urn:uuid:8fab2816-03c5-48cd-9d48-b61048f435da>
         a               <http://xmlns.com/foaf/0.1/Organization> ;
-        <http://uri.suomi.fi/datamodel/ns/iow/parentOrganization> <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09> ;
+        <https://iri.suomi.fi/model/iow/parentOrganization> <urn:uuid:74776e94-7f51-48dc-aeec-c084c4defa09> ;
         skos:prefLabel  "Test aliorganisaatio"@fi .

--- a/src/test/resources/properties_result.ttl
+++ b/src/test/resources/properties_result.ttl
@@ -1,27 +1,27 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test_lib/attribute-1>
+<https://iri.suomi.fi/model/test_lib/attribute-1>
         rdf:type            owl:DatatypeProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_lib/> ;
         rdfs:label          "Attribute attribute-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
         suomi-meta:publicationStatus     "VALID" .
 
-<http://uri.suomi.fi/datamodel/ns/test_lib/association-1>
+<https://iri.suomi.fi/model/test_lib/association-1>
         rdf:type            owl:ObjectProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_lib> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_lib/> ;
         rdfs:label          "Association association-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
         suomi-meta:publicationStatus     "VALID" .
 
-<http://uri.suomi.fi/datamodel/ns/test_lib>
-        owl:versionIRI       <http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0> .
+<https://iri.suomi.fi/model/test_lib/>
+        owl:versionIRI       <https://iri.suomi.fi/model/test_lib/1.0.0/> .

--- a/src/test/resources/property_shapes_result.ttl
+++ b/src/test/resources/property_shapes_result.ttl
@@ -4,18 +4,18 @@
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test_profile/ps-1>
+<https://iri.suomi.fi/model/test_profile/ps-1>
         rdf:type            sh:PropertyShape , owl:DatatypeProperty ;
-        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/test_profile> ;
+        rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_profile/> ;
         rdfs:label          "Property shape attribute"@fi ;
         dcterms:identifier  "ps-1"^^xsd:NCName ;
         suomi-meta:publicationStatus     "VALID" .
 
-<http://uri.suomi.fi/datamodel/ns/TestPropertyShape>
+<https://iri.suomi.fi/model/TestPropertyShape>
         rdf:type             sh:PropertyShape , owl:DatatypeProperty ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
         dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
@@ -30,11 +30,11 @@
         sh:maxLength         100 ;
         sh:minCount          1 ;
         sh:minLength         2 ;
-        sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .
+        sh:path              <https://iri.suomi.fi/model/ytm/some-attribute> .
 
-<http://uri.suomi.fi/datamodel/ns/test/DeactivatedPropertyShape>
+<https://iri.suomi.fi/model/test/DeactivatedPropertyShape>
         rdf:type             sh:PropertyShape , owl:DatatypeProperty ;
-        rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
+        rdfs:isDefinedBy     <https://iri.suomi.fi/model/test> ;
         dcterms:identifier   "DeactivatedPropertyShape"^^xsd:NCName ;
         sh:deactivated       true ;
         rdfs:label           "deactivated property shape"@fi .

--- a/src/test/resources/test_datamodel_internal_reference.ttl
+++ b/src/test/resources/test_datamodel_internal_reference.ttl
@@ -1,15 +1,15 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix ext:     <https://www.example.com/ns/ext> .
-@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
+@prefix int:     <https://iri.suomi.fi/model/int> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/int>
+<https://iri.suomi.fi/model/int/>
         a                               owl:Ontology ;
         rdfs:label                      "internal label"@fi ;
         dcterms:contributor             <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
@@ -18,7 +18,7 @@
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/int" ;
+        dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/int" ;
         dcap:preferredXMLNamespacePrefix
                 "int" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -1,15 +1,15 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix ext:     <https://www.example.com/ns/ext> .
-@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
+@prefix int:     <https://iri.suomi.fi/model/int> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
+<https://iri.suomi.fi/model/test/>
         a                               owl:Ontology ;
         rdfs:comment                    "test desc"@fi ;
         rdfs:label                      "testlabel"@fi ;
@@ -18,10 +18,10 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
+        owl:imports                     <https://iri.suomi.fi/model/int> ;
         dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/terminology/test> , owl: ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
@@ -35,7 +35,7 @@
                                             dcterms:title       "link title"@fi ;
                                             foaf:homepage       "https://example.com"
                                         ] ;
-        owl:priorVersion                "http://uri.suomi.fi/datamodel/ns/test/1.0.0" .
+        owl:priorVersion                "https://iri.suomi.fi/model/test/1.0.0/" .
 
 <https://www.example.com/ns/ext>
         dcterms:type                        rdfs:Resource ;

--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -1,14 +1,14 @@
 @prefix dcap:    <http://purl.org/ws-mmi-dc/terms/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix iow:     <http://uri.suomi.fi/datamodel/ns/iow/> .
+@prefix iow:     <https://iri.suomi.fi/model/iow/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix ext:     <https://www.example.com/ns/ext> .
-@prefix int:     <http://uri.suomi.fi/datamodel/ns/int> .
-@prefix suomi-meta: <http://uri.suomi.fi/datamodel/ns/suomi-meta/> .
+@prefix int:     <https://iri.suomi.fi/model/int> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
-<http://uri.suomi.fi/datamodel/ns/test>
+<https://iri.suomi.fi/model/test/>
         a                               iow:ApplicationProfile , owl:Ontology  ;
         rdfs:comment                    "test desc"@fi ;
         rdfs:label                      "testlabel"@fi ;
@@ -17,10 +17,10 @@
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
         dcterms:language                "fi" ;
-        owl:imports                     <http://uri.suomi.fi/datamodel/ns/int> ;
-        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/codelist/test/testcodelist> , <http://uri.suomi.fi/datamodel/ns/test_lib/1.0.0> ;
+        owl:imports                     <https://iri.suomi.fi/model/int> ;
+        dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/codelist/test/testcodelist> , <https://iri.suomi.fi/model/test_lib/1.0.0> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/test" ;
+        dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         iow:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;


### PR DESCRIPTION
- Change http://uri.suomi.fi/datamodel/ns/ -> https://iri.suomi.fi/model/ 
- Graph names always ends with `/`
- Create utility class for handling data model URIs
- IRI resolving with different accept headers
- Migration for old data
