### PR TITLE
YTI-2487 use internal address in groupmanagement service

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/config/RestConfig.java
@@ -20,8 +20,10 @@ import java.time.Duration;
 @Configuration
 public class RestConfig {
     public static final String URI_SUOMI_FI = "http://uri.suomi.fi";
-    @Value("${defaultGroupManagementAPI}")
-    private String defaultGroupManagementUrl;
+
+    @Value("${groupmanagement.url}")
+    private String groupManagementURL;
+
     private final HttpHeaders defaultHttpHeaders = new HttpHeaders();
     RestConfig() {
         defaultHttpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
@@ -30,7 +32,7 @@ public class RestConfig {
     WebClient defaultWebClient() {
         return WebClient.builder()
                 .defaultHeaders(headers -> headers.addAll(defaultHttpHeaders))
-                .baseUrl(defaultGroupManagementUrl)
+                .baseUrl(groupManagementURL)
                 .clientConnector(new ReactorClientHttpConnector(
                         HttpClient.create(getConnectionProvider("groupManagement"))
                 )

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/GroupManagementService.java
@@ -50,7 +50,7 @@ public class GroupManagementService {
 
     public void initOrganizations() {
         var organizations = webClient.get().uri(builder -> builder
-                        .path("/organizations")
+                        .pathSegment("public-api", "organizations")
                         .queryParam("onlyValid", "true")
                         .build())
                 .retrieve()
@@ -71,7 +71,7 @@ public class GroupManagementService {
     public void updateOrganizations() {
         LOG.info("Updating organizations cache");
         var organizations = webClient.get().uri(builder -> builder
-                        .path("/organizations")
+                        .pathSegment("public-api", "organizations")
                         .queryParam("onlyValid", "true")
                         .build())
                 .ifModifiedSince(ZonedDateTime.now().minusMinutes(30))
@@ -95,7 +95,7 @@ public class GroupManagementService {
         LOG.info("Initializing user cache");
         var users = webClient.get()
                 .uri(builder -> builder
-                        .path("/users")
+                        .pathSegment("private-api", "users")
                         .build())
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<List<GroupManagementUserDTO>>() {
@@ -117,7 +117,7 @@ public class GroupManagementService {
         LOG.info("Updating user cache");
         var users = webClient.get()
                 .uri(builder -> builder
-                    .path("/users")
+                    .pathSegment("private-api", "users")
                 .build())
                 .ifModifiedSince(ZonedDateTime.now().minusMinutes(30))
                 .retrieve()
@@ -145,13 +145,13 @@ public class GroupManagementService {
             if (creator != null) {
                 dto.getCreator().setName(creator.getFirstName() + " " + creator.getLastName());
             } else {
-                dto.getCreator().setName("fake user");
+                dto.getCreator().setName("");
             }
 
             if (modifier != null) {
                 dto.getModifier().setName(modifier.getFirstName() + " " + modifier.getLastName());
             } else {
-                dto.getModifier().setName("fake user");
+                dto.getModifier().setName("");
             }
         };
     }
@@ -176,7 +176,7 @@ public class GroupManagementService {
 
             try {
                 return webClient.get().uri(builder -> builder
-                                .path("/users")
+                                .pathSegment("public-api", "users")
                                 .build())
                         .retrieve()
                         .bodyToMono(new ParameterizedTypeReference<List<GroupManagementUserDTO>>() {


### PR DESCRIPTION
- User internal address, because fetching users doesn't work via public api in production
- Fetch organizations from public api and users (excluding fakeable users) from private api 