### PR TITLE
YTI-3922 default references and validation before release 

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
@@ -101,7 +100,7 @@ public class ClassController {
     })
     @GetMapping(value = "/library/{prefix}/{classIdentifier}", produces = APPLICATION_JSON_VALUE)
     public ClassInfoDTO getClass(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                 @PathVariable @Parameter(description = "Class identifier") @ValidResourceIdentifier String classIdentifier,
+                                 @PathVariable @Parameter(description = "Class identifier") String classIdentifier,
                                  @RequestParam(required = false) @Parameter(description = "Version") @ValidSemanticVersion String version) {
         return (ClassInfoDTO) classService.get(prefix, version, classIdentifier);
     }
@@ -233,7 +232,7 @@ public class ClassController {
     @Operation(summary = "Get all node shapes based on given targetClass")
     @ApiResponse(responseCode = "200", description = "List of node shapes fetched successfully")
     @GetMapping(value = "/nodeshapes", produces = APPLICATION_JSON_VALUE)
-    public Collection<IndexResourceInfo> getNodeShapes(@RequestParam @Parameter(description = "Target class") String targetClass) throws IOException {
+    public Collection<IndexResourceInfo> getNodeShapes(@RequestParam @Parameter(description = "Target class") String targetClass) {
         return classService.getNodeShapes(targetClass);
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -154,5 +156,9 @@ public class DataModelController {
         return ResponseEntity.noContent().build();
     }
 
-
+    @Operation(summary = "")
+    @GetMapping("/{prefix}/validate")
+    public ResponseEntity<Map<String, Set<UriDTO>>> validateRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
+        return ResponseEntity.ok(dataModelService.validateRelease(prefix));
+    }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -63,7 +63,12 @@ public class ClassMapper {
         nodeShapeResource.addProperty(RDF.type, SH.NodeShape);
 
         var modelResource = model.getResource(uri.getModelURI());
-        MapperUtils.addResourceRelationship(modelResource, nodeShapeResource, SH.targetClass, dto.getTargetClass());
+
+        if (dto.getTargetClass() == null && dto.getTargetNode() == null) {
+            nodeShapeResource.addProperty(SH.targetClass, OWL.Thing);
+        } else {
+            MapperUtils.addResourceRelationship(modelResource, nodeShapeResource, SH.targetClass, dto.getTargetClass());
+        }
         MapperUtils.addResourceRelationship(modelResource, nodeShapeResource, SH.node, dto.getTargetNode());
 
         MapperUtils.addTerminologyReference(dto, modelResource);
@@ -165,7 +170,10 @@ public class ClassMapper {
 
         MapperUtils.updateCommonResourceInfo(model, classResource, modelResource, nodeShapeDTO);
 
-        if (nodeShapeDTO.getTargetClass() == null) {
+        // either sh:node or sh:targetClass must be defined. If not, add owl:Thing as targetClass
+        if (nodeShapeDTO.getTargetClass() == null && nodeShapeDTO.getTargetNode() == null) {
+            classResource.addProperty(SH.targetClass, OWL.Thing);
+        } else if (nodeShapeDTO.getTargetClass() == null && nodeShapeDTO.getTargetNode() != null) {
             classResource.removeAll(SH.targetClass);
         } else {
             MapperUtils.updateUriPropertyAndAddReferenceNamespaces(modelResource, classResource, SH.targetClass, nodeShapeDTO.getTargetClass());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -66,12 +66,22 @@ public class ResourceMapper {
         var resource = MapperUtils.addCommonResourceInfo(model, uri, dto);
         var modelResource = model.getResource(uri.getModelURI());
 
-        resource.addProperty(RDF.type, SH.PropertyShape);
-        resource.addProperty(RDF.type, resourceType.equals(ResourceType.ASSOCIATION)
+        Resource typeResource = resourceType.equals(ResourceType.ASSOCIATION)
                 ? OWL.ObjectProperty
-                : OWL.DatatypeProperty);
+                : OWL.DatatypeProperty;
 
-        MapperUtils.addResourceRelationship(modelResource, resource, SH.path, dto.getPath());
+        Resource defaultPathResource = resourceType.equals(ResourceType.ASSOCIATION)
+                ? OWL2.topObjectProperty
+                : OWL2.topDataProperty;
+
+        resource.addProperty(RDF.type, SH.PropertyShape);
+        resource.addProperty(RDF.type, typeResource);
+
+        if (dto.getPath() == null) {
+            resource.addProperty(SH.path, defaultPathResource);
+        } else {
+            MapperUtils.addResourceRelationship(modelResource, resource, SH.path, dto.getPath());
+        }
         MapperUtils.addLiteral(resource, SH.minCount, dto.getMinCount());
         MapperUtils.addLiteral(resource, SH.maxCount, dto.getMaxCount());
 
@@ -171,7 +181,16 @@ public class ResourceMapper {
 
         MapperUtils.updateCommonResourceInfo(model,resource, modelResource, dto);
 
-        MapperUtils.updateUriPropertyAndAddReferenceNamespaces(modelResource, resource, SH.path, dto.getPath());
+        var defaultPathResource = MapperUtils.hasType(resource, OWL.ObjectProperty)
+                ? OWL2.topObjectProperty
+                : OWL2.topDataProperty;
+
+        if (dto.getPath() == null) {
+            resource.addProperty(SH.path, defaultPathResource);
+        } else {
+            MapperUtils.updateUriPropertyAndAddReferenceNamespaces(modelResource, resource, SH.path, dto.getPath());
+        }
+
         MapperUtils.updateLiteral(resource, SH.minCount, dto.getMinCount());
         MapperUtils.updateLiteral(resource, SH.maxCount, dto.getMaxCount());
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -331,8 +331,8 @@ public class DataModelService {
         if (MapperUtils.isApplicationProfile(model.getResource(datamodelURI.getModelURI()))) {
             var invalidResources = new ArrayList<Resource>();
             invalidResources.addAll(model.listSubjectsWithProperty(SH.targetClass, OWL.Thing).toList());
-            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL.DatatypeProperty).toList());
-            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL.ObjectProperty).toList());
+            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL2.topDataProperty).toList());
+            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL2.topObjectProperty).toList());
 
             var uriDTOs = MapperUtils.uriToURIDTOs(invalidResources.stream().map(Resource::getURI).toList(), model);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -20,10 +20,7 @@ import org.apache.jena.arq.querybuilder.ConstructBuilder;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.SimpleSelector;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.*;
@@ -38,8 +35,7 @@ import org.topbraid.shacl.vocabulary.SH;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 
@@ -325,6 +321,26 @@ public class DataModelService {
                         .addFilter(e.not(e.strstarts(e.str("?g"), graph)));
 
         coreRepository.queryUpdate(builder.buildRequest());
+    }
+
+    public Map<String, Set<UriDTO>> validateRelease(String prefix) {
+        var datamodelURI = DataModelURI.createModelURI(prefix);
+        var model = coreRepository.fetch(datamodelURI.getGraphURI());
+
+        var result = new HashMap<String, Set<UriDTO>>();
+        if (MapperUtils.isApplicationProfile(model.getResource(datamodelURI.getModelURI()))) {
+            var invalidResources = new ArrayList<Resource>();
+            invalidResources.addAll(model.listSubjectsWithProperty(SH.targetClass, OWL.Thing).toList());
+            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL.DatatypeProperty).toList());
+            invalidResources.addAll(model.listSubjectsWithProperty(SH.path, OWL.ObjectProperty).toList());
+
+            var uriDTOs = MapperUtils.uriToURIDTOs(invalidResources.stream().map(Resource::getURI).toList(), model);
+
+            if (!uriDTOs.isEmpty()) {
+                result.put("missing-reference-to-library", uriDTOs);
+            }
+        }
+        return result;
     }
 
     private void addPrefixes(Model model, DataModelDTO dto) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/PropertyShapeValidator.java
