### PR TITLE
YTI-3812 Application profile migration

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMapper.java
@@ -4,13 +4,14 @@ import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.dto.visualization.PositionDataDTO;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.properties.DCAP;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.util.*;
@@ -20,13 +21,22 @@ import static fi.vm.yti.datamodel.api.migration.V1DataMigrationService.OLD_NAMES
 
 public class V1DataMapper {
 
-    private V1DataMapper() {}
+    private V1DataMapper() {
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(V1DataMapper.class);
 
     private static final Property DOCUMENTATION =
             ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#documentation");
 
     private static final Property POINT_XY =
             ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#pointXY");
+
+    private static final Property CODE_LIST =
+            ResourceFactory.createProperty("http://purl.org/dc/dcam/memberOf");
+
+    private static final Property LOCAL_NAME =
+            ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#localName");
 
     public static DataModelDTO getLibraryMetadata(String modelURI, Model oldData, Model serviceCategories, String defaultOrganization) {
         var modelResource = oldData.getResource(modelURI);
@@ -42,8 +52,8 @@ public class V1DataMapper {
 
         if (defaultOrganization == null || defaultOrganization.isBlank()) {
             var org = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.contributor).stream()
-                .map(o -> UUID.fromString(o.replace("urn:uuid:", "")))
-                .collect(Collectors.toSet());
+                    .map(o -> UUID.fromString(o.replace("urn:uuid:", "")))
+                    .collect(Collectors.toSet());
             dto.setOrganizations(org);
         } else {
             dto.setOrganizations(Set.of(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")));
@@ -104,8 +114,6 @@ public class V1DataMapper {
     public static ClassDTO mapLibraryClass(Resource classResource) {
         var dto = new ClassDTO();
         mapCommon(dto, classResource);
-        dto.setLabel(MapperUtils.localizedPropertyToMap(classResource, SH.name));
-        dto.setNote(MapperUtils.localizedPropertyToMap(classResource, SH.description));
         var subClasses = MapperUtils.arrayPropertyToSet(classResource, RDFS.subClassOf).stream()
                 .map(V1DataMapper::fixNamespace)
                 .collect(Collectors.toSet());
@@ -116,20 +124,104 @@ public class V1DataMapper {
     public static ResourceDTO mapLibraryResource(Resource resource) {
         var dto = new ResourceDTO();
         mapCommon(dto, resource);
-        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
-        dto.setNote(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
         var range = fixNamespace(MapperUtils.propertyToString(resource, RDFS.range));
         dto.setRange(range);
         return dto;
     }
 
-    public static List<Resource> findResourcesByType(Model oldData, Resource type) {
-            return oldData.listSubjectsWithProperty(RDF.type, type)
-                    .mapWith(s -> oldData.getResource(s.getURI()))
-                    .toList();
+    public static NodeShapeDTO mapProfileClass(Resource nodeShapeResource) {
+        var dto = new NodeShapeDTO();
+        mapCommon(dto, nodeShapeResource);
+        dto.setProperties(new HashSet<>());
+        dto.setTargetClass(fixNamespace(MapperUtils.propertyToString(nodeShapeResource, SH.targetClass)));
+        return dto;
     }
 
-    public static List<PositionDataDTO> mapPositions(String modelURI, Model oldVisualization) {
+    public static PropertyShapeDTO mapProfileResource(Model oldData, Resource propertyShape) {
+        PropertyShapeDTO dto;
+
+        if (!propertyShape.hasProperty(SH.path)) {
+            LOG.warn("MIGRATION ERROR: No path found for property shape {}", propertyShape.getURI());
+        }
+
+        var type = propertyShape.getProperty(DCTerms.type).getObject();
+
+        if (OWL.DatatypeProperty.equals(type)) {
+            dto = mapProfileAttribute(propertyShape);
+        } else if (OWL.ObjectProperty.equals(type)) {
+            dto = mapProfileAssociation(oldData, propertyShape);
+        } else {
+            LOG.warn("MIGRATION ERROR: Invalid type for property shape {}", propertyShape.getURI());
+            return null;
+        }
+
+        mapCommon(dto, propertyShape);
+        dto.setPath(fixNamespace(MapperUtils.propertyToString(propertyShape, SH.path)));
+        dto.setMaxCount(MapperUtils.getLiteral(propertyShape, SH.maxCount, Integer.class));
+        dto.setMinCount(MapperUtils.getLiteral(propertyShape, SH.minCount, Integer.class));
+
+        return dto;
+    }
+
+    private static AttributeRestriction mapProfileAttribute(Resource resource) {
+        var attr = new AttributeRestriction();
+        attr.setDataType(MapperUtils.propertyToString(resource, SH.datatype));
+        attr.setCodeLists(MapperUtils.arrayPropertyToList(resource, CODE_LIST));
+        attr.setDefaultValue(MapperUtils.propertyToString(resource, SH.defaultValue));
+        attr.setHasValue(MapperUtils.propertyToString(resource, SH.hasValue));
+        attr.setLanguageIn(MapperUtils.arrayPropertyToSet(resource, SH.languageIn));
+        attr.setMaxInclusive(MapperUtils.getLiteral(resource, SH.maxInclusive, Integer.class));
+        attr.setMinInclusive(MapperUtils.getLiteral(resource, SH.minInclusive, Integer.class));
+        attr.setMaxExclusive(MapperUtils.getLiteral(resource, SH.maxExclusive, Integer.class));
+        attr.setMinExclusive(MapperUtils.getLiteral(resource, SH.minExclusive, Integer.class));
+        attr.setPattern(MapperUtils.propertyToString(resource, SH.pattern));
+        attr.setMaxLength(MapperUtils.getLiteral(resource, SH.maxLength, Integer.class));
+        attr.setMinLength(MapperUtils.getLiteral(resource, SH.minLength, Integer.class));
+
+        if (resource.hasProperty(SH.in)) {
+            attr.setAllowedValues(resource.getProperty(SH.in)
+                    .getList()
+                    .asJavaList().stream()
+                    .map(RDFNode::toString)
+                    .toList());
+        }
+
+        return attr;
+    }
+
+    private static AssociationRestriction mapProfileAssociation(Model oldData, Resource resource) {
+        var assoc = new AssociationRestriction();
+        var node = MapperUtils.propertyToString(resource, SH.node);
+
+        if (node != null) {
+            var nodeResource = oldData.getResource(node);
+            if (nodeResource.hasProperty(SH.targetClass)) {
+                assoc.setClassType(fixNamespace(MapperUtils.propertyToString(nodeResource, SH.targetClass)));
+            } else {
+                assoc.setClassType(fixNamespace(node));
+            }
+        }
+        return assoc;
+    }
+
+    public static String getUriForOldResource(String prefix, Resource resource) {
+        String id;
+        if (resource.hasProperty(LOCAL_NAME)) {
+            id = MapperUtils.propertyToString(resource, LOCAL_NAME);
+        } else {
+            id = resource.getURI()
+                    .replace(ModelConstants.URN_UUID, "uuid-");
+        }
+        return DataModelURI.createResourceURI(prefix, id).getResourceURI();
+    }
+
+    public static List<Resource> findResourcesByType(Model oldData, Resource type) {
+        return oldData.listSubjectsWithProperty(RDF.type, type)
+                .mapWith(s -> oldData.getResource(s.getURI()))
+                .toList();
+    }
+
+    public static List<PositionDataDTO> mapPositions(String modelURI, Model oldVisualization, PrefixMapping prefixMapping) {
         var positions = new ArrayList<PositionDataDTO>();
 
         oldVisualization.listSubjectsWithProperty(RDF.type, RDFS.Class).forEach(subj -> {
@@ -139,7 +231,7 @@ public class V1DataMapper {
             if (uri.toString().startsWith(modelURI)) {
                 dto.setIdentifier(uri.getLocalName());
             } else {
-                var prefix = MapperUtils.getModelIdFromNamespace(uri.getNameSpace().replace("#", ""));
+                var prefix = prefixMapping.getNsURIPrefix(uri.getNameSpace());
                 dto.setIdentifier(prefix + ":" + uri.getLocalName());
             }
             var coordinates = MapperUtils.propertyToString(subj, POINT_XY);
@@ -157,9 +249,30 @@ public class V1DataMapper {
     }
 
     private static void mapCommon(BaseDTO dto, Resource resource) {
-        dto.setIdentifier(resource.getLocalName());
+        if (resource.hasProperty(LOCAL_NAME)) {
+            dto.setIdentifier(MapperUtils.propertyToString(resource, LOCAL_NAME));
+        } else if (dto instanceof PropertyShapeDTO && !resource.hasProperty(LOCAL_NAME)) {
+            // Property shapes without localName are in uuid format.
+            // Add prefix 'uuid', because identifier cannot start with a number
+            dto.setIdentifier(resource.getURI().replace(ModelConstants.URN_UUID, "uuid-"));
+        } else {
+            dto.setIdentifier(resource.getLocalName());
+        }
         dto.setEditorialNote(MapperUtils.propertyToString(resource, SKOS.editorialNote));
         dto.setSubject(MapperUtils.propertyToString(resource, DCTerms.subject));
+
+        if (resource.hasProperty(SH.name)) {
+            dto.setLabel(MapperUtils.localizedPropertyToMap(resource, SH.name));
+
+        } else if (resource.hasProperty(RDFS.label)) {
+            dto.setLabel(MapperUtils.localizedPropertyToMap(resource, RDFS.label));
+        }
+
+        if (resource.hasProperty(SH.description)) {
+            dto.setNote(MapperUtils.localizedPropertyToMap(resource, SH.description));
+        } else if (resource.hasProperty(RDFS.comment)) {
+            dto.setNote(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
+        }
     }
 
     private static String fixNamespace(String uri) {

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
@@ -503,44 +503,16 @@ public class V1DataMigrationService {
 
     public void createVersions(String prefix) {
         try {
-            dataModelService.createRelease(prefix, "1.0.0", Status.VALID);
+            var version = "1.0.0";
+            dataModelService.createRelease(prefix, version, Status.VALID);
             var uri = DataModelURI.createModelURI(prefix).getGraphURI();
-            updateReferences(uri);
+            dataModelService.updateDraftReferences(uri, version);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
         }
     }
 
-    /**
-     * Updates references from draft to published version.
-     * E.g. https://iri.suomi.fi/model/foo/resource -> https://iri.suomi.fi/model/foo/1.0.0/resource
-     * @param graph published graph uri
-     */
-    private void updateReferences(String graph) {
-        var query = String.format("""
-                delete {
-                  graph ?g {
-                    ?s ?p ?o
-                  }
-                }
-                insert {
-                  graph ?g {
-                    ?s ?p ?uri
-                  }
-                }
-                where {
-                  graph ?g {
-                    ?s ?p ?o
-                    filter regex(str(?o), "%s([a-zA-Z](.)*)?$")
-                    bind(iri(
-                        replace(str(?o), "%s", "%s1.0.0/")
-                    ) as ?uri)
-                  }
-                  filter(!strstarts(str(?g), "%s"))
-                }""", graph, graph, graph, graph);
 
-        coreRepository.queryUpdate(query);
-    }
 
     private void addModelSpecificInfo(String prefix, DataModelDTO dataModel) {
         if (prefix.equals("fi-dcatap")) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -50,11 +50,6 @@ public class MapperUtils {
         return Status.valueOf(uri.substring(uri.lastIndexOf("/") + 1));
     }
 
-    public static String getModelIdFromNamespace(String namespace) {
-        var nsWithoutVersion = namespace.replaceAll("/[0-9.]+(.*)$", "");
-        return nsWithoutVersion.substring(nsWithoutVersion.lastIndexOf("/") + 1);
-    }
-
     public static ModelType getModelTypeFromResource(Resource resource){
         if(isApplicationProfile(resource)) {
             return ModelType.PROFILE;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -17,6 +17,7 @@ import fi.vm.yti.datamodel.api.v2.utils.SemVer;
 import fi.vm.yti.datamodel.api.v2.validator.ValidationConstants;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
+import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Model;
@@ -240,6 +241,8 @@ public class DataModelService {
         coreRepository.put(modelVersionURI.getDraftGraphURI(), newDraft);
         coreRepository.put(modelVersionURI.getGraphURI(), model);
 
+        updateDraftReferences(modelUri, version);
+
         var newVersion = mapper.mapToIndexModel(modelUri, model);
         openSearchIndexer.createModelToIndex(newVersion);
         var list = new ArrayList<IndexResource>();
@@ -300,6 +303,28 @@ public class DataModelService {
         var indexModel = mapper.mapToIndexModel(uri.getModelURI(), model);
         openSearchIndexer.updateModelToIndex(indexModel);
         auditService.log(AuditService.ActionType.UPDATE, uri.getGraphURI(), userProvider.getUser());
+    }
+
+    /**
+     * Updates references from draft to published version in other data models.
+     * E.g. https://iri.suomi.fi/model/foo/resource -> https://iri.suomi.fi/model/foo/1.0.0/resource
+     * @param graph published graph uri
+     */
+    public void updateDraftReferences(String graph, String newVersion) {
+        var builder = new UpdateBuilder();
+        var e = builder.getExprFactory();
+        builder
+                .addDelete("?g", "?s", "?p", "?o")
+                .addInsert("?g", "?s", "?p", "?releaseUri")
+                .addWhere(new WhereBuilder()
+                        .addGraph("?g", "?s", "?p", "?o"))
+                        .addFilter(e.regex(e.str("?o"), graph + "([a-zA-Z](.)*)?$", ""))
+                        .addBind(e.iri(
+                            e.replace(e.str("?o"), graph, graph + newVersion + "/")
+                        ), "releaseUri")
+                        .addFilter(e.not(e.strstarts(e.str("?g"), graph)));
+
+        coreRepository.queryUpdate(builder.buildRequest());
     }
 
     private void addPrefixes(Model model, DataModelDTO dto) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -95,6 +95,7 @@ public class DataModelService {
         terminologyService.resolveTerminology(dto.getTerminologies());
         codeListService.resolveCodelistScheme(dto.getCodeLists());
         var jenaModel = mapper.mapToJenaModel(dto, modelType, userProvider.getUser());
+        addPrefixes(jenaModel, dto);
 
         coreRepository.put(graphUri, jenaModel);
 
@@ -113,6 +114,7 @@ public class DataModelService {
         terminologyService.resolveTerminology(dto.getTerminologies());
         codeListService.resolveCodelistScheme(dto.getCodeLists());
         mapper.mapToUpdateJenaModel(graphUri, dto, model, userProvider.getUser());
+        addPrefixes(model, dto);
 
         coreRepository.put(graphUri, model);
 
@@ -298,5 +300,9 @@ public class DataModelService {
         var indexModel = mapper.mapToIndexModel(uri.getModelURI(), model);
         openSearchIndexer.updateModelToIndex(indexModel);
         auditService.log(AuditService.ActionType.UPDATE, uri.getGraphURI(), userProvider.getUser());
+    }
+
+    private void addPrefixes(Model model, DataModelDTO dto) {
+        dto.getExternalNamespaces().forEach(ns -> model.getGraph().getPrefixMapping().setNsPrefix(ns.getPrefix(), ns.getNamespace()));
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -40,7 +40,8 @@ public class NamespaceService {
             Map.entry("dc", "http://purl.org/dc/elements/1.1/"),
             Map.entry("sd", "http://www.w3.org/ns/sparql-service-description#"),
             Map.entry("sh", "http://www.w3.org/ns/shacl#"),
-            Map.entry("shsh", "http://www.w3.org/ns/shacl-shacl")
+            Map.entry("shsh", "http://www.w3.org/ns/shacl-shacl"),
+            Map.entry("foaf", "http://xmlns.com/foaf/0.1/")
     );
 
     public void resolveDefaultNamespaces() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -58,7 +58,7 @@ public class DataModelValidator extends BaseValidator implements
 
         checkPrefix(context, prefix, prefixPropertyLabel, updateModel);
         // Check prefix text content
-        checkPrefixContent(context, prefix, prefixPropertyLabel);
+        checkPrefixContent(context, prefix, prefixPropertyLabel, false);
 
         if (coreRepository.graphExists(ModelConstants.SUOMI_FI_NAMESPACE + prefix)) {
             // Checking if in use is different for data models and its resources so it is not in the above function
@@ -205,7 +205,7 @@ public class DataModelValidator extends BaseValidator implements
                 if(namespace.getNamespace().startsWith(ModelConstants.SUOMI_FI_NAMESPACE)){
                     addConstraintViolation(context, "namespace-not-external", externalNamespace);
                 }
-                checkPrefixContent(context, namespace.getPrefix(), externalNamespace);
+                checkPrefixContent(context, namespace.getPrefix(), externalNamespace, true);
             }
         });
     }
@@ -215,14 +215,15 @@ public class DataModelValidator extends BaseValidator implements
      * @param context Constraint validator context
      * @param prefix Prefix
      * @param property Property name if violation happens
+     * @param externalNamespace if true, allow using reserved prefixes, e.g. 'owl'
      */
-    private void checkPrefixContent(ConstraintValidatorContext context, String prefix, String property){
+    private void checkPrefixContent(ConstraintValidatorContext context, String prefix, String property, boolean externalNamespace){
         if(prefix == null){
             return;
         }
         //Checking for reserved words and reserved namespaces. This error won't distinguish which one it was
         if(ValidationConstants.RESERVED_WORDS.contains(prefix)
-                || ValidationConstants.RESERVED_NAMESPACES.containsKey(prefix)){
+                || (!externalNamespace && ValidationConstants.RESERVED_NAMESPACES.containsKey(prefix))) {
             addConstraintViolation(context, "prefix-is-reserved", property);
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
@@ -5,6 +5,7 @@ import fi.vm.yti.datamodel.api.v2.service.ResourceService;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -60,7 +61,8 @@ public class PropertyShapeValidator extends BaseValidator implements ConstraintV
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "path");
         }
 
-        if (path != null && !path.isBlank() && !resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty))) {
+        if (path != null && !path.isBlank()
+                && !resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty, RDF.Property))) {
             addConstraintViolation(context, "not-property-or-doesnt-exist", "path");
         }
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -289,8 +289,8 @@ class DataModelControllerTest {
         dataModelDTO = createDatamodelDTO(false);
         invalidExtRes = new ExternalNamespaceDTO();
         invalidExtRes.setName(Map.of("fi", "this is invalid"));
-        //Reserved namespace, see ValidationConstants.RESERVED_NAMESPACES
-        invalidExtRes.setPrefix("dcterms");
+        //Reserved words, see ValidationConstants.RESERVED_WORDS
+        invalidExtRes.setPrefix("urn");
         invalidExtRes.setNamespace("http:://example.com/ns/test");
         dataModelDTO.setExternalNamespaces(Set.of(invalidExtRes));
         args.add(dataModelDTO);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/DataMigrationTest.java
@@ -112,6 +112,7 @@ class DataMigrationTest {
         newModel.createResource(DataModelURI.createResourceURI(prefix, "CatalogRecord").getResourceURI());
 
         when(coreRepository.fetch(newModelURI)).thenReturn(newModel);
+        when(resourceService.exists(prefix, "primaryTopic")).thenReturn(true);
         when(dataModelService.create(any(DataModelDTO.class), any(ModelType.class))).thenReturn(new URI(newModelURI));
 
         migrationService.migrateDatamodel(prefix, oldData);
@@ -130,14 +131,16 @@ class DataMigrationTest {
 
         assertEquals(prefix, dataModelCaptor.getValue().getPrefix());
 
-        assertTrue(identifiers.containsAll(List.of("CatalogRecord", "Dataset", "primaryTopic", "modified")));
+        // Assume there is already resource with id primaryTopic, so suffix '-1' is added
+        assertTrue(identifiers.containsAll(List.of("CatalogRecord", "Dataset", "primaryTopic-1", "modified")));
         assertEquals(2, propertyURIs.size());
         assertTrue(propertyURIs.containsAll(List.of(
                 "https://iri.suomi.fi/model/fi-dcatap/modified",
-                "https://iri.suomi.fi/model/fi-dcatap/primaryTopic")
+                "https://iri.suomi.fi/model/fi-dcatap/primaryTopic-1")
         ));
 
         // should remove invalid language from label
+        assertTrue(datasetNodeShape.isPresent());
         assertEquals(1, datasetNodeShape.get().getLabel().keySet().size());
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
@@ -42,10 +42,11 @@ public class V1DataMapperTest {
         // internal namespaces have to add separately without validation
         assertEquals(Set.of(), result.getInternalNamespaces());
 
-        var externalNamespace = result.getExternalNamespaces().iterator().next();
-        assertEquals("test_un", externalNamespace.getPrefix());
-        assertEquals("https://vocabulary.uncefact.org/", externalNamespace.getNamespace());
-        assertEquals("test un", externalNamespace.getName().get("fi"));
+        var externalNamespace = result.getExternalNamespaces().stream().filter(e -> e.getPrefix().equals("test_un")).findFirst();
+        assertTrue(externalNamespace.isPresent());
+        assertEquals("test_un", externalNamespace.get().getPrefix());
+        assertEquals("https://vocabulary.uncefact.org/", externalNamespace.get().getNamespace());
+        assertEquals("test un", externalNamespace.get().getName().get("fi"));
 
         assertEquals(2, result.getLinks().size());
         var link = result.getLinks().stream()
@@ -166,8 +167,8 @@ public class V1DataMapperTest {
         assertTrue(propertyShapeAssociation.isPresent());
         assertTrue(propertyShapeAttribute.isPresent());
 
-        var associationDTO = (AssociationRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAssociation.get());
-        var attributeDTO = (AttributeRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAttribute.get());
+        var associationDTO = (AssociationRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAssociation.get(), "fi-dcatap", "classResource");
+        var attributeDTO = (AttributeRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAttribute.get(), "fi-dcatap", "classResource");
 
         assertTrue(associationDTO != null && attributeDTO != null);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/migration/V1DataMapperTest.java
@@ -2,10 +2,14 @@ package fi.vm.yti.datamodel.api.v2.migration;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
 import fi.vm.yti.datamodel.api.migration.V1DataMapper;
+import fi.vm.yti.datamodel.api.v2.dto.AssociationRestriction;
+import fi.vm.yti.datamodel.api.v2.dto.AttributeRestriction;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.Test;
+import org.topbraid.shacl.vocabulary.SH;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -14,15 +18,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class V1DataMapperTest {
 
-    public static final String GRAPH_URI = "http://uri.suomi.fi/datamodel/ns/merialsuun";
-    public static final String NEW_GRAPH_URI = "https://iri.suomi.fi/model/merialsuun/";
+    public static final String LIBRARY_GRAPH_URI = "http://uri.suomi.fi/datamodel/ns/merialsuun";
+    public static final String NEW_LIBRARY_GRAPH_URI = "https://iri.suomi.fi/model/merialsuun/";
+
+    public static final String PROFILE_GRAPH_URI = "http://uri.suomi.fi/datamodel/ns/fi-dcatap";
+    public static final String NEW_PROFILE_GRAPH_URI = "https://iri.suomi.fi/model/fi-dcatap/";
 
     @Test
     void testMapOldLibraryMetadata() {
 
         var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
         var serviceCategories = MapperTestUtils.getModelFromFile("/service-categories.ttl");
-        var result = V1DataMapper.getLibraryMetadata(GRAPH_URI, oldData, serviceCategories, null);
+        var result = V1DataMapper.getLibraryMetadata(LIBRARY_GRAPH_URI, oldData, serviceCategories, null);
 
         assertEquals("merialsuun", result.getPrefix());
         assertEquals("Merialuesuunnitelma", result.getLabel().get("fi"));
@@ -52,6 +59,23 @@ public class V1DataMapperTest {
     }
 
     @Test
+    void mapOldProfileMetadata() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/fi-dcatap.ttl");
+        var serviceCategories = MapperTestUtils.getModelFromFile("/service-categories.ttl");
+        var result = V1DataMapper.getLibraryMetadata(PROFILE_GRAPH_URI, oldData, serviceCategories, null);
+
+        assertEquals("fi-dcatap", result.getPrefix());
+        assertEquals("Avoindata.fi:n DCAT-AP laajennos", result.getLabel().get("fi"));
+        assertEquals(Set.of("fi", "en", "sv"), result.getLanguages());
+        assertEquals("P11", result.getGroups().iterator().next());
+        assertEquals(UUID.fromString("d9c76d52-03d3-4480-8c2c-b66e6d9c57f2"), result.getOrganizations().iterator().next());
+        assertEquals("Open Data’s extension is mostly compatible with DCAT-AP with some some exception.", result.getDescription().get("fi"));
+
+        // internal namespaces have to add separately without validation
+        assertEquals(Set.of(), result.getInternalNamespaces());
+    }
+
+    @Test
     void testMapOldLibraryAttributes() {
         var oldData = MapperTestUtils.getModelFromFile("/migration/merialsuun.ttl");
 
@@ -77,7 +101,7 @@ public class V1DataMapperTest {
         var dto = V1DataMapper.mapLibraryResource(associations.get(0));
         assertEquals("koostuu", dto.getIdentifier());
         assertEquals("Koostuu", dto.getLabel().get("fi"));
-        assertEquals(NEW_GRAPH_URI + "MerialuesuunnitelmanKohde", dto.getRange());
+        assertEquals(NEW_LIBRARY_GRAPH_URI + "MerialuesuunnitelmanKohde", dto.getRange());
     }
 
     @Test
@@ -89,7 +113,7 @@ public class V1DataMapperTest {
         assertEquals(2, classes.size());
 
         var c1 = classes.stream()
-                .filter(c -> c.getURI().equals(GRAPH_URI + "#Lahtotietoaineisto"))
+                .filter(c -> c.getURI().equals(LIBRARY_GRAPH_URI + "#Lahtotietoaineisto"))
                 .findFirst();
 
         assertTrue(c1.isPresent());
@@ -102,5 +126,66 @@ public class V1DataMapperTest {
         assertEquals("http://uri.suomi.fi/terminology/rytj-kaava/concept-13", dto.getSubject());
         assertEquals("https://iri.suomi.fi/model/rak/Lahtotietoaineisto", dto.getSubClassOf().iterator().next());
         assertEquals("Test editorial note", dto.getEditorialNote());
+    }
+
+    @Test
+    void testMapOldProfileNodeShapes() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/fi-dcatap.ttl");
+
+        var nodeShapes = V1DataMapper.findResourcesByType(oldData, SH.NodeShape);
+
+        assertEquals(2, nodeShapes.size());
+
+        var nodeShape = nodeShapes.stream().filter(n -> n.getURI().equals(PROFILE_GRAPH_URI + "#CatalogRecord")).findFirst();
+
+        assertTrue(nodeShape.isPresent());
+
+        var dto = V1DataMapper.mapProfileClass(nodeShape.get());
+
+        assertEquals("CatalogRecord", dto.getIdentifier());
+        assertEquals("Tietoaineiston kuvailutietue", dto.getLabel().get("fi"));
+        assertEquals("Tiedot, jotka liittävät yksittäisen tietoaineiston datakatalogiin.", dto.getNote().get("fi"));
+    }
+
+    @Test
+    void testMapOldProfilePropertyShape() {
+        var oldData = MapperTestUtils.getModelFromFile("/migration/fi-dcatap.ttl");
+
+        var propertyShapes = V1DataMapper.findResourcesByType(oldData, SH.PropertyShape);
+
+        assertEquals(2, propertyShapes.size());
+
+        var propertyShapeAssociation = propertyShapes.stream()
+                .filter(p -> p.getURI().equals("urn:uuid:88caff9f-b060-449b-a8b2-26a276e1fdce"))
+                .findFirst();
+
+        var propertyShapeAttribute = propertyShapes.stream()
+                .filter(p -> p.getURI().equals("urn:uuid:81f75fa1-561c-477e-b942-eb29edb05033"))
+                .findFirst();
+
+        assertTrue(propertyShapeAssociation.isPresent());
+        assertTrue(propertyShapeAttribute.isPresent());
+
+        var associationDTO = (AssociationRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAssociation.get());
+        var attributeDTO = (AttributeRestriction) V1DataMapper.mapProfileResource(oldData, propertyShapeAttribute.get());
+
+        assertTrue(associationDTO != null && attributeDTO != null);
+
+        assertEquals("primaryTopic", associationDTO.getIdentifier());
+        assertEquals("aihe", associationDTO.getLabel().get("fi"));
+        assertEquals("primary topic", associationDTO.getLabel().get("en"));
+        assertEquals("Liittää kuvailutietueen siinä kuvattavaan tietoaineistoon", associationDTO.getNote().get("fi"));
+        assertEquals("http://xmlns.com/foaf/0.1/primaryTopic", associationDTO.getPath());
+        assertEquals("http://www.w3.org/ns/dcat#Dataset", ((AssociationRestriction) associationDTO).getClassType());
+        assertEquals(3, associationDTO.getMaxCount());
+        assertEquals(2, associationDTO.getMinCount());
+
+        assertEquals("http://www.w3.org/2001/XMLSchema#dateTime", attributeDTO.getDataType());
+        assertEquals("http://uri.suomi.fi/codelist/test", attributeDTO.getCodeLists().get(0));
+        assertTrue(attributeDTO.getAllowedValues().containsAll(List.of("test", "test2")));
+        assertEquals("pattern", attributeDTO.getPattern());
+        assertEquals("default", attributeDTO.getDefaultValue());
+        assertEquals(10, attributeDTO.getMaxLength());
+        assertEquals(1, attributeDTO.getMinLength());
     }
 }

--- a/src/test/resources/migration/fi-dcatap.ttl
+++ b/src/test/resources/migration/fi-dcatap.ttl
@@ -1,0 +1,106 @@
+@prefix dcap:  <http://purl.org/ws-mmi-dc/terms/> .
+@prefix schema: <http://schema.org/> .
+@prefix spdx:  <http://spdx.org/rdf/terms#> .
+@prefix dcam:  <http://purl.org/dc/dcam/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix sd:    <http://www.w3.org/ns/sparql-service-description#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix text:  <http://jena.apache.org/text#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix httpv: <http://www.w3.org/2011/http#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix void:  <http://rdfs.org/ns/void#> .
+@prefix dcatap: <http://data.europa.eu/r5r#> .
+@prefix adms:  <http://www.w3.org/ns/adms#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix afn:   <http://jena.hpl.hp.com/ARQ/function#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix at:    <http://publications.europa.eu/ontology/authority/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix fi-dcatap: <http://uri.suomi.fi/datamodel/ns/fi-dcatap#> .
+@prefix odrl:  <http://www.w3.org/ns/odrl/2/> .
+@prefix ts:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<http://uri.suomi.fi/datamodel/ns/fi-dcatap>
+        rdf:type                        dcap:DCAP , owl:Ontology ;
+        rdfs:comment                    "Open Data’s extension is mostly compatible with DCAT-AP with some some exception."@fi ;
+        rdfs:label                      "Avoindata.fi:n DCAT-AP laajennos"@fi , "Suomi.fi Open Data’s extension on DCAT-AP"@en ;
+        dcterms:contributor             <urn:uuid:d9c76d52-03d3-4480-8c2c-b66e6d9c57f2> ;
+        dcterms:created                 "2022-11-23T13:55:35.278Z"^^xsd:dateTime ;
+        dcterms:hasPart                 fi-dcatap:distributor ;
+        dcterms:identifier              "urn:uuid:37538e8d-fcc3-4228-9ed2-d1ab0bb1b3da" ;
+        dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
+        dcterms:language                ( "en" "fi" "sv" ) ;
+        dcterms:modified                "2024-01-10T11:07:28.863Z"^^xsd:dateTime ;
+        dcterms:requires                skos: , prov: , dcterms: ;
+        dcap:preferredXMLNamespaceName  "http://uri.suomi.fi/datamodel/ns/fi-dcatap#" ;
+        dcap:preferredXMLNamespacePrefix
+                "fi-dcatap" ;
+        iow:contentModified             "2024-01-13T08:03:15.86Z"^^xsd:dateTime ;
+        iow:documentation               "[Lisätietoa Suomi.fi avoindatan DCAT-AP laajennoksesta](https://www.avoindata.fi/fi/dcat-ap)"@fi ;
+        iow:statusModified              "2023-05-10T11:58:56.892Z"^^xsd:dateTime ;
+        iow:useContext                  "InformationDescription" ;
+        owl:versionInfo                 "DRAFT" .
+
+fi-dcatap:CatalogRecord
+          a                   sh:NodeShape ;
+          rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/fi-dcatap> ;
+          dcterms:created     "2022-12-08T08:07:40.737Z"^^xsd:dateTime ;
+          dcterms:identifier  "urn:uuid:f94690e0-6e66-48c6-a95b-6ff35a04649b" ;
+          dcterms:modified    "2024-01-09T16:54:28.81Z"^^xsd:dateTime ;
+          iow:statusModified  "2023-05-10T11:58:56.13Z"^^xsd:dateTime ;
+          owl:versionInfo     "DRAFT" ;
+          sh:description      "A record in a data catalog, describing a single dataset."@en , "Tiedot, jotka liittävät yksittäisen tietoaineiston datakatalogiin."@fi ;
+          sh:name             "Catalog Record"@en , "Tietoaineiston kuvailutietue"@fi ;
+          sh:property         <urn:uuid:88caff9f-b060-449b-a8b2-26a276e1fdce> , <urn:uuid:81f75fa1-561c-477e-b942-eb29edb05033> ;
+          sh:targetClass      dcat:CatalogRecord .
+
+fi-dcatap:Dataset  a        sh:NodeShape ;
+        rdfs:isDefinedBy    <http://uri.suomi.fi/datamodel/ns/fi-dcatap> ;
+        dcterms:created     "2022-12-08T07:55:54.252Z"^^xsd:dateTime ;
+        dcterms:identifier  "urn:uuid:1d8476f7-f3be-423e-ad76-07b4610f3389" ;
+        dcterms:modified    "2024-01-15T12:11:37.672Z"^^xsd:dateTime ;
+        iow:statusModified  "2023-05-10T11:58:56.13Z"^^xsd:dateTime ;
+        owl:versionInfo     "DRAFT" ;
+        sh:description      "test"@fi ;
+        sh:name             "Tietoaineisto"@fi , "Invalid"@fr;
+        sh:targetClass      dcat:Dataset .
+
+<urn:uuid:88caff9f-b060-449b-a8b2-26a276e1fdce>
+          a                sh:PropertyShape ;
+          dcterms:type     owl:ObjectProperty ;
+          iow:localName    "primaryTopic" ;
+          owl:versionInfo  "DRAFT" ;
+          sh:description   "Liittää kuvailutietueen siinä kuvattavaan tietoaineistoon"@fi , "Links a data record to the dataset it describes"@en ;
+          sh:maxCount      3 ;
+          sh:minCount      2 ;
+          sh:name          "aihe"@fi , "primary topic"@en ;
+          sh:node          fi-dcatap:Dataset ;
+          sh:order         4 ;
+          sh:path          foaf:primaryTopic .
+
+<urn:uuid:81f75fa1-561c-477e-b942-eb29edb05033>
+          a                sh:PropertyShape ;
+          dcterms:type     owl:DatatypeProperty ;
+          iow:localName    "modified" ;
+          owl:versionInfo  "DRAFT" ;
+          sh:datatype      xsd:dateTime ;
+          sh:description   "The most recent date on which the Catalogue entry was changed or modified"@en , "Viimeisin kuvailutietueen päivitys- tai muokkauspäivä"@fi ;
+          sh:maxCount      1 ;
+          sh:minCount      1 ;
+          sh:name          "Date Modified"@en , "Viimeksi muokattu"@fi ;
+          sh:order         0 ;
+          sh:path          dcterms:modified ;
+          dcam:memberOf    <http://uri.suomi.fi/codelist/test> ;
+          sh:in            ( "test" "test2" ) ;
+          sh:pattern       "pattern" ;
+          sh:defaultValue  "default" ;
+          sh:maxLength     10 ;
+          sh:minLength     1 .


### PR DESCRIPTION
- migration script for profiles
- tweak validations (type of sh:path and allow reserved prefixes when linkin external namespace)
- add prefixes of the external namespaces to model's prefix map
- return errors in the response after migration finished
- add foaf to resolved namespaces
- update references from draft version to published one when creating new version