### PR TITLE
YTI-2554 Resource's references

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceReferenceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ResourceReferenceDTO.java
@@ -1,0 +1,45 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import java.util.Objects;
+
+public class ResourceReferenceDTO {
+    private UriDTO resourceURI;
+    private String property;
+    private ResourceType type;
+
+    public UriDTO getResourceURI() {
+        return resourceURI;
+    }
+
+    public void setResourceURI(UriDTO resourceURI) {
+        this.resourceURI = resourceURI;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+
+    public ResourceType getType() {
+        return type;
+    }
+
+    public void setType(ResourceType type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(o, this, "property");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceURI, property, type);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ResourceController.java
@@ -19,6 +19,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -250,6 +252,12 @@ public class ResourceController {
                                               @RequestParam @Parameter(description = "New identifier") @ValidResourceIdentifier String newIdentifier) throws URISyntaxException {
         var newURI = resourceService.renameResource(prefix, identifier, newIdentifier);
         return ResponseEntity.created(newURI).build();
+    }
+
+    @Operation(summary = "Gets resource references in other graphs")
+    @GetMapping(value = "/references", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<ResourceType, List<ResourceReferenceDTO>>> getResourceReferences(@RequestParam @Parameter(description = "Resource URI") String uri) {
+        return ResponseEntity.ok(resourceService.getResourceReferences(uri));
     }
 
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
@@ -2,6 +2,8 @@ package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceReferenceDTO;
+import fi.vm.yti.datamodel.api.v2.dto.ResourceType;
 import fi.vm.yti.datamodel.api.v2.dto.UriDTO;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
@@ -14,21 +16,24 @@ import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
 import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.Role;
+import fi.vm.yti.security.YtiUser;
 import org.apache.jena.arq.querybuilder.AskBuilder;
 import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.apache.jena.sparql.path.PathFactory;
-import org.apache.jena.vocabulary.DCTerms;
-import org.apache.jena.vocabulary.OWL2;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.net.URI;
@@ -41,6 +46,7 @@ import static fi.vm.yti.security.AuthorizationException.check;
 
 abstract class BaseResourceService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BaseResourceService.class);
     private final AuditService auditService;
 
     private final CoreRepository coreRepository;
@@ -259,5 +265,94 @@ abstract class BaseResourceService {
             openSearchIndexer.createResourceToIndex(indexClass);
         }
     }
-    
+
+    public Map<ResourceType, List<ResourceReferenceDTO>> getResourceReferences(String uri) {
+        var u = DataModelURI.fromURI(uri);
+
+        // search references for both versioned (other graphs) and non versioned (current graph) resource
+        var objects = new ArrayList<>();
+        objects.add(NodeFactory.createURI(uri));
+        if (u.getVersion() != null) {
+            objects.add(NodeFactory.createURI(u.getResourceURI()));
+        }
+
+        var user = userProvider.getUser();
+        var roles = user.getOrganizations(Role.ADMIN, Role.DATA_MODEL_EDITOR).stream()
+                .map(UUID::toString)
+                .toList();
+
+        var select = new SelectBuilder();
+        var exp = select.getExprFactory();
+
+        List.of("resource", "predicate", "type", "label", "contributor", "version")
+                .forEach(select::addVar);
+
+        try {
+            select.addPrefixes(ModelConstants.PREFIXES)
+                    .addWhereValueVar("?object", objects.toArray())
+                    .addGraph("?graph", new WhereBuilder()
+                            .addWhere("?subject", "?predicate", "?object")
+                            .addWhere("?subject", RDF.type, "?type")
+
+                            // reference as a restriction (blank node) in library class
+                            .addOptional(new WhereBuilder()
+                                    .addWhere("?restriction", "?i", "?subject")
+                                    .addWhere("?equivalent", "?e", "?restriction")
+                                    .addWhere("?classSubj", OWL.equivalentClass, "?equivalent")
+                                    .addWhere("?classSubj", RDFS.label, "?label")
+                                    .addBind("?classSubj", "?resource")
+                            )
+
+                            // reference as an object
+                            .addOptional(new WhereBuilder()
+                                    .addWhere("?subject", RDFS.label, "?label")
+                                    .addBind("?subject", "?resource")
+                            )
+                            .addWhere("?resource", RDFS.isDefinedBy, "?model")
+                            .addWhere("?model", DCTerms.contributor, "?contributor")
+                            .addOptional("?model", OWL.versionInfo, "?version")
+                    );
+        } catch (ParseException e) {
+            LOG.error(e.getMessage(), e);
+            throw new JenaQueryException("Error getting resource references: " + uri);
+        }
+
+        if (u.isDataModelURI()) {
+            select.addFilter(exp.or(
+                    exp.eq(exp.str("?graph"), u.getGraphURI()),
+                    exp.not(exp.strstarts(exp.str("?graph"), u.getModelURI()))
+            ));
+        }
+
+        var resultModel = ModelFactory.createDefaultModel();
+        resultModel.setNsPrefixes(ModelConstants.PREFIXES);
+
+        // add subjects (versioned resource URIs) as a resource to jena model
+        coreRepository.querySelect(select.build(),
+                (var row) -> mapReferencesToModel(row, user, roles, resultModel));
+
+        return ResourceMapper.mapToResourceReference(resultModel);
+    }
+
+    private static void mapReferencesToModel(QuerySolution row, YtiUser user, List<String> roles, Model resultModel) {
+        String version = row.contains("version")
+                ? row.get("version").toString()
+                : null;
+        var contributor = row.get("contributor").toString()
+                .replace(ModelConstants.URN_UUID, "");
+
+        // skip rows without label and draft resources if user has no permissions
+        if (row.get("label") == null
+            || (version == null && !user.isSuperuser() && !roles.contains(contributor))
+        ) {
+            return;
+        }
+
+        var dataModelURI = DataModelURI.fromURI(row.get("resource").toString());
+        var resource = DataModelURI.createResourceURI(dataModelURI.getModelId(), dataModelURI.getResourceId(), version);
+        resultModel.getResource(resource.getResourceVersionURI())
+                .addProperty(RDFS.label, row.get("label"))
+                .addProperty(RDF.type, row.get("type"))
+                .addProperty(DCTerms.references, row.get("predicate"));
+    }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ResourceMapperTest.java
@@ -813,4 +813,22 @@ class ResourceMapperTest {
 
         assertEquals(2, model.getResource(uri.getModelURI()).listProperties(DCTerms.requires).toList().size());
     }
+
+    @Test
+    void testMapResourceReferences() {
+        var resultModel = MapperTestUtils.getModelFromFile("/references-result.ttl");
+
+        var references = ResourceMapper.mapToResourceReference(resultModel);
+
+        var refClass = references.get(ResourceType.CLASS).get(0);
+        var refAssociation = references.get(ResourceType.ASSOCIATION).get(0);
+
+        assertEquals("https://iri.suomi.fi/model/model-1/1.0.0/class-1", refClass.getResourceURI().getUri());
+        assertEquals("rdfs:subClassOf", refClass.getProperty());
+        assertEquals("Class-fi", refClass.getResourceURI().getLabel().get("fi"));
+        assertEquals("model-1:class-1", refClass.getResourceURI().getCurie());
+
+        assertEquals("https://iri.suomi.fi/model/model-1/test-association", refAssociation.getResourceURI().getUri());
+        assertEquals("https://example.com/ns/some-property", refAssociation.getProperty());
+    }
 }