@@ -57,10 +57,6 @@ public class PropertyShapeValidator extends BaseValidator implements ConstraintV
     private void checkPath(ConstraintValidatorContext context, PropertyShapeDTO dto) {
         var path = dto.getPath();
 
-        if (path == null || path.isBlank()) {
-            addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, "path");
-        }
-
         if (path != null && !path.isBlank()
                 && !resourceService.checkIfResourceIsOneOfTypes(path, List.of(OWL.ObjectProperty, OWL.DatatypeProperty, RDF.Property))) {
             addConstraintViolation(context, "not-property-or-doesnt-exist", "path");

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
@@ -7,8 +7,10 @@ import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.OWL2;
 import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.Test;
 import org.topbraid.shacl.vocabulary.SH;
@@ -92,6 +94,15 @@ class PropertyShapeMapperTest {
         assertEquals(10, MapperUtils.getLiteral(resource, SH.maxCount, Integer.class));
         assertEquals(1, MapperUtils.getLiteral(resource, SH.minCount, Integer.class));
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestClass", MapperUtils.propertyToString(resource, SH.class_));
+
+        // should add default sh:path
+        model.removeAll(ResourceFactory.createResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/ps-1"), null, null);
+        dto.setPath(null);
+
+        ResourceMapper.mapToPropertyShapeResource(uri, model, dto, ResourceType.ASSOCIATION, mockUser);
+        resource = model.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "test/ps-1");
+
+        assertEquals(OWL2.topObjectProperty.getURI(), MapperUtils.propertyToString(resource, SH.path));
     }
 
 


### PR DESCRIPTION
Created a new endpoint `GET /model/prefix/validate`. For now, only validation rule checks that application profile has no resources without reference to core data model. Remove validation from sh:path.

Other changes
- Fix search resource query when modelType = profile (filter out all libraries from linked data models)
- Remove `@ValidResourcePrefix` annotation from get class endpoint