### PR TITLE
YTI-3849, YTI-3932 Fix node shape references

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/FrontendController.java
@@ -5,7 +5,6 @@ import fi.vm.yti.datamodel.api.v2.opensearch.dto.CountSearchResponse;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ModelSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.ResourceSearchRequest;
 import fi.vm.yti.datamodel.api.v2.opensearch.dto.SearchResponseDTO;
-import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexModel;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResourceInfo;
 import fi.vm.yti.datamodel.api.v2.service.FrontendService;

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -273,19 +273,6 @@ public class ClassMapper {
         return constructBuilder.build();
     }
 
-    public static Query getNodeShapeResourcesQuery(String nodeShapeURI) {
-        var constructBuilder = new ConstructBuilder();
-        var resourceName = "?resource";
-        var uri = NodeFactory.createURI(nodeShapeURI);
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDF.type, "?type");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.label, "?label");
-        SparqlUtils.addConstructOptional(resourceName, constructBuilder, DCTerms.identifier, "?identifier");
-        SparqlUtils.addConstructProperty(resourceName, constructBuilder, RDFS.isDefinedBy, "?isDefinedBy");
-        constructBuilder.addWhere(uri, SH.property, resourceName);
-
-        return constructBuilder.build();
-    }
-
     public static void addClassResourcesToDTO(List<IndexResource> uriResult, Set<SimpleResourceDTO> restrictions, ClassInfoDTO dto) {
         for (var restriction : restrictions) {
             var uri = DataModelURI.fromURI(restriction.getUri());

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -231,18 +231,18 @@ public class ResourceMapper {
         dto.getLanguageIn().forEach(lang -> MapperUtils.addOptionalStringProperty(resource, SH.languageIn, lang));
     }
 
-    public static void mapToCopyToLocalPropertyShape(String graphUri, Model model, String resourceIdentifier, Model targetModel, String targetGraph, String targetIdentifier, YtiUser user){
-        var resource = model.getResource(graphUri + ModelConstants.RESOURCE_SEPARATOR + resourceIdentifier);
-        var newResource = targetModel.createResource(targetGraph + ModelConstants.RESOURCE_SEPARATOR + targetIdentifier);
+    public static void mapToCopyToLocalPropertyShape(Model sourceModel, DataModelURI sourceURI, Model targetModel, DataModelURI targetURI, YtiUser user){
+        var resource = sourceModel.getResource(sourceURI.getResourceURI());
+        var newResource = targetModel.createResource(targetURI.getResourceURI());
         resource.listProperties().forEach(prop -> {
             var pred = prop.getPredicate();
             var obj = prop.getObject();
             newResource.addProperty(pred, obj);
-        }
-        );
+        });
 
-        MapperUtils.updateUriProperty(newResource, RDFS.isDefinedBy, targetGraph);
-        MapperUtils.updateLiteral(newResource, DCTerms.identifier, XSDDatatype.XSDNCName.parse(targetIdentifier));
+        MapperUtils.updateUriProperty(newResource, SuomiMeta.publicationStatus, MapperUtils.getStatusUri(Status.DRAFT));
+        MapperUtils.updateUriProperty(newResource, RDFS.isDefinedBy, targetURI.getModelURI());
+        MapperUtils.updateLiteral(newResource, DCTerms.identifier, XSDDatatype.XSDNCName.parse(targetURI.getResourceId()));
 
         newResource.removeAll(DCTerms.modified);
         newResource.removeAll(DCTerms.created);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -143,7 +143,7 @@ public class ResourceQueryFactory {
 
         // Add draft models to the separate list. Draft models do not have version,
         // published model's URI ends with version, e.g. /model/test-prefix/1.2.3/
-        internalNamespaces.stream()
+        internalNamespacesCondition.stream()
                 .filter(ns -> !ns.matches("(.*)\\.\\d+/$"))
                 .forEach(linkedDraftModels::add);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -77,8 +77,7 @@ public class ResourceQueryFactory {
     }
 
     public static SearchRequest createResourceQuery(ResourceSearchRequest request,
-                                                    List<String> externalNamespaces,
-                                                    List<String> internalNamespaces) {
+                                                    List<String> externalNamespaces) {
         var must = new ArrayList<Query>();
         var should = new ArrayList<Query>();
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ResourceService.java
@@ -254,18 +254,6 @@ public class ResourceService extends BaseResourceService {
         return !coreRepository.queryAsk(askBuilder.build());
     }
 
-    public Resource findResource(String uri, Set<String> graphsIncluded) {
-        if (uri == null) {
-            return null;
-        }
-        var resourceURI = DataModelURI.fromURI(uri).getResourceURI();
-        var result = findResources(Set.of(resourceURI), graphsIncluded).getResource(resourceURI);
-        if (result.listProperties().hasNext()) {
-            return result;
-        }
-        return null;
-     }
-
      public Set<String> findNodeShapeExternalProperties(String graphURI, Resource resourceType) {
          var externalResources = new HashSet<String>();
          if (resourceType == null) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/SearchIndexService.java
@@ -49,14 +49,13 @@ public class SearchIndexService {
      * Search resources with the same keyword that was used to search a model
      * @return response containing resources
      */
-    private SearchResponseDTO<IndexResource> getMatchingResources(ModelSearchRequest request, YtiUser user) {
+    private SearchResponseDTO<IndexResource> getMatchingResources(ModelSearchRequest request) {
         var resourceSearchRequest = new ResourceSearchRequest();
         // use the same query string for resources that was used for models
         resourceSearchRequest.setQuery(request.getQuery());
 
         var resourceQuery = ResourceQueryFactory.createResourceQuery(
                 resourceSearchRequest,
-                Collections.emptyList(),
                 Collections.emptyList());
         return client.search(resourceQuery, IndexResource.class);
     }
@@ -71,9 +70,8 @@ public class SearchIndexService {
         }
 
         // if we were provided a search string, let's search for resources with the same string
-        SearchResponseDTO<IndexResource> resources = null;
         if (searchRequest.getQuery() != null && !searchRequest.getQuery().isBlank()) {
-            resources = this.getMatchingResources(searchRequest, user);
+            SearchResponseDTO<IndexResource> resources = this.getMatchingResources(searchRequest);
 
             // now let's add those matching models to the model search request
             searchRequest.setAdditionalModelIds(resources
@@ -97,7 +95,7 @@ public class SearchIndexService {
         // if we were provided a search string, let's search for resources with the same string
         SearchResponseDTO<IndexResource> resources = null;
         if (request.getQuery() != null && !request.getQuery().isBlank()) {
-            resources = this.getMatchingResources(request, user);
+            resources = this.getMatchingResources(request);
 
             // now let's add those matching models to the model search request
             request.setAdditionalModelIds(resources

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.topbraid.shacl.vocabulary.SH;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/PropertyShapeMapperTest.java
@@ -225,14 +225,16 @@ class PropertyShapeMapperTest {
 
     @Test
     void testMapToCopyToLocalPropertyShape(){
-        var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
-        var newModel = ModelFactory.createDefaultModel();
+        var sourceModel = MapperTestUtils.getModelFromFile("/models/test_datamodel_profile_with_resources.ttl");
+        var targetModel = ModelFactory.createDefaultModel();
 
-        ResourceMapper.mapToCopyToLocalPropertyShape(ModelConstants.SUOMI_FI_NAMESPACE + "test", model, "DeactivatedPropertyShape", newModel, ModelConstants.SUOMI_FI_NAMESPACE + "new", "NewShape", EndpointUtils.mockUser);
+        var source = DataModelURI.createResourceURI("test", "DeactivatedPropertyShape");
+        var target = DataModelURI.createResourceURI("new", "NewShape");
+        ResourceMapper.mapToCopyToLocalPropertyShape(sourceModel, source, targetModel, target, EndpointUtils.mockUser);
 
-        var resource = newModel.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "new/NewShape");
+        var resource = targetModel.getResource(ModelConstants.SUOMI_FI_NAMESPACE + "new/NewShape");
         assertEquals("NewShape", resource.getProperty(DCTerms.identifier).getLiteral().getString());
-        assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "new", MapperUtils.propertyToString(resource, RDFS.isDefinedBy));
+        assertEquals(target.getModelURI(), MapperUtils.propertyToString(resource, RDFS.isDefinedBy));
         assertTrue(MapperUtils.hasType(resource, OWL.DatatypeProperty, SH.PropertyShape));
         assertEquals("deactivated property shape", MapperUtils.localizedPropertyToMap(resource, RDFS.label).get("fi"));
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ResourceQueryFactoryTest.java
@@ -39,7 +39,7 @@ class ResourceQueryFactoryTest {
         var internalNamespaces = List.of(ModelConstants.SUOMI_FI_NAMESPACE + "addedNs/1.0.0/", ModelConstants.SUOMI_FI_NAMESPACE + "draft_model/");
         var externalNamespaces = List.of("http://external-data.com/test");
 
-        var allowedIncompleteDataModels = Set.of(modelURI);
+        var allowedIncompleteDataModels = Set.of(modelURI, ModelConstants.SUOMI_FI_NAMESPACE + "draft_model/");
 
         var classQuery = ResourceQueryFactory.createInternalResourceQuery(request, externalNamespaces, internalNamespaces,
                 groupNamespaces, allowedIncompleteDataModels);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -2,10 +2,7 @@ package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
-import fi.vm.yti.datamodel.api.v2.dto.ClassDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.NodeShapeDTO;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
@@ -38,7 +35,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.net.URISyntaxException;
-import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -83,6 +79,8 @@ class ClassServiceTest {
     @Autowired
     ClassService classService;
 
+    Consumer<ResourceInfoBaseDTO> conceptMapper = (resource) -> {};
+
     @Test
     void getLibraryClass() {
         var model = ModelFactory.createDefaultModel();
@@ -98,7 +96,7 @@ class ClassServiceTest {
 
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(model);
-        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+        when(terminologyService.mapConcept()).thenReturn(conceptMapper);
         when(searchIndexService.findResourcesByURI(anySet(), eq(null))).thenReturn(new SearchResponseDTO<>());
 
         classService.get(resourceURI.getModelId(), null, resourceURI.getResourceId());
@@ -125,7 +123,7 @@ class ClassServiceTest {
 
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(model);
-        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+        when(terminologyService.mapConcept()).thenReturn(conceptMapper);
         when(searchIndexService.findResourcesByURI(anySet(), anyString())).thenReturn(new SearchResponseDTO<>());
         when(searchIndexService.findResourcesByURI(anySet(), eq(null))).thenReturn(new SearchResponseDTO<>());
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -1,6 +1,5 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
-import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
@@ -90,7 +89,7 @@ class ResourceServiceTest {
     void get() {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(EndpointUtils.getMockModel(OWL.Ontology));
-        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+        when(terminologyService.mapConcept()).thenReturn(conceptMapper);
 
         try(var mapper = mockStatic(ResourceMapper.class)) {
             resourceService.get("test", null, "TestResource");
@@ -108,7 +107,7 @@ class ResourceServiceTest {
     void getWithVersion() {
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.fetch(anyString())).thenReturn(EndpointUtils.getMockModel(OWL.Ontology));
-        when(terminologyService.mapConcept()).thenReturn(mock(Consumer.class));
+        when(terminologyService.mapConcept()).thenReturn(conceptMapper);
 
         try(var mapper = mockStatic(ResourceMapper.class)) {
             resourceService.get("test", "1.0.1", "TestResource");

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -250,19 +250,21 @@ class ResourceServiceTest {
         verify(coreRepository).resourceExistsInGraph(anyString(), anyString());
         verify(coreRepository).resourceExistsInGraph(anyString(), anyString(), eq(false));
         verify(coreRepository, times(2)).fetch(anyString());
-        verify(authorizationManager, times(2)).hasRightToModel(anyString(), any(Model.class));
+        verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
     }
 
     @Test
     void failCopyPropertyShapeNotExists() {
+        when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         assertThrows(ResourceNotFoundException.class, () -> resourceService.copyPropertyShape("test", "Identifier", "newTest", "newId"));
     }
 
     @Test
     void failCopyPropertyShapeIdInUse() {
+        when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
         when(coreRepository.resourceExistsInGraph(anyString(), anyString())).thenReturn(true);
         when(coreRepository.resourceExistsInGraph(anyString(), anyString(), eq(false))).thenReturn(true);
-        var error = assertThrows(MappingError.class, () ->resourceService.copyPropertyShape("test", "Identifier", "newTest", "newId"));
+        var error = assertThrows(MappingError.class, () -> resourceService.copyPropertyShape("test", "Identifier", "newTest", "newId"));
         assertEquals("Error during mapping: Identifier in use", error.getMessage());
 
     }

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -31,30 +31,6 @@
                 }
               },
               {
-                "bool": {
-                  "must": [
-                    {
-                      "terms": {
-                        "isDefinedBy": [
-                          "https://iri.suomi.fi/model/draft_model/"
-                        ]
-                      }
-                    },
-                    {
-                      "bool": {
-                        "must_not": [
-                          {
-                            "exists": {
-                              "field": "fromVersion"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              },
-              {
                 "terms": {
                   "id": []
                 }
@@ -64,7 +40,10 @@
         },
         {
           "terms": {
-            "resourceType": ["ASSOCIATION", "ATTRIBUTE"]
+            "resourceType": [
+              "ATTRIBUTE",
+              "ASSOCIATION"
+            ]
           }
         },
         {
@@ -79,7 +58,8 @@
         {
           "terms": {
             "isDefinedBy": [
-              "https://iri.suomi.fi/model/test/"
+              "https://iri.suomi.fi/model/test/",
+              "https://iri.suomi.fi/model/draft_model/"
             ]
           }
         },
@@ -99,6 +79,7 @@
       ]
     }
   },
+  "size": 100,
   "sort": [
     {
       "label.en.keyword": {

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -46,14 +46,14 @@ test:TestClass  rdf:type     sh:NodeShape ;
         rdfs:comment         "test technical description fi"@fi, "test technical description en"@en ;
         suomi-meta:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
-        sh:property          <https://iri.suomi.fi/model/test/TestPropertyShape> , <https://iri.suomi.fi/model/test/DeactivatedPropertyShape> ;
+        sh:property          <https://iri.suomi.fi/model/test/TestAttributeRestriction> , <https://iri.suomi.fi/model/test/DeactivatedPropertyShape> ;
         sh:targetClass       <https://iri.suomi.fi/model/target/Class> .
 
 test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;
         rdf:type             owl:DatatypeProperty ;
         rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
+        dcterms:identifier   "TestAttributeRestriction"^^xsd:NCName ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;
@@ -77,7 +77,7 @@ test:TestAssociationRestriction  rdf:type  sh:PropertyShape ;
         rdf:type             owl:ObjectProperty ;
         rdfs:isDefinedBy     <https://iri.suomi.fi/model/test/> ;
         dcterms:subject      <http://uri.suomi.fi/terminology/test/test1> ;
-        dcterms:identifier   "TestPropertyShape"^^xsd:NCName ;
+        dcterms:identifier   "TestAssociationRestriction"^^xsd:NCName ;
         dcterms:created      "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         dcterms:modified     "2023-02-03T11:46:36.404Z"^^xsd:dateTime ;
         rdfs:label           "test property shape"@fi ;


### PR DESCRIPTION
### Node shape references
Split mapping node shape properties: 
- properties in the same model, get them from model already fetched
- external properties, fetched from OpenSearch
- setting property restrictions (inherited from sh:node reference / is property deactivated)

### Other fixes
- Create a local copy (missing source property shape version)
- Handle linked draft models
- Better unit tests for creating and getting class / node shape
- Fix sonar errors and remove unused code / method parameters