### PR TITLE
YTI-4106 Add new namespace 

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/StartUpListener.java
@@ -44,11 +44,11 @@ public class StartUpListener {
     public void contextInitialized() {
         logger.info("System is starting ...");
 
-        initDefaultNamespaces();
         initOrganizations();
         initUsers();
         initServiceCategories();
         initOpenSearchIndices();
+        initDefaultNamespaces();
     }
 
     private void initOrganizations() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -59,6 +59,9 @@ public class NamespaceResolver {
     public boolean resolveNamespace(String namespace){
         logger.info("Resolving namespace: {}", namespace);
         var model = ModelFactory.createDefaultModel();
+
+        // resolvable URI is different from graph name
+        var resolvableURI = NamespaceService.DEFAULT_NAMESPACE_RESOLVABLE_URIS.getOrDefault(namespace, namespace);
         try{
             var accept = String.join(", ", ACCEPT_TYPES);
 
@@ -67,7 +70,7 @@ public class NamespaceResolver {
                 accept = "application/ld+json";
             }
             RDFParser.create()
-                    .source(namespace)
+                    .source(resolvableURI)
                     .lang(Lang.RDFXML)
                     .acceptHeader(accept)
                     .parse(model);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceService.java
@@ -44,7 +44,13 @@ public class NamespaceService {
             Map.entry("foaf", "http://xmlns.com/foaf/0.1/"),
             Map.entry("vcard", "http://www.w3.org/2006/vcard/ns#"),
             Map.entry("elm", "http://data.europa.eu/snb/model/elm"),
-            Map.entry("unece", "https://vocabulary.uncefact.org/")
+            Map.entry("unece", "https://vocabulary.uncefact.org/"),
+            Map.entry("gs1", "https://gs1.org/voc/")
+    );
+
+    // Resolvable URIs by namespace name
+    public static final Map<String, String> DEFAULT_NAMESPACE_RESOLVABLE_URIS = Map.of(
+            "https://gs1.org/voc/", "https://www.gs1.org/docs/gs1-smartsearch/gs1Voc_v1_10.ttl"
     );
 
     public void resolveDefaultNamespaces() {


### PR DESCRIPTION
Add https://gs1.org/voc/ namespace. Because namespace is not resolvable, create new map containing resolvable URL for each not resolvable namespace. 

Fix startup initialization by moving namespace resolving after Opensearch indexes creation.