### PR TITLE
YTI-3830 External namespaces changes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/V1DataMigrationService.java
@@ -527,6 +527,13 @@ public class V1DataMigrationService {
             spdx.setPrefix("spdx");
 
             dataModel.getExternalNamespaces().addAll(Set.of(rdfs, spdx));
+        } else if (prefix.equals("fi-nsipap")) {
+            var skos = new ExternalNamespaceDTO();
+            skos.setName(Map.of("en", "skos"));
+            skos.setNamespace("http://www.w3.org/2004/02/skos/core# ");
+            skos.setPrefix("skos");
+
+            dataModel.getExternalNamespaces().add(skos);
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/index/OpenSearchIndexer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import fi.vm.yti.datamodel.api.index.OpenSearchConnector;
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.mapper.ModelMapper;
 import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.opensearch.queries.QueryFactoryUtils;
@@ -276,27 +277,64 @@ public class OpenSearchIndexer {
     }
 
     public void initExternalResourceIndex() {
-        var builder = new ConstructBuilder()
-                .addPrefixes(NamespaceService.DEFAULT_NAMESPACES);
+        NamespaceService.DEFAULT_NAMESPACES.forEach((prefix, graphURI) -> {
+            logger.info("Indexing external namespace {}", graphURI);
+            var builder = new ConstructBuilder()
+                    .addPrefix(prefix, graphURI)
+                    .addPrefixes(ModelConstants.PREFIXES)
+                    .from(graphURI);
 
-        SparqlUtils.addConstructOptional("?s", builder, RDFS.label, "?label");
-        SparqlUtils.addConstructOptional("?s", builder, RDFS.isDefinedBy, "?isDefinedBy");
-        SparqlUtils.addConstructOptional("?s", builder, RDFS.comment, "?comment");
-        SparqlUtils.addConstructOptional("?s", builder, RDF.type, "?type");
-        SparqlUtils.addConstructOptional("?s", builder, OWL.inverseOf, "?inverseOf");
+            SparqlUtils.addConstructOptional("?s", builder, RDFS.label, "?label");
+            SparqlUtils.addConstructOptional("?s", builder, RDFS.isDefinedBy, "?isDefinedBy");
+            SparqlUtils.addConstructOptional("?s", builder, RDFS.comment, "?comment");
+            SparqlUtils.addConstructOptional("?s", builder, RDF.type, "?type");
+            SparqlUtils.addConstructOptional("?s", builder, OWL.inverseOf, "?inverseOf");
 
-        var result = importsRepository.queryConstruct(builder.build());
-        var list = new ArrayList<IndexBase>();
-        result.listSubjects().forEach(resource -> {
-            var indexClass = ResourceMapper.mapExternalToIndexResource(resource);
-            if (indexClass == null) {
-                logger.info("Could not determine required properties for resource {}", resource.getURI());
-                return;
-            }
-            list.add(indexClass);
+            var result = importsRepository.queryConstruct(builder.build());
+            var list = new ArrayList<IndexBase>();
+            result.listSubjects().forEach(resource -> {
+                var indexResource = ResourceMapper.mapExternalToIndexResource(resource);
+                if (indexResource == null) {
+                    logger.info("Could not determine required properties for resource {}", resource.getURI());
+                    return;
+                }
+
+                // try to find type from other graphs in imports dataset
+                if (indexResource.getResourceType() == null && resource.hasProperty(RDF.type)) {
+                    var select = new SelectBuilder()
+                        .addPrefixes(ModelConstants.PREFIXES)
+                        .addVar("?t");
+
+                    var where = new WhereBuilder();
+                    var typeProperties = resource.listProperties(RDF.type);
+                    typeProperties.forEach(t -> where.addUnion(
+                            new WhereBuilder().addWhere(t.getObject(), RDF.type, "?t")
+                    ));
+                    select.addWhere(where).addGroupBy("?t");
+
+                    var types = new ArrayList<RDFNode>();
+                    importsRepository.querySelect(select.build(), (res -> types.add(res.get("t"))));
+
+                    if (types.contains(OWL.Class) || types.contains(RDFS.Class)) {
+                        indexResource.setResourceType(ResourceType.CLASS);
+                    } else if (types.contains(OWL.DatatypeProperty)) {
+                        indexResource.setResourceType(ResourceType.ATTRIBUTE);
+                    } else if (types.contains(OWL.ObjectProperty)) {
+                        indexResource.setResourceType(ResourceType.ASSOCIATION);
+                    } else {
+                        logger.warn("Cannot determine type for resource {}, types: {}", resource,
+                                String.join(", ", typeProperties
+                                        .mapWith(t -> t.getObject().toString())
+                                        .toList())
+                        );
+                        return;
+                    }
+                }
+                list.add(indexResource);
+            });
+            logger.info("Indexing {} items to index {},", list.size(), OPEN_SEARCH_INDEX_EXTERNAL);
+            bulkInsert(OPEN_SEARCH_INDEX_EXTERNAL, list);
         });
-        logger.info("Indexing {} items to index {},", list.size(), OPEN_SEARCH_INDEX_EXTERNAL);
-        bulkInsert(OPEN_SEARCH_INDEX_EXTERNAL, list);
     }
 
     public <T extends IndexBase> void bulkInsert(String indexName,

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -143,7 +143,7 @@ public class ResourceQueryFactory {
             builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", request.getIncludeDraftFrom()));
         }
 
-        builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", externalNamespaces))
+        builder.should(QueryFactoryUtils.termsQuery("namespace", externalNamespaces))
             .should(QueryFactoryUtils.termsQuery("versionIri", internalNamespacesCondition))
             .should(QueryFactoryUtils.termsQuery("id", request.getAdditionalResources() != null
                     ? request.getAdditionalResources()

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -60,15 +60,21 @@ public class NamespaceResolver {
         logger.info("Resolving namespace: {}", namespace);
         var model = ModelFactory.createDefaultModel();
         try{
+            var accept = String.join(", ", ACCEPT_TYPES);
+
+            // Uncefact works only with one accept header
+            if (namespace.equals("https://vocabulary.uncefact.org/")) {
+                accept = "application/ld+json";
+            }
             RDFParser.create()
                     .source(namespace)
                     .lang(Lang.RDFXML)
-                    .acceptHeader(String.join(", ", ACCEPT_TYPES))
+                    .acceptHeader(accept)
                     .parse(model);
-            if(model.size() > 0){
+            if (!model.isEmpty()){
                 importsRepository.put(namespace, model);
                 var indexResources = model.listSubjects()
-                        .mapWith(resource -> ResourceMapper.mapExternalToIndexResource(model, resource))
+                        .mapWith(ResourceMapper::mapExternalToIndexResource)
                         .toList()
                         .stream().filter(Objects::nonNull)
                         .toList();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -71,7 +71,12 @@ public class NamespaceResolver {
                     .lang(Lang.RDFXML)
                     .acceptHeader(accept)
                     .parse(model);
-            if (!model.isEmpty()){
+            if (!model.isEmpty()) {
+
+                // add resource separator if not exist
+                if (!(namespace.endsWith("/") || namespace.endsWith("#"))) {
+                    namespace += "/";
+                }
                 importsRepository.put(namespace, model);
                 var indexResources = model.listSubjects()
                         .mapWith(ResourceMapper::mapExternalToIndexResource)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -24,7 +24,7 @@ public class NamespaceService {
         this.importsRepository = importsRepository;
     }
 
-    private static final Map<String, String> DEFAULT_NAMESPACES = Map.ofEntries(
+    public static final Map<String, String> DEFAULT_NAMESPACES = Map.ofEntries(
             Map.entry("oa", "http://www.w3.org/ns/oa#"),
             Map.entry("dcterms", "http://purl.org/dc/terms/"),
             Map.entry("skos", "http://www.w3.org/2004/02/skos/core#"),
@@ -41,7 +41,10 @@ public class NamespaceService {
             Map.entry("sd", "http://www.w3.org/ns/sparql-service-description#"),
             Map.entry("sh", "http://www.w3.org/ns/shacl#"),
             Map.entry("shsh", "http://www.w3.org/ns/shacl-shacl"),
-            Map.entry("foaf", "http://xmlns.com/foaf/0.1/")
+            Map.entry("foaf", "http://xmlns.com/foaf/0.1/"),
+            Map.entry("vcard", "http://www.w3.org/2006/vcard/ns#"),
+            Map.entry("elm", "https://publications.europa.eu/resource/authority/snb/model/elm"),
+            Map.entry("uncefact", "https://vocabulary.uncefact.org/")
     );
 
     public void resolveDefaultNamespaces() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -43,8 +43,8 @@ public class NamespaceService {
             Map.entry("shsh", "http://www.w3.org/ns/shacl-shacl"),
             Map.entry("foaf", "http://xmlns.com/foaf/0.1/"),
             Map.entry("vcard", "http://www.w3.org/2006/vcard/ns#"),
-            Map.entry("elm", "https://publications.europa.eu/resource/authority/snb/model/elm"),
-            Map.entry("uncefact", "https://vocabulary.uncefact.org/")
+            Map.entry("elm", "http://data.europa.eu/snb/model/elm"),
+            Map.entry("unece", "https://vocabulary.uncefact.org/")
     );
 
     public void resolveDefaultNamespaces() {

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -714,8 +714,8 @@ class ResourceMapperTest {
         var resource1 = model.getResource("http://www.w3.org/ns/oa#describing");
         var resource2 = model.getResource("http://www.w3.org/ns/oa#Motivation");
 
-        var indexResource1 = ResourceMapper.mapExternalToIndexResource(model, resource1);
-        var indexResource2 = ResourceMapper.mapExternalToIndexResource(model, resource2);
+        var indexResource1 = ResourceMapper.mapExternalToIndexResource(resource1);
+        var indexResource2 = ResourceMapper.mapExternalToIndexResource(resource2);
 
         assertNotNull(indexResource1);
         assertNotNull(indexResource2);
@@ -729,6 +729,7 @@ class ResourceMapperTest {
         assertEquals("http://www.w3.org/ns/oa#", indexResource1.getIsDefinedBy());
         assertEquals("Label describing", indexResource1.getLabel().get("en"));
         assertEquals("Test comment describing", indexResource1.getNote().get("en"));
+        assertEquals("oa:describing", indexResource1.getCurie());
     }
 
     @Test
@@ -737,8 +738,8 @@ class ResourceMapperTest {
         var resource1 = model.getResource("http://www.w3.org/ns/oa#exact");
         var resource2 = model.getResource("http://www.w3.org/ns/oa#hasEndSelector");
 
-        var indexResource1 = ResourceMapper.mapExternalToIndexResource(model, resource1);
-        var indexResource2 = ResourceMapper.mapExternalToIndexResource(model, resource2);
+        var indexResource1 = ResourceMapper.mapExternalToIndexResource(resource1);
+        var indexResource2 = ResourceMapper.mapExternalToIndexResource(resource2);
 
         assertNotNull(indexResource1);
         assertNotNull(indexResource2);

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -33,7 +33,7 @@
               },
               {
                 "terms": {
-                  "isDefinedBy": []
+                  "namespace": []
                 }
               },
               {

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -18,7 +18,7 @@
             "should": [
               {
                 "terms": {
-                  "isDefinedBy": [
+                  "namespace": [
                     "http://external-data.com/test"
                   ]
                 }

--- a/src/test/resources/es/classesByVersion.json
+++ b/src/test/resources/es/classesByVersion.json
@@ -29,7 +29,7 @@
               },
               {
                 "terms": {
-                  "isDefinedBy": []
+                  "namespace": []
                 }
               },
               {


### PR DESCRIPTION
## Namespace resolving
- Add new resolvable namespaces
- Simplify the query which fetches resources for indexing, as it's very slow with larger datasets
- Use only application/ld+json accept header when resolving uncefact namespace (works only with one accept header)

## Search resources
- Add curie for external resources in index
- Use namespace field when searching external resources from OpenSearch, because isDefinedBy might refer to different namespace or might miss resource separator