### PR TITLE
use mock SNS service when running as "docker" profile

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/sns/MockSnsService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/sns/MockSnsService.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-@Profile({"junit", "local"})
+@Profile({"junit", "local", "docker"})
 public class MockSnsService implements SnsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MockSnsService.class);


### PR DESCRIPTION
Local development containers were trying to use the full SNS service, causing errors:

```
yti-datamodel-api                      | ***************************
yti-datamodel-api                      | APPLICATION FAILED TO START
yti-datamodel-api                      | ***************************
yti-datamodel-api                      |
yti-datamodel-api                      | Description:
yti-datamodel-api                      |
yti-datamodel-api                      | Parameter 2 of constructor in fi.vm.yti.datamodel.api.v2.service.DataModelSubscriptionService required a bean of type 'fi.vm.yti.datamodel.api.v2.service.s
ns.SnsService' that could not be found.
yti-datamodel-api                      |
yti-datamodel-api                      |
yti-datamodel-api                      | Action:
yti-datamodel-api                      |
yti-datamodel-api                      | Consider defining a bean of type 'fi.vm.yti.datamodel.api.v2.service.sns.SnsService' in your configuration.
yti-datamodel-api                      |
```

As a fix, I added the "docker" profile for `MockSnsService`.