### PR TITLE
YTI-4025 Add origin to visualization data

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
@@ -40,8 +40,7 @@ public class V15_VisualizationAddOrigin implements MigrationTask {
                    filter strstarts(str(?g), "https://iri.suomi.fi/model/")
                 }
                 """;
-        // TODO: uncomment when doing migration
-        // repository.querySelect(graphsQuery, row -> graphs.add(row.get("g").toString()));
+        repository.querySelect(graphsQuery, row -> graphs.add(row.get("g").toString()));
 
         for (var graph : graphs) {
             LOG.info("Migrating visualization for {}", graph);
@@ -100,9 +99,6 @@ public class V15_VisualizationAddOrigin implements MigrationTask {
             model.setNsPrefixes(ModelConstants.PREFIXES);
 
             var targetGraph = getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion());
-
-            // store in test graph at first?
-            // targetGraph = targetGraph.replace("iri.suomi.fi/model-positions/", "iri.suomi.fi/model-positions-test/");
 
             repository.put(targetGraph, model);
         }

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
@@ -1,0 +1,250 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.visualization.*;
+import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.mapper.VisualizationMapper;
+import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.datamodel.api.v2.service.VisualizationService;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
+import fi.vm.yti.migration.MigrationTask;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.DCTerms;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@SuppressWarnings("java:S101")
+@Component
+public class V15_VisualizationAddOrigin implements MigrationTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(V15_VisualizationAddOrigin.class);
+    private final CoreRepository repository;
+    private final VisualizationService visualizationService;
+
+    public V15_VisualizationAddOrigin(CoreRepository repository,
+                                      VisualizationService visualizationService) {
+        this.repository = repository;
+        this.visualizationService = visualizationService;
+    }
+
+    @Override
+    public void migrate() {
+        var graphs = new ArrayList<String>();
+        String graphsQuery = """
+                select * where { graph ?g {}
+                   filter strstarts(str(?g), "https://iri.suomi.fi/model/")
+                }
+                """;
+        // TODO: uncomment when doing migration
+        // repository.querySelect(graphsQuery, row -> graphs.add(row.get("g").toString()));
+
+        for (var graph : graphs) {
+            LOG.info("Migrating visualization for {}", graph);
+
+            var dataModelURI = DataModelURI.fromURI(graph);
+            VisualizationResultDTO visuData;
+            Model positions;
+            try {
+                visuData = visualizationService.getVisualizationData(dataModelURI.getModelId(), dataModelURI.getVersion());
+                positions = repository.fetch(getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion()));
+            } catch (Exception e) {
+                LOG.info("No visualization data for graph {}", dataModelURI.getModelURI());
+                continue;
+            }
+
+            // backup old data
+            var backUpGraph = getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion())
+                    .replace("iri.suomi.fi/model-positions/", "iri.suomi.fi/model-positions-backup/");
+            repository.put(backUpGraph, positions);
+
+            var hiddenNodes = mapPathAndCreateHiddenNodes(positions, visuData.getNodes());
+
+            visuData.setHiddenNodes(hiddenNodes);
+
+            // construct visualization payload using old implementation
+            var positionData = new ArrayList<PositionDataDTO>();
+            visuData.getNodes().forEach(n -> {
+                var position = getPositionData(n.getIdentifier(), n.getPosition());
+                var targets = new HashSet<PositionDataDTO.ReferenceTarget>();
+
+                if (n instanceof VisualizationClassDTO classDTO) {
+                    classDTO.getAssociations().forEach(r -> {
+                        if (r.getReferenceTarget() != null && r.getReferenceTarget().startsWith(ModelConstants.CORNER_PREFIX)) {
+                            targets.add(new PositionDataDTO.ReferenceTarget(r.getReferenceTarget(), r.getIdentifier()));
+                        }
+                    });
+                }
+                n.getReferences().forEach(r -> {
+                    if (r.getReferenceTarget() != null && r.getReferenceTarget().startsWith(ModelConstants.CORNER_PREFIX)) {
+                        targets.add(new PositionDataDTO.ReferenceTarget(r.getReferenceTarget(), r.getIdentifier()));
+                    }
+                });
+                position.setReferenceTargets(targets);
+
+                positionData.add(position);
+            });
+
+            visuData.getHiddenNodes().forEach(n -> {
+                var position = getPositionData(n.getIdentifier(), n.getPosition());
+                position.setReferenceTargets(Set.of(new PositionDataDTO.ReferenceTarget(n.getReferenceTarget(), n.getOrigin())));
+                positionData.add(position);
+            });
+
+            var model = VisualizationMapper.mapPositionDataToModel(
+                    getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion()),  positionData);
+            model.setNsPrefixes(ModelConstants.PREFIXES);
+
+            var targetGraph = getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion());
+
+            // store in test graph at first?
+            // targetGraph = targetGraph.replace("iri.suomi.fi/model-positions/", "iri.suomi.fi/model-positions-test/");
+
+            repository.put(targetGraph, model);
+        }
+    }
+
+    private static PositionDataDTO getPositionData(String identifier, PositionDTO position) {
+        var positionDTO = new PositionDataDTO();
+        positionDTO.setIdentifier(identifier);
+        positionDTO.setX(roundPosition(position.getX()));
+        positionDTO.setY(roundPosition(position.getY()));
+
+        return positionDTO;
+    }
+    public static Set<VisualizationHiddenNodeDTO> mapPathAndCreateHiddenNodes(
+            Model positions, Set<VisualizationNodeDTO> classes) {
+        var hiddenElements = new HashSet<VisualizationHiddenNodeDTO>();
+
+        var handledElements = new HashSet<String>();
+
+        classes.forEach(dto -> {
+
+            // check if there are hidden nodes between parent relations
+            if (dto.getReferences() != null && !dto.getReferences().isEmpty()) {
+                dto.getReferences().forEach(reference -> {
+                    var path = handlePath(positions, dto.getIdentifier(), reference, hiddenElements, handledElements);
+                    reference.setReferenceTarget(path.get(0));
+                });
+            }
+
+            if (dto instanceof VisualizationClassDTO classDTO) {
+                // check if there are hidden nodes between association relations
+                classDTO.getAssociations().forEach(reference -> {
+                    var target = reference.getReferenceTarget();
+                    if (target != null) {
+                        var path = handlePath(positions, dto.getIdentifier(), reference, hiddenElements, handledElements);
+                        reference.setReferenceTarget(path.get(0));
+                    }
+                });
+            }
+        });
+        return hiddenElements;
+    }
+
+    private static List<String> handlePath(Model positions, String sourceIdentifier, VisualizationReferenceDTO reference,
+                                           Set<VisualizationHiddenNodeDTO> hiddenElements, Set<String> handledElements) {
+
+        var positionResources = positions.listSubjectsWithProperty(SuomiMeta.referenceTarget, reference.getReferenceTarget()).toList();
+        for (Resource positionResource : positionResources) {
+            var path = new LinkedList<String>();
+            while (positionResource.hasProperty(SuomiMeta.referenceTarget)) {
+                var identifier = MapperUtils.propertyToString(positionResource, DCTerms.identifier);
+
+                if (shouldSkip(positions, sourceIdentifier, handledElements, identifier)) {
+                    break;
+                } else if (sourceIdentifier.equals(identifier)) {
+                    // reached the source node
+                    if (path.isEmpty()) {
+                        path.add(reference.getReferenceTarget());
+                    }
+                    return path;
+                }
+
+                handledElements.add(positionResource.getLocalName());
+
+                path.addFirst(positionResource.getLocalName());
+                hiddenElements.add(mapHiddenNode(positionResource, reference, sourceIdentifier));
+
+                var references = positions.listSubjectsWithProperty(SuomiMeta.referenceTarget, positionResource.getLocalName()).toList();
+
+                // no more references found, return path
+                // should not happen as each hidden node should have references
+                // and otherwise should have returned earlier
+                if (references.isEmpty()) {
+                    return path;
+                }
+
+                // assume, that there is only one reference for hidden nodes
+                positionResource = references.get(0);
+            }
+        }
+        // no hidden nodes between source and target
+        return List.of(reference.getReferenceTarget());
+    }
+
+    private static boolean shouldSkip(Model positions, String sourceIdentifier, Set<String> handledElements, String identifier) {
+        if (identifier == null) {
+            return true;
+        } else if (!identifier.startsWith(ModelConstants.CORNER_PREFIX) && !identifier.equals(sourceIdentifier)) {
+            // if there is an element in the path, that is not a hidden node and not the same as source node,
+            // this is the wrong path. Jump to the next resource
+            return true;
+        } else if (handledElements.contains(identifier)) {
+            // already handled
+            return true;
+        } else if (identifier.startsWith(ModelConstants.CORNER_PREFIX)) {
+            // find starting point of hidden node, it should equal to sourceIdentifier
+            var i = identifier;
+            while (i.startsWith(ModelConstants.CORNER_PREFIX)) {
+                var s = positions.listSubjectsWithProperty(SuomiMeta.referenceTarget, i).next();
+                i = s.getLocalName();
+            }
+            return !i.equals(sourceIdentifier);
+        }
+        return false;
+    }
+
+    private static VisualizationHiddenNodeDTO mapHiddenNode(Resource position, VisualizationReferenceDTO reference, String sourceIdentifier) {
+        var dto = new VisualizationHiddenNodeDTO();
+
+        dto.setIdentifier(MapperUtils.propertyToString(position, DCTerms.identifier));
+        dto.setPosition(getPositionFromResource(position));
+        dto.setReferenceTarget(MapperUtils.propertyToString(position, SuomiMeta.referenceTarget));
+        dto.setReferenceType(reference.getReferenceType());
+
+        if (reference.getReferenceType().equals(VisualizationReferenceType.ASSOCIATION)) {
+            dto.setOrigin(reference.getIdentifier());
+        } else {
+            dto.setOrigin(sourceIdentifier);
+        }
+
+        return dto;
+    }
+
+    private static PositionDTO getPositionFromResource(Resource positionResource) {
+        var x = MapperUtils.getLiteral(positionResource, SuomiMeta.posX, Double.class);
+        var y = MapperUtils.getLiteral(positionResource, SuomiMeta.posY, Double.class);
+        return new PositionDTO(roundPosition(x), roundPosition(y));
+    }
+
+    private static Double roundPosition(Double p) {
+        if (p != null) {
+            return (double) (Math.round(p / 10) * 10);
+        }
+        return 0.0;
+    }
+
+    private String getPositionGraphURI(String prefix, String version) {
+        var positionURI = ModelConstants.MODEL_POSITIONS_NAMESPACE + prefix;
+        if (version != null) {
+            positionURI += "/" + version;
+        }
+        positionURI += "/";
+        return positionURI;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V15_VisualizationAddOrigin.java
@@ -56,11 +56,6 @@ public class V15_VisualizationAddOrigin implements MigrationTask {
                 continue;
             }
 
-            // backup old data
-            var backUpGraph = getPositionGraphURI(dataModelURI.getModelId(), dataModelURI.getVersion())
-                    .replace("iri.suomi.fi/model-positions/", "iri.suomi.fi/model-positions-backup/");
-            repository.put(backUpGraph, positions);
-
             var hiddenNodes = mapPathAndCreateHiddenNodes(positions, visuData.getNodes());
 
             visuData.setHiddenNodes(hiddenNodes);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/PositionDataDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/visualization/PositionDataDTO.java
@@ -6,7 +6,7 @@ public class PositionDataDTO {
     private String identifier;
     private Double x;
     private Double y;
-    private Set<String> referenceTargets;
+    private Set<ReferenceTarget> referenceTargets = Set.of();
 
     public String getIdentifier() {
         return identifier;
@@ -32,11 +32,13 @@ public class PositionDataDTO {
         this.y = y;
     }
 
-    public Set<String> getReferenceTargets() {
+    public Set<ReferenceTarget> getReferenceTargets() {
         return referenceTargets;
     }
 
-    public void setReferenceTargets(Set<String> referenceTargets) {
+    public void setReferenceTargets(Set<ReferenceTarget> referenceTargets) {
         this.referenceTargets = referenceTargets;
     }
+
+    public record ReferenceTarget(String target, String origin) {}
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/VisualizationMapper.java
@@ -285,13 +285,24 @@ public class VisualizationMapper {
             while (positionSubject.hasProperty(SuomiMeta.referenceTarget)) {
                 var identifier = MapperUtils.propertyToString(positionSubject, DCTerms.identifier);
 
+                // if there is an element in the path, that is not a hidden node and not the same as source node,
+                // this is the wrong path. Jump to the next resource
+                if (identifier != null
+                        && !identifier.startsWith(ModelConstants.CORNER_PREFIX)
+                        && !sourceIdentifier.equals(identifier)) {
+                    break;
+                }
+
                 // reached the source node
                 if (sourceIdentifier.equals(identifier)) {
                     return path;
                 }
 
                 path.addFirst(positionSubject.getLocalName());
-                hiddenElements.add(mapHiddenNode(positionSubject, reference, sourceIdentifier));
+
+                if (positionSubject.getLocalName().startsWith(ModelConstants.CORNER_PREFIX)) {
+                    hiddenElements.add(mapHiddenNode(positionSubject, reference, sourceIdentifier));
+                }
 
                 var references = positions.listSubjectsWithProperty(SuomiMeta.target, positionSubject.getLocalName()).toList();
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
@@ -26,4 +26,6 @@ public class SuomiMeta {
     public static final Property posX = ResourceFactory.createProperty(URI, "posX");
     public static final Property posY = ResourceFactory.createProperty(URI, "posY");
     public static final Property referenceTarget = ResourceFactory.createProperty(URI, "referenceTarget");
+    public static final Property target = ResourceFactory.createProperty(URI, "target");
+    public static final Property origin = ResourceFactory.createProperty(URI, "origin");
 }

--- a/src/test/resources/positions.ttl
+++ b/src/test/resources/positions.ttl
@@ -1,12 +1,15 @@
 @prefix dcterms:    <http://purl.org/dc/terms/> .
-@prefix suomi-meta:        <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
 @prefix visuprof:   <https://iri.suomi.fi/model-positions/visuprof/> .
 
 visuprof:person
         dcterms:identifier      "person" ;
         suomi-meta:posX                "1.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
         suomi-meta:posY                "2.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
-        suomi-meta:referenceTarget     "corner-1" .
+        suomi-meta:referenceTarget     [
+                                            suomi-meta:target  "corner-1" ;
+                                            suomi-meta:origin  "is-address" ;
+                                       ].
 
 visuprof:address
         dcterms:identifier      "address" ;
@@ -17,4 +20,7 @@ visuprof:corner-1
         dcterms:identifier      "corner-1" ;
         suomi-meta:posX                "6.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
         suomi-meta:posY                "7.0"^^<http://www.w3.org/2001/XMLSchema#double> ;
-        suomi-meta:referenceTarget     "address" .
+        suomi-meta:referenceTarget     [
+                                           suomi-meta:target  "address" ;
+                                           suomi-meta:origin  "is-address" ;
+                                       ].


### PR DESCRIPTION
Store origin of the line to each corner node. When determining the path from source node to target node, check that each corner node has correct origin and ending point of the line matches the source node.

Created a migration script for modifying old data to new format.

Old data with only information of the corner id
```
test:person
        dcterms:identifier      "person" ;
        suomi-meta:posX                "1.0"^^xsd:double ;
        suomi-meta:posY                "2.0"^^xsd:double ;
        suomi-meta:referenceTarget     "corner-1" .

test:address
        dcterms:identifier      "address" ;
        suomi-meta:posX                "10.0"^^xsd:double;
        suomi-meta:posY                "20.0"^^xsd:double .

test:corner-1
        dcterms:identifier      "corner-1" ;
        suomi-meta:posX                "6.0"^^xsd:double ;
        suomi-meta:posY                "7.0"^^xsd:double;
        suomi-meta:referenceTarget     "address" .
```

New data with target id and origin (association)
```
test:person
        dcterms:identifier      "person" ;
        suomi-meta:posX                "1.0"^^xsd:double ;
        suomi-meta:posY                "2.0"^^xsd:double> ;
        suomi-meta:referenceTarget     [
                                            suomi-meta:target  "corner-1" ;
                                            suomi-meta:origin  "is-address" ;
                                       ].

test:address
        dcterms:identifier      "address" ;
        suomi-meta:posX                "10.0"^^xsd:double ;
        suomi-meta:posY                "20.0"^^xsd:double .

test:corner-1
        dcterms:identifier      "corner-1" ;
        suomi-meta:posX                "6.0"^^xsd:double ;
        suomi-meta:posY                "7.0"^^xsd:double ;
        suomi-meta:referenceTarget     [
                                           suomi-meta:target  "address" ;
                                           suomi-meta:origin  "is-address" ;
                                       ].
```