### PR TITLE
YTI-4030 Fix orphan blank nodes

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -522,7 +522,9 @@ public class ClassMapper {
             String onProperty = MapperUtils.propertyToString(rdfNode.asResource(), OWL.onProperty);
             var someValuesFrom = MapperUtils.propertyToString(rdfNode.asResource(), OWL.someValuesFrom);
 
-            if (propertyResource.getURI().equals(onProperty) && (
+            // check that removed is still null, because in migrated data there might be more than one
+            // association with the same uri and target
+            if (removed == null && propertyResource.getURI().equals(onProperty) && (
                     MapperUtils.hasType(propertyResource, OWL.DatatypeProperty, OWL.AnnotationProperty)
                     || Objects.equals(target, someValuesFrom))
             ) {


### PR DESCRIPTION
If there are more than one association with the same id (uri) and target, it will cause an issue when it is removed. This should not be any issue in the new application but migrated data may contain this kind of data.