### PR TITLE
YTI-4042 Remove datamodels

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -4,6 +4,7 @@ import fi.vm.yti.datamodel.api.v2.dto.DataModelDTO;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
 import fi.vm.yti.datamodel.api.v2.dto.ModelType;
 import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -60,7 +61,7 @@ public class DataModelValidator extends BaseValidator implements
         // Check prefix text content
         checkPrefixContent(context, prefix, prefixPropertyLabel, false);
 
-        if (coreRepository.graphExists(ModelConstants.SUOMI_FI_NAMESPACE + prefix)) {
+        if (coreRepository.graphExists(DataModelURI.createModelURI(prefix).getGraphURI())) {
             // Checking if in use is different for data models and its resources so it is not in the above function
             addConstraintViolation(context, "prefix-in-use", prefixPropertyLabel);
         }


### PR DESCRIPTION
Allow removing draft data models if:
- there are no published versions (draft version)
- there are no references to the model (owl:imports / dcterms:requires)

Normal user can remove only draft version if conditions above are true. Super user can remove also published versions if there are no references to them. When removing versioned models, `owl:priorVersion` information is updated.

Other bug fix: fix checking if graph exists (add missing trailing slash)