### PR TITLE
YTI-3842 visualization performance

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -334,6 +334,7 @@ public class ResourceMapper {
         var indexResource = new IndexResource();
 
         indexResource.setId(resource.getURI());
+        indexResource.setUri(resource.getURI());
         indexResource.setIdentifier(resource.getLocalName());
         indexResource.setNamespace(resource.getNameSpace());
         indexResource.setIsDefinedBy(MapperUtils.propertyToString(resource, RDFS.isDefinedBy));

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -93,7 +93,7 @@ public class VisualizationService {
                 externalResources.forEach(restrictionResource -> {
                     var onProperty = MapperUtils.propertyToString(restrictionResource, OWL.onProperty);
                     var externalResource = extResult.stream()
-                            .filter(e -> e.getId().equals(onProperty) || e.getUri().equals(onProperty))
+                            .filter(e -> onProperty != null && onProperty.equals(e.getUri()))
                             .findFirst();
 
                     externalResource.ifPresent(indexResource ->


### PR DESCRIPTION
For performance, fetch model's external resources from Opensearch instead of Fuseki. Fetch single class's resources at once, not one by one.