### PR TITLE
YTI-3999 Fix setting hidden node's origin

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -13,6 +13,7 @@ public class ModelConstants {
     public static final String CODELIST_NAMESPACE = "http://uri.suomi.fi/codelist/";
     public static final String TERMINOLOGY_NAMESPACE = "http://uri.suomi.fi/terminology/";
     public static final String MODEL_POSITIONS_NAMESPACE = "https://iri.suomi.fi/model-positions/";
+    public static final String CORNER_PREFIX = "corner-";
     public static final String SUOMI_FI_DOMAIN = "uri.suomi.fi";
 
     public static final String RESOURCE_SEPARATOR = "/";

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
@@ -105,7 +105,7 @@ abstract class BaseResourceService {
 
     public boolean exists(String prefix, String identifier) {
         // identifiers e.g. corner-abcd1234 are reserved for visualization
-        if(identifier.startsWith("corner-")) {
+        if(identifier.startsWith(ModelConstants.CORNER_PREFIX)) {
             return true;
         }
         var uri = DataModelURI.createResourceURI(prefix, identifier);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
 import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.Status;
 import jakarta.validation.ConstraintValidatorContext;
 
@@ -82,7 +83,7 @@ public abstract class BaseValidator implements Annotation{
     }
 
     public void checkReservedIdentifier(ConstraintValidatorContext context, BaseDTO dto) {
-        if (dto.getIdentifier() != null && dto.getIdentifier().startsWith("corner-")) {
+        if (dto.getIdentifier() != null && dto.getIdentifier().startsWith(ModelConstants.CORNER_PREFIX)) {
             addConstraintViolation(context, "reserved-identifier", "identifier");
         }
     }


### PR DESCRIPTION
In following scenario:

![yti-3999](https://github.com/VRK-YTI/yti-datamodel-api/assets/16885816/cf4189b8-072f-4e1c-aeb0-7a2e566a7372)

When determining path from CLASS-2 to CLASS-1, we start checking which nodes have CLASS-1 as their reference target. The result is CLASS-2 and C1 (hidden node) and in some cases we might get the wrong node (in this case hidden node C1).

Fixed this by checking hidden nodes' path and comparing the staring point to the source node identifier.