### PR TITLE
search models by resources

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelSearchResultDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelSearchResultDTO.java
@@ -1,0 +1,27 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
+import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
+
+import java.util.List;
+
+public class ModelSearchResultDTO extends IndexModel {
+
+    public ModelSearchResultDTO() {
+        this.setMatchingResources(new java.util.ArrayList<>());
+    }
+
+    private List<IndexResource> matchingResources;
+
+    public List<IndexResource> getMatchingResources() {
+        return matchingResources;
+    }
+
+    public void setMatchingResources(List<IndexResource> matchingResources) {
+        this.matchingResources = matchingResources;
+    }
+
+    public void addMatchingResource(IndexResource resource) {
+        this.matchingResources.add(resource);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -1,9 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.endpoint;
 
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.OrganizationDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ServiceCategoryDTO;
-import fi.vm.yti.datamodel.api.v2.dto.UriDTO;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountSearchResponse;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
@@ -83,7 +80,7 @@ public class FrontendController {
     @Operation(summary = "Search models")
     @ApiResponse(responseCode = "200", description = "List of data model objects")
     @GetMapping(value = "/search-models", produces = APPLICATION_JSON_VALUE)
-    public SearchResponseDTO<IndexModel> getModels(@Parameter(description = "Data model search parameters") ModelSearchRequest request) {
+    public SearchResponseDTO<ModelSearchResultDTO> getModels(@Parameter(description = "Data model search parameters") ModelSearchRequest request) {
         return searchIndexService.searchModels(request, userProvider.getUser());
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ModelSearchRequest.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/ModelSearchRequest.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.opensearch.dto;
 
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
 
@@ -18,6 +19,8 @@ public class ModelSearchRequest extends BaseSearchRequest {
     private Set<String> groups;
 
     private boolean searchResources;
+
+    private Set<String> additionalModelIds;
 
     public String getLanguage() {
         return language;
@@ -65,5 +68,13 @@ public class ModelSearchRequest extends BaseSearchRequest {
 
     public void setSearchResources(boolean searchResources) {
         this.searchResources = searchResources;
+    }
+
+    public Collection<String> getAdditionalModelIds() {
+        return additionalModelIds;
+    }
+
+    public void setAdditionalModelIds(Set<String> additionalModelIds) {
+        this.additionalModelIds = additionalModelIds;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/SearchResponseDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/dto/SearchResponseDTO.java
@@ -3,6 +3,7 @@ package fi.vm.yti.datamodel.api.v2.opensearch.dto;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexBase;
 
 import java.util.List;
+import java.util.Map;
 
 public class SearchResponseDTO<T extends IndexBase> {
     private long totalHitCount;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexBase.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/IndexBase.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.v2.opensearch.index;
 
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 
+import java.util.List;
 import java.util.Map;
 
 public abstract class IndexBase {
@@ -12,6 +13,7 @@ public abstract class IndexBase {
     private Status status;
     private String modified;
     private String created;
+    private Map<String, List<String>> highlights;
 
     public String getId() {
         return id;
@@ -69,4 +71,11 @@ public abstract class IndexBase {
         this.created = created;
     }
 
+    public Map<String, List<String>> getHighlights() {
+        return highlights;
+    }
+
+    public void setHighlights(Map<String, List<String>> highlights) {
+        this.highlights = highlights;
+    }
 }

--- a/src/test/resources/es/modelrequest.json
+++ b/src/test/resources/es/modelrequest.json
@@ -1,24 +1,13 @@
 {
-  "size": 100,
   "from": 1,
+  "highlight": {
+    "fields": {
+      "label.*": {}
+    }
+  },
   "query": {
     "bool": {
       "must": [
-        {
-          "term": {
-            "language":  {
-              "value": "en"
-            }
-          }
-        },
-        {
-          "terms": {
-            "isPartOf": [
-              "P11",
-              "P1"
-            ]
-          }
-        },
         {
           "terms": {
             "contributor": [
@@ -26,25 +15,6 @@
             ]
           }
         },
-        {
-          "terms": {
-            "type": ["PROFILE"]
-            }
-        },
-        {
-          "terms": {
-            "status": ["SUGGESTED", "VALID"]
-          }
-        },
-        {
-          "query_string": {
-            "query": "*test query*",
-            "fields": ["label.*"],
-            "fuzziness": "2"
-          }
-        }
-      ],
-      "should": [
         {
           "bool": {
             "must_not": [
@@ -60,12 +30,54 @@
         },
         {
           "terms": {
-            "contributor": ["7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"]
+            "type": [
+              "PROFILE"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "isPartOf": [
+              "P1",
+              "P11"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "contributor": [
+              "7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"
+            ]
+          }
+        },
+        {
+          "term": {
+            "language": {
+              "value": "en"
+            }
+          }
+        },
+        {
+          "terms": {
+            "status": [
+              "VALID",
+              "SUGGESTED"
+            ]
+          }
+        },
+        {
+          "query_string": {
+            "fields": [
+              "label.*"
+            ],
+            "fuzziness": "2",
+            "query": "*test query*"
           }
         }
       ]
     }
   },
+  "size": 100,
   "sort": [
     {
       "label.en.keyword": {

--- a/src/test/resources/es/models_count_request.json
+++ b/src/test/resources/es/models_count_request.json
@@ -1,18 +1,4 @@
 {
-  "size": 0,
-  "query": {
-    "bool": {
-      "minimum_should_match": "1",
-      "must": [],
-      "should": [
-        {
-          "bool": {
-            "must_not": [{ "term": { "status": { "value": "DRAFT" } } }]
-          }
-        }
-      ]
-    }
-  },
   "aggregations": {
     "types": {
       "terms": {
@@ -34,5 +20,25 @@
         "field": "isPartOf"
       }
     }
-  }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "status": {
+                    "value": "DRAFT"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 0
 }


### PR DESCRIPTION
Search results will now also find models if their resources match the keyword. This is done by performing an additional search, and combining the search results.

* search-models will return `ModelSearchResultDTO`, which adds matching resources to the search result in addition to the model data
* matching keywords will be highlighted in the search result
* `IndexBase` base class now contains `highlights` property
* opensearch queries have been rearranged (`must`/`should`), hopefully for more correct behaviour

Cut down example of the result:
`/v2/frontend/search-models?pageSize=50&searchResources=true&sortLang=fi&status=VALID&query=test`
```json
{
  "responseObjects": [
    {
      "id": "https://iri.suomi.fi/model/test/1.0.0/",
      "uri": "https://iri.suomi.fi/model/test/1.0.0/",
      "label": {
        "fi": "Test model"
      },
      "status": "VALID",
      "highlights": {
        "label.fi.keyword": [
          "<em>Test model</em>"
        ],
        "label.fi": [
          "<em>Test model</em>"
        ]
      },
      "matchingResources": [
        {
          "id": "https://iri.suomi.fi/model/test/1.0.0/testattribute",
          "uri": "https://iri.suomi.fi/model/test/testattribute",
          "label": {
            "fi": "Test attribute"
          },
          "status": "DRAFT",
          "highlights": {
            "label.fi.keyword": [
              "<b>Test attribute</b>"
            ],
            "label.fi": [
              "<b>Test attribute</b>"
            ]
          }
        }
      ]
    }
  ]
}

```
