### PR TITLE
YTI-3903 update linked models

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -36,6 +36,8 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 
@@ -110,7 +112,33 @@ public class DataModelService {
 
         terminologyService.resolveTerminology(dto.getTerminologies());
         codeListService.resolveCodelistScheme(dto.getCodeLists());
+
+        var modelResource = model.getResource(graphUri);
+
+        var oldNamespaces = DataModelUtils.getInternalReferenceModels(modelResource).stream()
+                .map(DataModelURI::fromURI)
+                .toList();
+        var newNamespaces = dto.getInternalNamespaces().stream()
+                .map(DataModelURI::fromURI)
+                .toList();
+
         mapper.mapToUpdateJenaModel(graphUri, dto, model, userProvider.getUser());
+
+        // check if version of some dependency model has changed
+        var versionChangedNamespaces = new HashMap<String, String>();
+        newNamespaces.forEach(newNS -> oldNamespaces.stream()
+                .filter(oldNS -> oldNS.isSameModel(newNS))
+                .findFirst()
+                .ifPresent(oldNS -> versionChangedNamespaces.put(oldNS.getGraphURI(), newNS.getGraphURI()))
+        );
+
+        // rename old namespace with the new one, all references will be updated to new version
+        handleNamespaceVersionChange(model, versionChangedNamespaces);
+
+        // check if dependency model with references is removed,
+        // removing is not allowed if there are any references to the namespace being removed
+        handleNamespaceRemove(model, newNamespaces, oldNamespaces, versionChangedNamespaces);
+
         addPrefixes(model, dto);
 
         coreRepository.put(graphUri, model);
@@ -345,5 +373,89 @@ public class DataModelService {
 
     private void addPrefixes(Model model, DataModelDTO dto) {
         dto.getExternalNamespaces().forEach(ns -> model.getGraph().getPrefixMapping().setNsPrefix(ns.getPrefix(), ns.getNamespace()));
+    }
+
+    private static void handleNamespaceRemove(Model model,
+                                               List<DataModelURI> newNamespaces,
+                                               List<DataModelURI> oldNamespaces,
+                                               HashMap<String, String> versionChangedNamespaces) {
+        Set<String> removedNamespaces = new HashSet<>();
+        if (newNamespaces.isEmpty()) {
+            removedNamespaces = oldNamespaces.stream()
+                    .map(DataModelURI::getGraphURI)
+                    .collect(Collectors.toSet());
+        } else if (!oldNamespaces.isEmpty()) {
+            oldNamespaces.stream()
+                    .filter(oldNs -> !newNamespaces.contains(oldNs)
+                                     && !versionChangedNamespaces.containsKey(oldNs.getGraphURI()))
+                    .map(DataModelURI::getGraphURI)
+                    .forEach(removedNamespaces::add);
+        }
+
+        // throw an error if there are references to removed linked model
+        removedNamespaces.forEach(removed -> {
+            var stmtList = model.listStatements()
+                    .filterDrop(s -> s.getObject().toString().equals(removed))
+                    .filterKeep(objectHasNamespace(removed))
+                    .toList();
+
+            if (!stmtList.isEmpty()) {
+                throw new MappingError(getNamespaceRemoveErrorMessage(model, stmtList));
+            }
+        });
+    }
+
+    private static void handleNamespaceVersionChange(Model model, HashMap<String, String> versionChangedNamespaces) {
+        versionChangedNamespaces.forEach((oldNS, newNS) -> {
+            var stmtList = model.listStatements()
+                    // need to drop triple "subj owl:imports <newNs>" because otherwise it will be removed when changing from draft to published version
+                    .filterDrop(s -> s.getObject().toString().equals(newNS))
+                    .filterKeep(objectHasNamespace(oldNS))
+                    .toList();
+
+            stmtList.forEach(s -> {
+                var newStatement = ResourceFactory.createStatement(
+                        s.getSubject(),
+                        s.getPredicate(),
+                        ResourceFactory.createResource(newNS + s.getObject().asResource().getLocalName())
+                );
+                model.add(newStatement);
+            });
+            model.remove(stmtList);
+        });
+    }
+
+    private static String getNamespaceRemoveErrorMessage(Model model, List<Statement> stmtList) {
+        var resources = stmtList.stream()
+                .limit(5)
+                .map(s -> {
+                    var subj = s.getSubject();
+                    if (subj.isAnon()) {
+                        while (subj.isAnon()) {
+                            var stmt = model.listStatements(null, null, subj).next();
+                            subj = stmt.getSubject();
+                        }
+                        return subj.getURI();
+                    } else {
+                        return subj.getURI();
+                    }
+                })
+                .collect(Collectors.toSet());
+
+        var message = new StringBuilder("Cannot remove namespace, because it has existing references: ")
+                .append(String.join(", ", resources));
+        if (stmtList.size() > 5) {
+            message.append(" ... ")
+                    .append(stmtList.size() - 5)
+                    .append(" other resources");
+        }
+        return message.toString();
+    }
+
+    private static Predicate<Statement> objectHasNamespace(String ns) {
+        return stmt -> {
+            var s = stmt.getObject();
+            return s.isResource() && s.toString().startsWith(ns);
+        };
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -132,7 +132,7 @@ public class DataModelService {
                 .ifPresent(oldNS -> versionChangedNamespaces.put(oldNS.getGraphURI(), newNS.getGraphURI()))
         );
 
-        // rename old namespace with the new one, all references will be updated to new version
+        // change version of the dependency model, all references will be updated to new version
         handleNamespaceVersionChange(model, versionChangedNamespaces);
 
         // check if dependency model with references is removed,

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURI.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelURI.java
@@ -4,6 +4,7 @@ import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.shared.PrefixMapping;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 public class DataModelURI {
@@ -189,5 +190,26 @@ public class DataModelURI {
 
     public boolean isTerminologyURI() {
         return this.namespace.startsWith(ModelConstants.TERMINOLOGY_NAMESPACE);
+    }
+
+    public boolean isSameModel(DataModelURI other) {
+        if (other == null) {
+            return false;
+        }
+        return Objects.equals(other.getModelId(), this.getModelId())
+                && !Objects.equals(other.getVersion(), this.getVersion());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataModelURI that = (DataModelURI) o;
+        return Objects.equals(modelId, that.modelId) && Objects.equals(resourceId, that.resourceId) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelId, resourceId, version);
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/utils/DataModelUtils.java
@@ -50,10 +50,17 @@ public class DataModelUtils {
         );
     }
 
+    public static Set<String> getInternalReferenceModels(Resource modelResource) {
+        return getInternalReferenceModels(null, modelResource);
+    }
+
     public static Set<String> getInternalReferenceModels(String versionUri, Resource modelResource) {
         var includedNamespaces = MapperUtils.arrayPropertyToSet(modelResource, OWL.imports);
         includedNamespaces.addAll(MapperUtils.arrayPropertyToSet(modelResource, DCTerms.requires));
-        includedNamespaces.add(versionUri);
+
+        if (versionUri != null) {
+            includedNamespaces.add(versionUri);
+        }
 
         return includedNamespaces.stream()
                 .filter(ns -> ns.startsWith(ModelConstants.SUOMI_FI_NAMESPACE))

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -492,7 +492,14 @@ class DataModelServiceTest {
 
         // error message should contain linked resources
         assertTrue(error.getMessage().contains(resourceURI.getResourceURI()));
+
+        // linked model without any references should get removed
+        dto.setInternalNamespaces(Set.of(linkedResourceURI_1.getGraphURI()));
+        dataModelService.update(prefix, dto);
+
+        verify(coreRepository).put(anyString(), any(Model.class));
     }
+
     private Predicate<RDFNode> containsReferences(String ns) {
         return (var o) -> o.isResource() && o.asResource().getNameSpace().equals(ns);
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -16,9 +16,7 @@ import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.AuthorizationException;
 import fi.vm.yti.security.YtiUser;
 import org.apache.jena.query.Query;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
@@ -37,6 +35,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -363,6 +362,139 @@ class DataModelServiceTest {
         assertEquals(1, errors.size());
         assertEquals("incomplete resource", error.getLabel().get("en"));
         assertEquals("https://iri.suomi.fi/model/test/incomplete", error.getUri());
+    }
+
+    @Test
+    void changeLinkedModelVersions() {
+        var resourceURI = DataModelURI.createResourceURI("test", "class-1");
+        var linkedResourceURI_1 = DataModelURI.createResourceURI("linked", "link-1", "1.0.0");
+        var linkedResourceURI_2 = DataModelURI.createResourceURI("linked", "link-1", "2.0.0");
+        var linkedResourceURI_3 = DataModelURI.createResourceURI("foo", "bar-1", "1.0.0");
+        var model = ModelFactory.createDefaultModel();
+        var prefix = resourceURI.getModelId();
+
+        // create model with one class with some references to other models' classes
+        model.createResource(resourceURI.getModelURI())
+                .addProperty(RDF.type, OWL.Ontology)
+                .addProperty(OWL.imports, ResourceFactory.createResource(linkedResourceURI_1.getGraphURI()));
+
+        model.createResource(resourceURI.getResourceURI())
+                .addProperty(RDFS.subClassOf, ResourceFactory.createResource(linkedResourceURI_1.getResourceVersionURI()))
+                .addProperty(OWL.disjointWith, ResourceFactory.createResource(linkedResourceURI_3.getResourceVersionURI()));
+
+        when(coreRepository.fetch(resourceURI.getGraphURI())).thenReturn(model);
+        when(authorizationManager.hasRightToModel(eq(prefix), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(EndpointUtils.mockUser);
+
+        var dto = new DataModelDTO();
+        var resourceSubject = ResourceFactory.createResource(resourceURI.getResourceURI());
+        var modelSubject = ResourceFactory.createResource(resourceURI.getModelURI());
+
+        // should change references to version 2.0.0
+        dto.setInternalNamespaces(Set.of(linkedResourceURI_2.getGraphURI()));
+
+        dataModelService.update(prefix, dto);
+
+        // rdfs:subClassOf -> version 2.0.0
+        assertTrue(model.contains(
+                resourceSubject,
+                RDFS.subClassOf,
+                ResourceFactory.createResource(linkedResourceURI_2.getResourceVersionURI())));
+
+        // references to other models should not change
+        assertTrue(model.contains(
+                resourceSubject,
+                OWL.disjointWith,
+                ResourceFactory.createResource(linkedResourceURI_3.getResourceVersionURI())));
+
+        // owl:imports -> version 2.0.0
+        assertTrue(model.contains(
+                modelSubject,
+                OWL.imports,
+                ResourceFactory.createResource(linkedResourceURI_2.getGraphURI())));
+
+        // model doesn't contain any references to version 1.0.0
+        assertTrue(model.listObjects().toList().stream()
+                .noneMatch(containsReferences(linkedResourceURI_1.getGraphURI())));
+
+        // change reference to draft version
+        dto.setInternalNamespaces(Set.of(linkedResourceURI_2.getDraftGraphURI()));
+        dataModelService.update(prefix, dto);
+
+        // rdfs:subClassOf -> draft version (without version number)
+        assertTrue(model.contains(
+                resourceSubject,
+                RDFS.subClassOf,
+                ResourceFactory.createResource(linkedResourceURI_2.getResourceURI())));
+
+        assertTrue(model.contains(
+                resourceSubject,
+                OWL.disjointWith,
+                ResourceFactory.createResource(linkedResourceURI_3.getResourceVersionURI())));
+
+        assertTrue(model.contains(
+                modelSubject,
+                OWL.imports,
+                ResourceFactory.createResource(linkedResourceURI_2.getDraftGraphURI())));
+
+        // model doesn't contain any references to version 2.0.0
+        assertTrue(model.listObjects().toList().stream()
+                .noneMatch(containsReferences(linkedResourceURI_2.getGraphURI())));
+
+        // change back to version 1.0.0
+        dto.setInternalNamespaces(Set.of(linkedResourceURI_1.getGraphURI()));
+        dataModelService.update(prefix, dto);
+
+        assertTrue(model.contains(
+                resourceSubject,
+                RDFS.subClassOf,
+                ResourceFactory.createResource(linkedResourceURI_1.getResourceVersionURI())));
+
+        assertTrue(model.contains(
+                resourceSubject,
+                OWL.disjointWith,
+                ResourceFactory.createResource(linkedResourceURI_3.getResourceVersionURI())));
+
+        assertTrue(model.contains(
+                modelSubject,
+                OWL.imports,
+                ResourceFactory.createResource(linkedResourceURI_1.getGraphURI())));
+
+        // model doesn't contain any references to draft version
+        assertTrue(model.listObjects().toList().stream()
+                .noneMatch(containsReferences(linkedResourceURI_1.getDraftGraphURI())));
+    }
+
+    @Test
+    void testRemoveLinkedNamespace() {
+        var resourceURI = DataModelURI.createResourceURI("test", "class-1");
+        var linkedResourceURI_1 = DataModelURI.createResourceURI("linked", "link-1", "1.0.0");
+        var linkedNsWithoutReferences = DataModelURI.createModelURI("foo", "1.0.0").getGraphURI();
+        var model = ModelFactory.createDefaultModel();
+        var prefix = resourceURI.getModelId();
+
+        model.createResource(resourceURI.getModelURI())
+                .addProperty(RDF.type, OWL.Ontology)
+                .addProperty(OWL.imports, ResourceFactory.createResource(linkedResourceURI_1.getGraphURI()))
+                .addProperty(OWL.imports, ResourceFactory.createResource(linkedNsWithoutReferences));
+
+        model.createResource(resourceURI.getResourceURI())
+                .addProperty(RDFS.subClassOf, ResourceFactory.createResource(linkedResourceURI_1.getResourceVersionURI()));
+
+        when(coreRepository.fetch(resourceURI.getGraphURI())).thenReturn(model);
+        when(authorizationManager.hasRightToModel(eq(prefix), any(Model.class))).thenReturn(true);
+        when(userProvider.getUser()).thenReturn(EndpointUtils.mockUser);
+
+        var dto = new DataModelDTO();
+        dto.setInternalNamespaces(Set.of(linkedNsWithoutReferences));
+
+        var error = assertThrows(MappingError.class, () -> dataModelService.update(prefix, dto));
+
+        // error message should contain linked resources
+        assertTrue(error.getMessage().contains(resourceURI.getResourceURI()));
+    }
+    private Predicate<RDFNode> containsReferences(String ns) {
+        return (var o) -> o.isResource() && o.asResource().getNameSpace().equals(ns);
     }
 
     /**


### PR DESCRIPTION
If the version of dependency model is changed, all references (e.g. subClassOf) to the resources of that model will be updated to new version. Removing dependency model with any references will cause a validation error. 