### PR TITLE
YTI-3874 include results from draft models

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -140,6 +140,9 @@ public class ResourceQueryFactory {
         }
 
         var linkedDraftModels = new ArrayList<String>();
+
+        // Add draft models to the separate list. Draft models do not have version,
+        // published model's URI ends with version, e.g. /model/test-prefix/1.2.3/
         internalNamespaces.stream()
                 .filter(ns -> !ns.matches("(.*)\\.\\d+/$"))
                 .forEach(linkedDraftModels::add);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -35,8 +35,8 @@ class ResourceQueryFactoryTest {
         request.setTargetClass(modelURI + "TestClass");
         request.setResourceTypes(Set.of(ResourceType.ATTRIBUTE, ResourceType.ASSOCIATION));
 
-        var groupNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "groupNs/", ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/");
-        var internalNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/");
+        var groupNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "groupNs/1.0.0/", ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/1.0.0/");
+        var internalNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/1.0.0/", ModelConstants.SUOMI_FI_NAMESPACE + "draft_model/");
         var externalNamespaces = List.of("http://external-data.com/test");
 
         var allowedIncompleteDataModels = Set.of(modelURI);

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -26,7 +26,31 @@
               {
                 "terms": {
                   "versionIri": [
-                    "https://iri.suomi.fi/model/addedNs/"
+                    "https://iri.suomi.fi/model/addedNs/1.0.0/"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "terms": {
+                        "isDefinedBy": [
+                          "https://iri.suomi.fi/model/draft_model/"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "fromVersion"
+                            }
+                          }
+                        ]
+                      }
+                    }
                   ]
                 }
               },


### PR DESCRIPTION
Add new search condition if there are draft models in internal namespaces:
...
OR {
  isDefinedBy = ["draft-1", "draft-2"]
  AND
  not exists (fromVersion)
}
...

See frontend changes: https://github.com/VRK-YTI/yti-ui/pull/695