--- a/src/test/resources/references-result.ttl
+++ b/src/test/resources/references-result.ttl
@@ -1,0 +1,15 @@
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://iri.suomi.fi/model/model-1/1.0.0/class-1>
+        rdf:type            owl:Class ;
+        rdfs:label          "Class-fi"@fi , "Class-sv"@sv ;
+        dcterms:references  rdfs:subClassOf .
+
+<https://iri.suomi.fi/model/model-1/test-association>
+        rdf:type            owl:ObjectProperty ;
+        rdfs:label          "Association"@fi ;
+        dcterms:references  <https://example.com/ns/some-property> .


### PR DESCRIPTION
Find all references to particular resource. In the simplest case, the reference is added as an object to the triple where the subject is the resource uri (e.g. <http://subject> <rdfs:subClassOf> <http://reference>). In more complex one,  the reference is an object of a blank node. The structure looks like this

```
test:test-class  rdf:type    owl:Class ;
    rdfs:isDefinedBy         test: ;
    rdfs:label               "Testiluokka"@fi ;
    owl:equivalentClass      [ rdf:type            owl:Class ;
                                  owl:intersectionOf  (
                                    [ rdf:type            owl:Restriction ;
                                      owl:onProperty      test:test-association ;
                                      owl:someValuesFrom  test:test-target
                                    ]
                                  )
                              ]
```

With sparql we can find the subject (test:test-class) for an object (test:test-target):

```
SELECT ?classSubj ?label WHERE { 
  GRAPH ?graph {
    ?subject  ?predicate  test:test-target ;
    OPTIONAL { 
      ?restriction owl:intersectionOf/rdf:rest*/rdf:first ?subject .
      ?classSubj  owl:equivalentClass  ?restriction ;
        rdfs:label ?label .
    }
  }
}
```

Searching references is limited to the current graph and the versions of the other data models. 

 