### PR TITLE
add simple json schema support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,10 @@ dependencies {
     implementation "org.apache.jena:jena-querybuilder:4.6.1"
     implementation "com.google.guava:guava:31.1-jre"
 
+    // library for programmatically generating json schema
+    // NOTE: the project is in maintenance mode
+    implementation "com.github.erosb:everit-json-schema:1.14.4"
+
     compileOnly "org.springframework.boot:spring-boot-configuration-processor"
     compileOnly "org.jetbrains:annotations:23.0.0"
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ExportController.java
@@ -34,7 +34,7 @@ public class ExportController {
             @ApiResponse(responseCode = "404", description = "Model or Resource not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
     })
     @GetMapping(value = {"{prefix}", "/{prefix}/{resourceIdentifier}"},
-            produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8", "application/vnd+oai+openapi+json;charset=utf-8"})
+            produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8", "application/vnd+oai+openapi+json;charset=utf-8", "application/schema+json"})
     public ResponseEntity<String> export(@PathVariable @Parameter(description = "Data model prefix") String prefix,
                                          @RequestParam(required = false) @Parameter(description = "Version") @ValidSemanticVersion String version,
                                          @RequestParam(required = false) @Parameter(description = "Content type") String contentType,

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -220,6 +220,10 @@ public class DataModelService {
                 fileExtension = ".json";
                 OpenAPIBuilder.export(stringWriter, exportedModel, language);
                 break;
+            case "application/schema+json":
+                fileExtension = ".json";
+                JSONSchemaBuilder.export(stringWriter, exportedModel, language);
+                break;
             case "application/ld+json":
             default:
                 RDFDataMgr.write(stringWriter, exportedModel, Lang.JSONLD);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
@@ -1,0 +1,209 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.mapper.ClassMapper;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.everit.json.schema.*;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.topbraid.shacl.vocabulary.SH;
+
+import java.io.StringWriter;
+import java.util.Map;
+
+public class JSONSchemaBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClassMapper.class);
+
+    private enum SchemaType {
+        UNKNOWN,
+        BOOLEAN,
+        NUMBER,
+        INTEGER,
+        STRING
+    }
+
+    private static final Map<String, SchemaType> TYPE_MAP = Map.ofEntries(
+            Map.entry("http://www.w3.org/2001/XMLSchema#boolean", SchemaType.BOOLEAN),
+            Map.entry("http://www.w3.org/2002/07/owl#real", SchemaType.NUMBER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#double", SchemaType.NUMBER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#float", SchemaType.NUMBER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#decimal", SchemaType.NUMBER),
+            Map.entry("http://www.w3.org/2002/07/owl#rational", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#byte", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#int", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#integer", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#long", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#negativeInteger", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#nonNegativeInteger", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#nonPositiveInteger", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#positiveInteger", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#short", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#unsignedByte", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#unsignedInt", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#unsignedLong", SchemaType.INTEGER),
+            Map.entry("http://www.w3.org/2001/XMLSchema#unsignedShort", SchemaType.INTEGER)
+    );
+
+    private JSONSchemaBuilder() {
+    }
+
+    public static void export(StringWriter stringWriter, Model model, String language) {
+        var modelSubj = model.listSubjectsWithProperty(RDF.type, SuomiMeta.ApplicationProfile);
+        if (!modelSubj.hasNext()) {
+            logger.error("No model found");
+            return;
+        }
+
+        var modelResource = model.getResource(modelSubj.next().getURI());
+
+        final var lang = language == null
+                ? ModelConstants.DEFAULT_LANGUAGE
+                : language;
+
+        var schemaBuilder = ObjectSchema.builder();
+        schemaBuilder.description(getLocalizedValue(modelResource, RDFS.comment, language));
+        schemaBuilder.title(getLocalizedValue(modelResource, RDFS.label, language));
+
+        var nodeShapes = model.listSubjectsWithProperty(RDF.type, SH.NodeShape);
+        nodeShapes.forEach(nodeShape -> {
+            var schema = getNodeShapeSchema(nodeShape, model, lang);
+            schemaBuilder.addPropertySchema(nodeShape.getLocalName(), schema);
+        });
+
+        var jsonSchema = new JSONObject(schemaBuilder.build().toString());
+        stringWriter.write(jsonSchema.toString(4));
+    }
+
+    private static ObjectSchema getNodeShapeSchema(Resource nodeShape, Model model, String language) {
+        var schemaBuilder = ObjectSchema.builder();
+        schemaBuilder.description(getLocalizedValue(nodeShape, RDFS.comment, language));
+        schemaBuilder.title(getLocalizedValue(nodeShape, RDFS.label, language));
+
+        handlePropertyShapes(schemaBuilder, nodeShape, model, language);
+        return schemaBuilder.build();
+    }
+
+    private static void handlePropertyShapes(
+            ObjectSchema.Builder schemaBuilder,
+            Resource nodeShape,
+            Model model,
+            String language) {
+
+        var deactivated = model.listSubjectsWithProperty(SH.deactivated)
+                .mapWith(Resource::getURI)
+                .toList();
+
+        nodeShape.listProperties(SH.property).forEach(p -> {
+            var propertyURI = p.getObject().toString();
+            var propertyResource = model.getResource(propertyURI);
+
+            if (deactivated.contains(propertyURI) ||
+                    !propertyResource.listProperties().hasNext()) {
+                return;
+            }
+
+            var propertySchema = MapperUtils.hasType(propertyResource, OWL.DatatypeProperty)
+                    ? handleAttribute(propertyResource, language)
+                    : handleAssociation(model, propertyResource, language);
+
+            schemaBuilder.addPropertySchema(
+                    propertyResource.getLocalName(),
+                    propertySchema);
+        });
+    }
+
+    private static Schema handleAssociation(
+            Model model,
+            Resource propertyResource,
+            String language) {
+
+        var description = getLocalizedValue(propertyResource, RDFS.comment, language);
+        var title = getLocalizedValue(propertyResource, RDFS.label, language);
+
+        Resource targetClass = null;
+        var maxCount = MapperUtils.getLiteral(propertyResource, SH.maxCount, Integer.class);
+        var shClass = MapperUtils.propertyToString(propertyResource, SH.class_);
+
+        if (shClass != null) {
+            var target = model.listSubjectsWithProperty(SH.targetClass, shClass);
+            targetClass = target.hasNext() ? target.next() : null;
+        }
+
+        BooleanSchema referredSchema = BooleanSchema.builder().build();
+
+        ReferenceSchema subject = ReferenceSchema.builder()
+                .refValue(getRef(targetClass))
+                .build();
+        subject.setReferredSchema(EmptySchema.builder().build());
+
+        if (maxCount != null && maxCount > 0) {
+            ArraySchema schema = ArraySchema.builder()
+                    .addItemSchema(subject)
+                    .description(description)
+                    .title(title)
+                    .build();
+            return schema;
+        } else {
+            return subject;
+        }
+    }
+
+    private static Schema handleAttribute(
+            Resource propertyResource,
+            String language) {
+        var description = getLocalizedValue(propertyResource, RDFS.comment, language);
+        var title = getLocalizedValue(propertyResource, RDFS.label, language);
+        var type = getDatatype(MapperUtils.propertyToString(propertyResource, SH.datatype));
+        switch (type) {
+            case NUMBER, INTEGER:
+                return NumberSchema.builder()
+                        .description(description)
+                        .title(title)
+                        .build();
+            case STRING:
+                return StringSchema.builder()
+                        .description(description)
+                        .title(title)
+                        .build();
+            case BOOLEAN:
+                return BooleanSchema.builder()
+                        .description(description)
+                        .title(title)
+                        .build();
+            default:
+                return ObjectSchema.builder()
+                        .description(description)
+                        .title(title)
+                        .build();
+        }
+    }
+
+    private static String getLocalizedValue(Resource resource, Property property, String language) {
+        var value = MapperUtils.localizedPropertyToMap(resource, property);
+        if (value.isEmpty()) {
+            return "";
+        }
+        var key = value.containsKey(language) ? language : value.keySet().iterator().next();
+        return value.get(key);
+    }
+
+    private static String getRef(Resource pathResource) {
+        return "/properties/" + pathResource.getLocalName();
+    }
+
+    private static SchemaType getDatatype(String typeURI) {
+        if (typeURI == null) {
+            return SchemaType.UNKNOWN;
+        }
+        return TYPE_MAP.getOrDefault(typeURI, SchemaType.STRING);
+    }
+}

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
@@ -1,6 +1,9 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
 import org.junit.jupiter.api.Test;
@@ -21,8 +24,50 @@ public class JSONSchemaTest {
 
         var expected = MapperTestUtils.getJsonString("/json-schema-expected.json");
 
-        System.out.println(writer);
-
         JSONAssert.assertEquals(expected, writer.toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    void testJSONSchemaValidationSuccess() throws ValidationException {
+        var model = MapperTestUtils.getModelFromFile("/json-schema-data.ttl");
+        var writer = new StringWriter();
+        JSONSchemaBuilder.export(writer, model, "en");
+
+        var schema = SchemaLoader.load(new JSONObject(writer.toString()));
+        var jsonToValidate = new JSONObject("""
+{
+  "class-1": {
+    "property-1": ["Test"],
+    "property-2": 4,
+    "property-3": [{}]
+  }
+}
+""");
+
+        schema.validate(jsonToValidate);
+    }
+
+    @Test
+    void testJSONSchemaValidationFailure() throws ValidationException {
+        var model = MapperTestUtils.getModelFromFile("/json-schema-data.ttl");
+        var writer = new StringWriter();
+        JSONSchemaBuilder.export(writer, model, "en");
+
+        var schema = SchemaLoader.load(new JSONObject(writer.toString()));
+        var jsonToValidate = new JSONObject("""
+{
+  "class-1": {
+    "property-1": [42],
+    "property-2": "invalid-number",
+    "property-3": {}
+  }
+}
+""");
+        try {
+            schema.validate(jsonToValidate);
+            throw new RuntimeException("Validation should have failed");
+        } catch (ValidationException e) {
+            // expected
+        }
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
@@ -1,0 +1,28 @@
+package fi.vm.yti.datamodel.api.v2.service;
+
+import fi.vm.yti.datamodel.api.index.OpenSearchUtils;
+import org.skyscreamer.jsonassert.JSONAssert;
+import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.io.*;
+import java.util.stream.Collectors;
+
+public class JSONSchemaTest {
+
+    @Test
+    void testJSONSchemaGeneration() throws Exception {
+        var model = MapperTestUtils.getModelFromFile("/json-schema-data.ttl");
+        var writer = new StringWriter();
+        JSONSchemaBuilder.export(writer, model, "en");
+
+        var expected = MapperTestUtils.getJsonString("/json-schema-expected.json");
+
+        System.out.println(writer);
+
+        JSONAssert.assertEquals(expected, writer.toString(), JSONCompareMode.LENIENT);
+    }
+}

--- a/src/test/resources/json-schema-data.ttl
+++ b/src/test/resources/json-schema-data.ttl
@@ -1,0 +1,53 @@
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix test:       <https://iri.suomi.fi/model/test/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix http:       <http://www.w3.org/2011/http#> .
+
+test:property-1  rdf:type   owl:DatatypeProperty ;
+        rdfs:label          "Property label"@en ;
+        dcterms:identifier  "property-1" ;
+        sh:datatype         "http://www.w3.org/2001/XMLSchema#string" ;
+        sh:in               "02" , "01" ;
+        sh:minCount         "1"^^xsd:long .
+
+test:class-2  rdf:type      sh:NodeShape ;
+        rdfs:label          "Target node"@en ;
+        dcterms:identifier  "class-2" ;
+        sh:targetClass      "https://iri.suomi.fi/model/test_lib/2.0.0/class-2" .
+
+test:property-4  rdf:type   owl:ObjectProperty ;
+        dcterms:identifier  "property-3" ;
+        sh:deactivated      true .
+
+test:property-2  rdf:type   owl:DatatypeProperty ;
+        rdfs:label          "Property label 2"@en ;
+        dcterms:identifier  "property-2" ;
+        sh:datatype         "http://www.w3.org/2001/XMLSchema#integer" ;
+        sh:maxCount         "5"^^xsd:long .
+
+test:class-1  rdf:type      sh:NodeShape ;
+        rdfs:comment        "Property shape info"@en ;
+        rdfs:label          "Node shape label"@en ;
+        dcterms:identifier  "class-1" ;
+        http:absolutePath   "/path/{var1}/{var2}?q=123" ;
+        sh:property         test:property-4 , test:property-3 , test:property-2 , test:property-1 .
+
+test:   rdf:type         suomi-meta:ApplicationProfile ;
+        rdfs:comment     "Model info"@en ;
+        rdfs:label       "Model label"@en ;
+        dcap:preferredXMLNamespacePrefix
+                "test" ;
+        owl:versionIRI   "https://iri.suomi.fi/model/test/1.0.0/" ;
+        owl:versionInfo  "1.0.0" .
+
+test:property-3  rdf:type   owl:ObjectProperty ;
+        rdfs:label          "Property label 3"@en ;
+        dcterms:identifier  "property-3" ;
+        sh:class            "https://iri.suomi.fi/model/test_lib/2.0.0/class-2" ;
+        sh:maxCount         "2"^^xsd:long .

--- a/src/test/resources/json-schema-expected.json
+++ b/src/test/resources/json-schema-expected.json
@@ -14,9 +14,11 @@
       "title": "Node shape label",
       "properties": {
         "property-1": {
+          "minItems": 1,
           "description": "",
-          "type": "string",
-          "title": "Property label"
+          "type": "array",
+          "title": "Property label",
+          "items": {"type": "string"}
         },
         "property-3": {
           "description": "",

--- a/src/test/resources/json-schema-expected.json
+++ b/src/test/resources/json-schema-expected.json
@@ -22,7 +22,7 @@
           "description": "",
           "type": "array",
           "title": "Property label 3",
-          "items": [{"$ref": "/properties/class-2"}]
+          "items": [{"$ref": "#/properties/class-2"}]
         },
         "property-2": {
           "description": "",

--- a/src/test/resources/json-schema-expected.json
+++ b/src/test/resources/json-schema-expected.json
@@ -1,0 +1,35 @@
+{
+  "description": "Model info",
+  "type": "object",
+  "title": "Model label",
+  "properties": {
+    "class-2": {
+      "description": "",
+      "type": "object",
+      "title": "Target node"
+    },
+    "class-1": {
+      "description": "Property shape info",
+      "type": "object",
+      "title": "Node shape label",
+      "properties": {
+        "property-1": {
+          "description": "",
+          "type": "string",
+          "title": "Property label"
+        },
+        "property-3": {
+          "description": "",
+          "type": "array",
+          "title": "Property label 3",
+          "items": [{"$ref": "/properties/class-2"}]
+        },
+        "property-2": {
+          "description": "",
+          "type": "number",
+          "title": "Property label 2"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/open-api-data.ttl
+++ b/src/test/resources/open-api-data.ttl
@@ -31,7 +31,7 @@ test:class-2  rdf:type      sh:NodeShape ;
 
 test:class-3  rdf:type      sh:NodeShape ;
         rdfs:label          "Target node"@en ;
-        dcterms:identifier  "class-2" ;
+        dcterms:identifier  "class-3" ;
         sh:targetClass      "https://iri.suomi.fi/model/test_lib/2.0.0/class-3" .
 
 test:property-1  rdf:type   owl:DatatypeProperty ;


### PR DESCRIPTION
Added json schema export using the org.everit.json.schema library.

This library doesn't support the latest draft, and is in maintenance mode, so it might not be the final solution.