### PR TITLE
YTI-3823 add origin for hidden nodes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/VisualizationHiddenNodeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/VisualizationHiddenNodeDTO.java
@@ -7,6 +7,7 @@ public class VisualizationHiddenNodeDTO {
     private PositionDTO position;
     private String referenceTarget;
     private VisualizationReferenceType referenceType;
+    private String origin;
 
     public String getIdentifier() {
         return identifier;
@@ -38,6 +39,14 @@ public class VisualizationHiddenNodeDTO {
 
     public void setReferenceType(VisualizationReferenceType referenceType) {
         this.referenceType = referenceType;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -265,7 +265,7 @@ public class VisualizationMapper {
                 handledElements.add(positionResource.getLocalName());
 
                 path.addFirst(positionResource.getLocalName());
-                hiddenElements.add(mapHiddenNode(positionResource, reference.getReferenceType()));
+                hiddenElements.add(mapHiddenNode(positionResource, reference, sourceIdentifier));
 
                 var references = positions.listSubjectsWithProperty(SuomiMeta.referenceTarget, positionResource.getLocalName()).toList();
 
@@ -284,13 +284,19 @@ public class VisualizationMapper {
         return List.of(reference.getReferenceTarget());
     }
 
-    private static VisualizationHiddenNodeDTO mapHiddenNode(Resource position, VisualizationReferenceType referenceType) {
+    private static VisualizationHiddenNodeDTO mapHiddenNode(Resource position, VisualizationReferenceDTO reference, String sourceIdentifier) {
         var dto = new VisualizationHiddenNodeDTO();
 
         dto.setIdentifier(MapperUtils.propertyToString(position, DCTerms.identifier));
         dto.setPosition(getPositionFromResource(position));
         dto.setReferenceTarget(MapperUtils.propertyToString(position, SuomiMeta.referenceTarget));
-        dto.setReferenceType(referenceType);
+        dto.setReferenceType(reference.getReferenceType());
+
+        if (reference.getReferenceType().equals(VisualizationReferenceType.ASSOCIATION)) {
+            dto.setOrigin(reference.getIdentifier());
+        } else {
+            dto.setOrigin(sourceIdentifier);
+        }
 
         return dto;
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/VisualizationDataMapperTest.java
@@ -421,6 +421,7 @@ class VisualizationDataMapperTest {
         var association = new VisualizationReferenceDTO();
         association.setReferenceTarget("class-1");
         association.setIdentifier("assoc-1");
+        association.setReferenceType(VisualizationReferenceType.ASSOCIATION);
 
         var node1 = new PositionDataDTO();
         node1.setIdentifier("class-1");


### PR DESCRIPTION
Add origin for hidden nodes to make it easier to set association / parent relation highlights in the UI. For association references the origin is association id, for parent relations origin is source class id.