### PR TITLE
YTI-3940 Add api path for node shapes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -30,7 +30,8 @@ public class ModelConstants {
             "xsd", "http://www.w3.org/2001/XMLSchema#",
             "suomi-meta", "https://iri.suomi.fi/model/suomi-meta/",
             "skos", "http://www.w3.org/2004/02/skos/core#",
-            "sh", "http://www.w3.org/ns/shacl#"
+            "sh", "http://www.w3.org/ns/shacl#",
+            "http", "http://www.w3.org/2011/http#"
     );
     public static final List<String> SUPPORTED_DATA_TYPES = List.of(
             "http://www.w3.org/2002/07/owl#rational",

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeDTO.java
@@ -6,6 +6,7 @@ public class NodeShapeDTO extends BaseDTO {
     private String targetClass;
     private String targetNode;
     private Set<String> properties;
+    private String apiPath;
 
     public String getTargetNode() {
         return targetNode;
@@ -29,5 +30,13 @@ public class NodeShapeDTO extends BaseDTO {
 
     public void setTargetClass(String targetClass) {
         this.targetClass = targetClass;
+    }
+
+    public String getApiPath() {
+        return apiPath;
+    }
+
+    public void setApiPath(String apiPath) {
+        this.apiPath = apiPath;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/NodeShapeInfoDTO.java
@@ -8,6 +8,7 @@ public class NodeShapeInfoDTO extends ResourceInfoBaseDTO {
     private UriDTO targetNode;
     private List<SimplePropertyShapeDTO> attribute = new ArrayList<>();
     private List<SimplePropertyShapeDTO> association = new ArrayList<>();
+    private String apiPath;
 
     public UriDTO getTargetClass() {
         return targetClass;
@@ -39,5 +40,13 @@ public class NodeShapeInfoDTO extends ResourceInfoBaseDTO {
 
     public void setAssociation(List<SimplePropertyShapeDTO> association) {
         this.association = association;
+    }
+
+    public String getApiPath() {
+        return apiPath;
+    }
+
+    public void setApiPath(String apiPath) {
+        this.apiPath = apiPath;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -3,6 +3,7 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
+import fi.vm.yti.datamodel.api.v2.properties.HTTP;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import fi.vm.yti.datamodel.api.v2.utils.SparqlUtils;
@@ -70,7 +71,7 @@ public class ClassMapper {
             MapperUtils.addResourceRelationship(modelResource, nodeShapeResource, SH.targetClass, dto.getTargetClass());
         }
         MapperUtils.addResourceRelationship(modelResource, nodeShapeResource, SH.node, dto.getTargetNode());
-
+        MapperUtils.addOptionalStringProperty(nodeShapeResource, HTTP.API_PATH, dto.getApiPath());
         MapperUtils.addTerminologyReference(dto, modelResource);
     }
 
@@ -187,7 +188,7 @@ public class ClassMapper {
 
         classResource.removeAll(SH.property);
         mapNodeShapeProperties(model, classResource.getURI(), properties);
-
+        MapperUtils.updateStringProperty(classResource, HTTP.API_PATH, nodeShapeDTO.getApiPath());
         MapperUtils.addUpdateMetadata(classResource, user);
     }
 
@@ -238,7 +239,7 @@ public class ClassMapper {
                 MapperUtils.propertyToString(nodeShapeResource, SH.targetClass), model));
         dto.setTargetNode(MapperUtils.uriToURIDTO(
                 MapperUtils.propertyToString(nodeShapeResource, SH.node), model));
-
+        dto.setApiPath(MapperUtils.propertyToString(nodeShapeResource, HTTP.API_PATH));
         return dto;
     }
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/properties/HTTP.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/properties/HTTP.java
@@ -1,0 +1,13 @@
+package fi.vm.yti.datamodel.api.v2.properties;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class HTTP {
+
+    private HTTP() {
+        // property class
+    }
+    public static final Property API_PATH =
+            ResourceFactory.createProperty("http://www.w3.org/2011/http#absolutePath");
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/NodeShapeValidator.java
@@ -36,6 +36,7 @@ public class NodeShapeValidator extends BaseValidator implements
         checkReservedIdentifier(context, nodeShapeDTO);
         checkTargetClass(context, nodeShapeDTO);
         checkTargetNode(context, nodeShapeDTO);
+        checkCommonTextField(context, nodeShapeDTO.getApiPath(), "apiPath");
 
         return !isConstraintViolationAdded();
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -6,6 +6,7 @@ import fi.vm.yti.datamodel.api.v2.endpoint.error.MappingError;
 import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
 import fi.vm.yti.datamodel.api.v2.opensearch.index.IndexResource;
+import fi.vm.yti.datamodel.api.v2.properties.HTTP;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -44,6 +45,7 @@ class NodeShapeMapperTest {
         dto.setLabel(Map.of("fi", "test label"));
         dto.setNote(Map.of("fi", "test note"));
         dto.setTargetClass(ModelConstants.SUOMI_FI_NAMESPACE + "target/Class");
+        dto.setApiPath("/api/path/");
 
         var uri = DataModelURI.createResourceURI("test", "TestClass");
         ClassMapper.createNodeShapeAndMapToModel(uri, model, dto, mockUser);
@@ -91,6 +93,7 @@ class NodeShapeMapperTest {
                 propertyShapeAttribute.getProperty(SH.path).getObject().toString());
         assertEquals(Status.DRAFT, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(propertyShapeAttribute, SuomiMeta.publicationStatus)));
         assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));
+        assertEquals("/api/path/", MapperUtils.propertyToString(classResource, HTTP.API_PATH));
     }
 
     @Test
@@ -116,6 +119,7 @@ class NodeShapeMapperTest {
         assertEquals(MapperTestUtils.TEST_ORG_ID.toString(), dto.getContributor().stream().findFirst().orElseThrow().getId());
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/TestClass", dto.getUri());
         assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "target/Class"), dto.getTargetClass());
+        assertEquals("/api/path/", dto.getApiPath());
     }
 
     @Test

--- a/src/test/resources/models/test_datamodel_profile_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_profile_with_resources.ttl
@@ -8,7 +8,7 @@
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#>
 @prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
-
+@prefix http:    <http://www.w3.org/2011/http#> .
 
 <https://iri.suomi.fi/model/test/>
 a                               suomi-meta:ApplicationProfile , owl:Ontology ;
@@ -47,6 +47,7 @@ test:TestClass  rdf:type     sh:NodeShape ;
         suomi-meta:creator          "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         suomi-meta:modifier         "2a5c075f-0d0e-4688-90e0-29af1eebbf6d" ;
         sh:property          <https://iri.suomi.fi/model/test/TestAttributeRestriction> , <https://iri.suomi.fi/model/test/DeactivatedPropertyShape> ;
+        http:absolutePath    "/api/path/" ;
         sh:targetClass       <https://iri.suomi.fi/model/target/Class> .
 
 test:TestAttributeRestriction  rdf:type  sh:PropertyShape ;


### PR DESCRIPTION
- Add new property API path for node shape, stored to the property `http://www.w3.org/2011/http#absolutePath` as in old application
- Created new property class HTTP because the property is not available in Jena