### PR TITLE
YTI-3720: publicationStatus to use uri in codelists

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V13_StatusToUri.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V13_StatusToUri.java
@@ -1,0 +1,42 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.repository.ConceptRepository;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.repository.SchemesRepository;
+import fi.vm.yti.migration.MigrationTask;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V13_StatusToUri implements MigrationTask {
+
+    private final CoreRepository coreRepository;
+    private final SchemesRepository schemesRepository;
+    private final ConceptRepository conceptRepository;
+
+    public V13_StatusToUri(CoreRepository coreRepository, SchemesRepository schemesRepository, ConceptRepository conceptRepository) {
+        this.coreRepository = coreRepository;
+        this.schemesRepository = schemesRepository;
+        this.conceptRepository = conceptRepository;
+    }
+
+
+    @Override
+    public void migrate() {
+        var query = """
+                PREFIX suomi-meta: <https://iri.suomi.fi/model/suomi-meta/>
+                DELETE {
+                  graph ?g { ?s suomi-meta:publicationStatus ?status }
+                } INSERT{
+                  graph ?g {?s suomi-meta:publicationStatus ?uri}
+                }WHERE {
+                graph ?g {
+                 ?s suomi-meta:publicationStatus ?status
+                  BIND(iri("http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/" + str(?status)) as ?uri)
+                  }
+                }
+                """;
+        coreRepository.queryUpdate(query);
+        schemesRepository.queryUpdate(query);
+        conceptRepository.queryUpdate(query);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -113,7 +113,7 @@ public class ClassMapper {
                     .addProperty(RDF.type, SH.PropertyShape)
                     .addProperty(RDF.type, targetResource.getProperty(RDF.type).getObject())
                     .addProperty(RDFS.isDefinedBy, classResource.getProperty(RDFS.isDefinedBy).getObject())
-                    .addProperty(SuomiMeta.publicationStatus, Status.DRAFT.name());
+                    .addProperty(SuomiMeta.publicationStatus, ResourceFactory.createResource(MapperUtils.getStatusUri(Status.DRAFT)));
 
             MapperUtils.addCreationMetadata(propertyShapeResource, user);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CodeListMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CodeListMapper.java
@@ -1,7 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.v2.dto.CodeListDTO;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -29,7 +28,7 @@ public class CodeListMapper {
         var label = MapperUtils.localizedPropertyToMap(resource, RDFS.label);
         dto.setPrefLabel(label);
         dto.setId(graph);
-        dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        dto.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         return dto;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -39,6 +39,17 @@ public class MapperUtils {
         }
     }
 
+    public static String getStatusUri(Status status) {
+        return "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/" + status.name();
+    }
+
+    public static Status getStatusFromUri(String uri) {
+        if(uri == null || uri.isBlank()) {
+            throw new MappingError("Could not get status from uri");
+        }
+        return Status.valueOf(uri.substring(uri.lastIndexOf("/") + 1));
+    }
+
     public static String getModelIdFromNamespace(String namespace) {
         var nsWithoutVersion = namespace.replaceAll("/[0-9.]+(.*)$", "");
         return nsWithoutVersion.substring(nsWithoutVersion.lastIndexOf("/") + 1);
@@ -398,7 +409,7 @@ public class MapperUtils {
         dto.setCurie(uriDTO.getCurie());
 
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
-        dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        dto.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
 
         var subject = MapperUtils.propertyToString(resource, DCTerms.subject);
         if (subject != null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -164,7 +164,7 @@ public class ModelMapper {
         datamodelDTO.setUri(uri.getGraphURI());
         var modelResource = model.getResource(uri.getModelURI());
 
-        datamodelDTO.setStatus(Status.valueOf(MapperUtils.propertyToString(modelResource, SuomiMeta.publicationStatus)));
+        datamodelDTO.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(modelResource, SuomiMeta.publicationStatus)));
         datamodelDTO.setVersion(MapperUtils.propertyToString(modelResource, OWL.versionInfo));
         datamodelDTO.setVersionIri(MapperUtils.propertyToString(modelResource, OWL2.versionIRI));
         if(MapperUtils.isApplicationProfile(modelResource)){
@@ -256,7 +256,7 @@ public class ModelMapper {
             indexModel.setId(resource.getURI());
         }
         indexModel.setUri(resource.getURI());
-        indexModel.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        indexModel.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         indexModel.setVersion(MapperUtils.propertyToString(resource, OWL.versionInfo));
         indexModel.setVersionIri(versionIri);
         indexModel.setModified(resource.getProperty(DCTerms.modified).getString());
@@ -402,7 +402,7 @@ public class ModelMapper {
         var res = model.getResource(uri.getModelURI());
         res.addProperty(OWL2.versionIRI, ResourceFactory.createResource(uri.getGraphURI()));
         res.addProperty(OWL.versionInfo, uri.getVersion());
-        model.listSubjectsWithProperty(SuomiMeta.publicationStatus).forEach(subject -> MapperUtils.updateStringProperty(subject, SuomiMeta.publicationStatus, status.name()));
+        model.listSubjectsWithProperty(SuomiMeta.publicationStatus).forEach(subject -> MapperUtils.updateUriProperty(subject, SuomiMeta.publicationStatus, MapperUtils.getStatusUri(status)));
     }
 
     public void mapPriorVersion(Model model, String modelUri, String priorVersionUri) {
@@ -415,7 +415,7 @@ public class ModelMapper {
         var dto = new ModelVersionInfo();
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
         dto.setVersionIRI(MapperUtils.propertyToString(resource, OWL2.versionIRI));
-        dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        dto.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         dto.setVersion(MapperUtils.propertyToString(resource, OWL.versionInfo));
         return dto;
     }
@@ -453,7 +453,7 @@ public class ModelMapper {
     public void mapUpdateVersionedModel(Model model, String modelUri, VersionedModelDTO dto, YtiUser user) {
         var resource = model.getResource(modelUri);
 
-        var status = Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus));
+        var status = MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus));
         if(status.equals(Status.VALID) && !List.of(Status.VALID, Status.RETIRED, Status.SUPERSEDED).contains(dto.getStatus())){
             throw new MappingError("Cannot change status from VALID to " + dto.getStatus());
         }else if(status.equals(Status.SUGGESTED) && !List.of(Status.SUGGESTED, Status.VALID, Status.RETIRED, Status.SUPERSEDED).contains(dto.getStatus())) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -250,7 +250,7 @@ public class ResourceMapper {
         indexResource.setId(id.getResourceVersionURI());
         indexResource.setCurie(MapperUtils.uriToURIDTO(resourceUri, model).getCurie());
         indexResource.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
-        indexResource.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        indexResource.setStatus(MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         indexResource.setIsDefinedBy(MapperUtils.propertyToString(resource, RDFS.isDefinedBy));
         indexResource.setIdentifier(resource.getLocalName());
         indexResource.setNamespace(resource.getNameSpace());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/TerminologyMapper.java
@@ -45,7 +45,7 @@ public class TerminologyMapper {
         resource.addProperty(RDF.type, SKOS.Concept);
         resource.addProperty(SKOS.inScheme, ResourceFactory.createResource(terminologyURI));
         resource.addProperty(SuomiMeta.publicationStatus,
-                getProperty(nodeDTO.getProperties().getStatus(), Status.DRAFT.name()));
+                ResourceFactory.createResource(getProperty(nodeDTO.getProperties().getStatus(), MapperUtils.getStatusUri(Status.DRAFT))));
 
         for (var def : nodeDTO.getProperties().getDefinition()) {
             if (def.getValue() == null || def.getValue().isEmpty()) {
@@ -74,7 +74,7 @@ public class TerminologyMapper {
 
         var status = Status.DRAFT;
         try {
-            status = Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus));
+            status = MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus));
         } catch (Exception e) {
             // use default status in case of status is missing or invalid
         }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -58,7 +58,7 @@ class ClassMapperTest {
         assertEquals("fi", classResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(OWL.Class, classResource.getProperty(RDF.type).getResource());
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(classResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(classResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), classResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, classResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -239,7 +239,7 @@ class ClassMapperTest {
                 .filterDrop(p -> p.getObject().isAnon())
                 .next().getObject().toString());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubClass", resource.getProperty(RDFS.subClassOf).getObject().toString());
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
 
@@ -251,7 +251,7 @@ class ClassMapperTest {
         assertNull(resource.getProperty(RDFS.label));
         assertEquals("TestClass", resource.getProperty(DCTerms.identifier).getLiteral().getString());
         assertNull(resource.getProperty(DCTerms.subject));
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertNull(resource.getProperty(SKOS.editorialNote));
         assertEquals(0, resource.listProperties(RDFS.comment).toList().size());
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/CodeListMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/CodeListMapperTest.java
@@ -27,7 +27,7 @@ class CodeListMapperTest {
 
         assertEquals(graph, resource.getURI());
         assertEquals("Test@en", resource.getProperty(RDFS.label).getObject().toString());
-        assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.DRAFT, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ModelMapperTest.java
@@ -116,7 +116,7 @@ class ModelMapperTest {
         Resource modelResource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test" + ModelConstants.RESOURCE_SEPARATOR);
 
         assertEquals(2, modelResource.listProperties(RDFS.label).toList().size());
-        assertEquals(Status.DRAFT, Status.valueOf(modelResource.getProperty(SuomiMeta.publicationStatus).getString()));
+        assertEquals(Status.DRAFT, MapperUtils.getStatusFromUri(modelResource.getProperty(SuomiMeta.publicationStatus).getString()));
 
 
         var requires = MapperUtils.arrayPropertyToList(modelResource, DCTerms.requires);
@@ -369,7 +369,7 @@ class ModelMapperTest {
         var resource = m.getResource(graphUri);
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/", MapperUtils.propertyToString(resource, OWL2.versionIRI));
 
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("1.0.1", MapperUtils.propertyToString(resource, OWL.versionInfo));
 
         assertEquals(graphUri + "1.0.0/", MapperUtils.propertyToString(resource, OWL.priorVersion));
@@ -452,7 +452,7 @@ class ModelMapperTest {
 
         var resource = m.getResource(graphUri);
         assertEquals("new documentation", MapperUtils.localizedPropertyToMap(resource, SuomiMeta.documentation).get("fi"));
-        assertEquals(Status.RETIRED, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.RETIRED, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("new description", MapperUtils.localizedPropertyToMap(resource, RDFS.comment).get("fi"));
         assertEquals("new label", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
         assertEquals("new@localhost", MapperUtils.propertyToString(resource, SuomiMeta.contact));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -61,7 +61,7 @@ class NodeShapeMapperTest {
         assertEquals("fi", classResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
         assertEquals(SH.NodeShape, classResource.getProperty(RDF.type).getResource());
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(classResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(classResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), classResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, classResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -89,7 +89,7 @@ class NodeShapeMapperTest {
 
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test_lib/1.0.0/attribute-1",
                 propertyShapeAttribute.getProperty(SH.path).getObject().toString());
-        assertEquals(Status.DRAFT, Status.valueOf(MapperUtils.propertyToString(propertyShapeAttribute, SuomiMeta.publicationStatus)));
+        assertEquals(Status.DRAFT, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(propertyShapeAttribute, SuomiMeta.publicationStatus)));
         assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
@@ -49,7 +49,7 @@ class PropertyShapeMapperTest {
         var allowedValues = resource.listProperties(SH.in).mapWith((var s) -> s.getObject().toString()).toList();
 
         assertEquals("PropertyShape label", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test_lib/1.0.0/test_attribute", resource.getProperty(SH.path).getObject().toString());
         assertTrue(MapperUtils.hasType(resource, OWL.DatatypeProperty, SH.PropertyShape));
         assertTrue(allowedValues.containsAll(List.of("Value 1", "Value 2")));
@@ -86,7 +86,7 @@ class PropertyShapeMapperTest {
         var resource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/ps-1");
 
         assertEquals("PropertyShape label", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test_lib/1.0.0/test_attribute", resource.getProperty(SH.path).getObject().toString());
         assertTrue(MapperUtils.hasType(resource, OWL.ObjectProperty, SH.PropertyShape));
         assertEquals(10, MapperUtils.getLiteral(resource, SH.maxCount, Integer.class));

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -65,7 +65,7 @@ class ResourceMapperTest {
         assertEquals("test label", resourceResource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -119,7 +119,7 @@ class ResourceMapperTest {
         assertEquals("test label", resourceResource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -164,7 +164,7 @@ class ResourceMapperTest {
         assertEquals("test label", resourceResource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -213,7 +213,7 @@ class ResourceMapperTest {
         assertEquals("test label", resourceResource.getProperty(RDFS.label).getLiteral().getString());
         assertEquals("fi", resourceResource.getProperty(RDFS.label).getLiteral().getLanguage());
 
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resourceResource, SuomiMeta.publicationStatus)));
         assertEquals(uri.getModelURI(), resourceResource.getProperty(RDFS.isDefinedBy).getObject().toString());
 
         assertEquals(XSDDatatype.XSDNCName, resourceResource.getProperty(DCTerms.identifier).getLiteral().getDatatype());
@@ -526,7 +526,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));
@@ -581,7 +581,7 @@ class ResourceMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/test/test1", resource.getProperty(DCTerms.subject).getObject().toString());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqResource", resource.getProperty(OWL.equivalentProperty).getObject().toString());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubResource", resource.getProperty(RDFS.subPropertyOf).getObject().toString());
-        assertEquals(Status.VALID, Status.valueOf(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
+        assertEquals(Status.VALID, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(resource, SuomiMeta.publicationStatus)));
         assertEquals("comment visible for admin", resource.getProperty(SKOS.editorialNote).getObject().toString());
         assertEquals(2, resource.listProperties(RDFS.comment).toList().size());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/DomainClass", MapperUtils.propertyToString(resource, RDFS.domain));

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -350,7 +350,7 @@ class ResourceServiceTest {
         var uri = DataModelURI.createResourceURI("test", "resource-1");
         model.createResource(uri.getResourceURI())
                 .addProperty(DCTerms.identifier, "resource-1")
-                .addProperty(SuomiMeta.publicationStatus, Status.DRAFT.name())
+                .addProperty(SuomiMeta.publicationStatus, ResourceFactory.createResource(MapperUtils.getStatusUri(Status.DRAFT)))
                 .addProperty(DCTerms.created, "created")
                 .addProperty(DCTerms.modified, "modified");
         model.createResource(uri.getModelURI() + "resource-2")

--- a/src/test/resources/codelist.ttl
+++ b/src/test/resources/codelist.ttl
@@ -6,4 +6,4 @@
 <http://uri.suomi.fi/codelist/test/testcodelist>
     a               suomi-meta:CodeScheme ;
     rdfs:label      "testkoodisto"@fi , "Test codelist"@en  ;
-    suomi-meta:publicationStatus "DRAFT" .
+    suomi-meta:publicationStatus <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .

--- a/src/test/resources/migration/old-identifiers-version.ttl
+++ b/src/test/resources/migration/old-identifiers-version.ttl
@@ -28,7 +28,7 @@
     suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
     owl:versionInfo                 "1.0.0" ;
     owl:versionIRI                  test:1.0.0 ;
-    suomi-meta:publicationStatus    "VALID" .
+    suomi-meta:publicationStatus    <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 test:TestClass  rdf:type     sh:NodeShape ;
         rdfs:isDefinedBy     <http://uri.suomi.fi/datamodel/ns/test> ;
@@ -37,7 +37,7 @@ test:TestClass  rdf:type     sh:NodeShape ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        suomi-meta:publicationStatus      "VALID" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         suomi-meta:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
@@ -53,7 +53,7 @@ test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:defaultValue      "foo" ;
         suomi-meta:codeList         <http://uri.suomi.fi/codelist/Test> ;
         sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .

--- a/src/test/resources/migration/old-identifiers.ttl
+++ b/src/test/resources/migration/old-identifiers.ttl
@@ -27,7 +27,7 @@
     "test" ;
     suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
     owl:priorVersion                test:1.0.0 ;
-    suomi-meta:publicationStatus    "VALID" .
+    suomi-meta:publicationStatus    <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://www.example.com/ns/ext>
     dcterms:type                        rdfs:Resource ;
@@ -41,7 +41,7 @@ test:TestClass  rdf:type     sh:NodeShape ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        suomi-meta:publicationStatus      "VALID" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         suomi-meta:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
@@ -57,7 +57,7 @@ test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:defaultValue      "foo" ;
         suomi-meta:codeList         <http://uri.suomi.fi/codelist/Test> ;
         sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> .
@@ -70,7 +70,7 @@ test:TestAssociationRestriction  rdf:type  sh:PropertyShape ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:maxCount          10 ;
         sh:minCount          1 ;
         sh:path              <http://uri.suomi.fi/datamodel/ns/ytm/some-attribute> ;

--- a/src/test/resources/models/test_datamodel_library_version.ttl
+++ b/src/test/resources/models/test_datamodel_library_version.ttl
@@ -24,7 +24,7 @@
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus    "VALID" ;
+        suomi-meta:publicationStatus    <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         owl:versionInfo                 "1.0.1" ;
         suomi-meta:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;

--- a/src/test/resources/models/test_datamodel_library_visualization.ttl
+++ b/src/test/resources/models/test_datamodel_library_visualization.ttl
@@ -81,7 +81,7 @@ visu:natural-person  rdf:type         owl:Class ;
         dcap:preferredXMLNamespacePrefix
                 "visu" ;
         owl:imports                   <https://www.example.com/ns/external/> ;
-        suomi-meta:publicationStatus  "DRAFT" .
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
 visu:is-address  rdf:type             owl:ObjectProperty ;
         rdfs:isDefinedBy              <https://iri.suomi.fi/model/visu/> ;

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -25,7 +25,7 @@ dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-suomi-meta:publicationStatus    "VALID" ;
+suomi-meta:publicationStatus    <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
 owl:versionInfo                 "1.0.1" ;
 owl:versionIRI                  <https://iri.suomi.fi/model/test/1.0.1/> .
 
@@ -43,7 +43,7 @@ test:TestClass  rdf:type     owl:Class ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
         owl:equivalentClass  <https://iri.suomi.fi/model/test/EqClass> ;
-        suomi-meta:publicationStatus      "VALID" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test note fi"@fi, "test note en"@en ;
         suomi-meta:creator           "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
@@ -67,7 +67,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
         owl:equivalentProperty  <https://iri.suomi.fi/model/test/EqResource> ;
-        suomi-meta:publicationStatus         "VALID" ;
+        suomi-meta:publicationStatus         <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         suomi-meta:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
@@ -84,7 +84,7 @@ test:TestAssociation  rdf:type     owl:ObjectProperty, owl:FunctionalProperty ;
         dcterms:modified        "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject         <http://uri.suomi.fi/terminology/test/test1> ;
         owl:equivalentProperty  <https://iri.suomi.fi/model/test/EqResource> ;
-        suomi-meta:publicationStatus         "VALID" ;
+        suomi-meta:publicationStatus         <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote      "comment visible for admin" ;
         rdfs:comment            "test note fi"@fi, "test note en"@en ;
         suomi-meta:creator             "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;

--- a/src/test/resources/models/test_datamodel_prior_versions.ttl
+++ b/src/test/resources/models/test_datamodel_prior_versions.ttl
@@ -9,13 +9,13 @@
 @prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 
 <https://iri.suomi.fi/model/test/1.0.0/>
-        suomi-meta:publicationStatus "VALID" ;
+        suomi-meta:publicationStatus <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         owl:versionInfo       "1.0.0" ;
         rdfs:label            "Test"@fi ;
         owl:versionIRI        <https://iri.suomi.fi/model/test/1.0.0/> .
 
 <https://iri.suomi.fi/model/test/2.0.0/>
-        suomi-meta:publicationStatus "VALID" ;
+        suomi-meta:publicationStatus <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         owl:versionInfo       "2.0.0";
         rdfs:label            "Test"@fi ;
         owl:versionIRI        <https://iri.suomi.fi/model/test/2.0.0/> .

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -27,7 +27,7 @@ dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-suomi-meta:publicationStatus                 "VALID" .
+suomi-meta:publicationStatus                 <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://www.example.com/ns/ext>
 dcterms:type                        rdfs:Resource ;
@@ -41,7 +41,7 @@ test:TestClass  rdf:type     sh:NodeShape ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        suomi-meta:publicationStatus      "VALID" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         skos:editorialNote   "comment visible for admin" ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         suomi-meta:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
@@ -57,7 +57,7 @@ test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:defaultValue      "foo" ;
         sh:hasValue          "hasValue" ;
         sh:datatype          "xsd:integer" ;
@@ -81,7 +81,7 @@ test:TestAssociationRestriction  rdf:type  sh:PropertyShape ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:maxCount          10 ;
         sh:minCount          1 ;
         sh:path              <https://iri.suomi.fi/model/ytm/some-attribute> ;

--- a/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
+++ b/src/test/resources/models/test_datamodel_with_minimal_resources.ttl
@@ -25,7 +25,7 @@
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus                 "VALID" .
+        suomi-meta:publicationStatus                 <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://www.example.com/ns/ext>
         dcterms:type                        rdfs:Resource ;
@@ -38,7 +38,7 @@ test:TestClass  rdf:type     owl:Class ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestClass"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus      "VALID" .
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
@@ -46,7 +46,7 @@ test:TestAttribute  rdf:type     owl:DatatypeProperty ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAttribute"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus      "VALID" .
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 test:TestAssociation  rdf:type     owl:ObjectProperty ;
         rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
@@ -54,4 +54,4 @@ test:TestAssociation  rdf:type     owl:ObjectProperty ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:identifier   "TestAssociation"^^xsd:NCName ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus      "VALID" .
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .

--- a/src/test/resources/properties_result.ttl
+++ b/src/test/resources/properties_result.ttl
@@ -13,14 +13,14 @@
         rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_lib/> ;
         rdfs:label          "Attribute attribute-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
-        suomi-meta:publicationStatus     "VALID" .
+        suomi-meta:publicationStatus     <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://iri.suomi.fi/model/test_lib/association-1>
         rdf:type            owl:ObjectProperty ;
         rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_lib/> ;
         rdfs:label          "Association association-1"@fi ;
         dcterms:identifier  "attribute-1"^^xsd:NCName ;
-        suomi-meta:publicationStatus     "VALID" .
+        suomi-meta:publicationStatus     <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://iri.suomi.fi/model/test_lib/>
         owl:versionIRI       <https://iri.suomi.fi/model/test_lib/1.0.0/> .

--- a/src/test/resources/property_shapes_result.ttl
+++ b/src/test/resources/property_shapes_result.ttl
@@ -11,7 +11,7 @@
         rdfs:isDefinedBy    <https://iri.suomi.fi/model/test_profile/> ;
         rdfs:label          "Property shape attribute"@fi ;
         dcterms:identifier  "ps-1"^^xsd:NCName ;
-        suomi-meta:publicationStatus     "VALID" .
+        suomi-meta:publicationStatus     <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> .
 
 <https://iri.suomi.fi/model/TestPropertyShape>
         rdf:type             sh:PropertyShape , owl:DatatypeProperty ;
@@ -21,7 +21,7 @@
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
-        suomi-meta:publicationStatus      "DRAFT" ;
+        suomi-meta:publicationStatus      <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         sh:defaultValue      "foo" ;
         sh:hasValue          "hasValue" ;
         sh:datatype          "xsd:integer" ;

--- a/src/test/resources/terminology_with_concept.ttl
+++ b/src/test/resources/terminology_with_concept.ttl
@@ -6,7 +6,7 @@
 
 <http://uri.suomi.fi/terminology/dd0e10ed/concept-1>
         rdfs:label       "Testisanasto"@fi , "Test terminology"@en ;
-        suomi-meta:publicationStatus  "DRAFT" ;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> ;
         skos:inScheme    <http://uri.suomi.fi/terminology/dd0e10ed/> ;
         skos:prefLabel   "käsite"@fi , "concept"@en ;
         skos:definition  "määritelmä"@fi , "definition"@en .

--- a/src/test/resources/test_datamodel_internal_reference.ttl
+++ b/src/test/resources/test_datamodel_internal_reference.ttl
@@ -21,6 +21,6 @@
         dcap:preferredXMLNamespacePrefix
                 "int" ;
         suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus                 "VALID" ;
+        suomi-meta:publicationStatus                 <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         suomi-meta:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" .

--- a/src/test/resources/test_datamodel_library.ttl
+++ b/src/test/resources/test_datamodel_library.ttl
@@ -24,7 +24,7 @@
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus                 "VALID" ;
+        suomi-meta:publicationStatus                 <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         suomi-meta:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:contact                     "test@localhost"                       ;

--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -23,7 +23,7 @@
         dcap:preferredXMLNamespacePrefix
                 "test" ;
         suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-        suomi-meta:publicationStatus                 "VALID" ;
+        suomi-meta:publicationStatus                 <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID> ;
         suomi-meta:creator                     "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier                    "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:contact                     "test@localhost"                       .


### PR DESCRIPTION
Changelog:
- Use uri instead of string for publication status