### PR TITLE
YTI-3939 Fixes to checking if resource exists

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/ReleaseValidationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/ReleaseValidationService.java
@@ -7,6 +7,8 @@ import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import fi.vm.yti.datamodel.api.v2.validator.release.LibraryReferenceValidator;
 import fi.vm.yti.datamodel.api.v2.validator.release.ReferencesExistsValidator;
 import fi.vm.yti.datamodel.api.v2.validator.release.ReleaseValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -15,6 +17,9 @@ import static fi.vm.yti.security.AuthorizationException.check;
 
 @Service
 public class ReleaseValidationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReleaseValidationService.class);
+
     private final CoreRepository coreRepository;
     private final AuthorizationManager authorizationManager;
     private final List<ReleaseValidator> validators = new ArrayList<>();
@@ -36,12 +41,16 @@ public class ReleaseValidationService {
 
         check(authorizationManager.hasRightToModel(prefix, model));
 
-        validators.forEach(validator -> {
-            var validateResult = validator.validate(model);
-            if (!validateResult.isEmpty()) {
-                result.put(validator.getErrorKey(), validateResult);
-            }
-        });
+        try {
+            validators.forEach(validator -> {
+                var validateResult = validator.validate(model);
+                if (!validateResult.isEmpty()) {
+                    result.put(validator.getErrorKey(), validateResult);
+                }
+            });
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
 
         return result;
     }


### PR DESCRIPTION
- skip checking graph references (owl:imports and dcterms:requires)
- add exception handling so release is possible to create despite unhandled exception in the validation