### PR TITLE
YTI-3752 fixes for handling external resources

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -165,7 +165,7 @@ public class VisualizationMapper {
             var attribute = new VisualizationPropertyShapeAttributeDTO();
             attribute.setIdentifier(getReferenceIdentifier(versionedResourceURI, namespaces));
             attribute.setLabel(label);
-            attribute.setUri(resource.getURI());
+            attribute.setUri(versionedResourceURI);
             var dataType = MapperUtils.propertyToString(resource, SH.datatype);
             if (dataType != null) {
                 var uriDTO = MapperUtils.uriToURIDTO(dataType, model);
@@ -179,7 +179,7 @@ public class VisualizationMapper {
             var association = new VisualizationPropertyShapeAssociationDTO();
             association.setIdentifier(getReferenceIdentifier(versionedResourceURI, namespaces));
             association.setLabel(label);
-            association.setUri(resource.getURI());
+            association.setUri(versionedResourceURI);
             association.setMaxCount(MapperUtils.getLiteral(resource, SH.maxCount, Integer.class));
             association.setMinCount(MapperUtils.getLiteral(resource, SH.minCount, Integer.class));
             association.setReferenceTarget(getPropertyShapeAssociationTarget(model, resource, namespaces));

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ClassService.java
@@ -412,9 +412,11 @@ public class ClassService extends BaseResourceService {
         Resource restrictionResource;
         if (model.contains(ResourceFactory.createResource(uri), null)) {
             restrictionResource = model.getResource(uri);
-        } else {
+        } else if (uri.startsWith(ModelConstants.SUOMI_FI_NAMESPACE)) {
             var includedNamespaces = DataModelUtils.getInternalReferenceModels(graphURI, modelResource);
             restrictionResource = getResourceWithVersion(uri, includedNamespaces);
+        } else {
+            restrictionResource = findResources(Set.of(uri), Set.of()).getResource(uri);
         }
 
         if (!restrictionResource.listProperties().hasNext()) {


### PR DESCRIPTION
- When mapping application profile resources, use resource uri with version
- When mapping library resources, check if external resource is part of Interoperability platform