### PR TITLE
YTI-4137 library code lists

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/DataMigrationController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/DataMigrationController.java
@@ -2,6 +2,7 @@ package fi.vm.yti.datamodel.api.migration;
 
 import fi.vm.yti.datamodel.api.security.AuthorizationManager;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
@@ -19,6 +20,7 @@ import static fi.vm.yti.security.AuthorizationException.check;
 
 @RestController
 @RequestMapping("v2/migration")
+@Hidden
 public class DataMigrationController {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataMigrationController.class);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/AddCodeListPayloadDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/AddCodeListPayloadDTO.java
@@ -1,0 +1,24 @@
+package fi.vm.yti.datamodel.api.v2.dto;
+
+import java.util.Set;
+
+public class AddCodeListPayloadDTO {
+    private String attributeUri;
+    private Set<String> codeLists;
+
+    public String getAttributeUri() {
+        return attributeUri;
+    }
+
+    public void setAttributeUri(String attributeUri) {
+        this.attributeUri = attributeUri;
+    }
+
+    public Set<String> getCodeLists() {
+        return codeLists;
+    }
+
+    public void setCodeLists(Set<String> codeLists) {
+        this.codeLists = codeLists;
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/SimpleResourceDTO.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.datamodel.api.v2.dto;
 
 import java.util.Map;
+import java.util.Set;
 
 public class SimpleResourceDTO {
 
@@ -14,6 +15,7 @@ public class SimpleResourceDTO {
     private ConceptDTO concept;
     private Map<String, String> note;
     private UriDTO range;
+    private Set<String> codeLists = Set.of();
 
     public String getUri() {
         return uri;
@@ -93,5 +95,13 @@ public class SimpleResourceDTO {
 
     public void setRange(UriDTO range) {
         this.range = range;
+    }
+
+    public Set<String> getCodeLists() {
+        return codeLists;
+    }
+
+    public void setCodeLists(Set<String> codeLists) {
+        this.codeLists = codeLists;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -264,7 +264,7 @@ public class ClassController {
 
     @Operation(summary = "Add code lists for library class' attribute")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Code list successfully"),
+            @ApiResponse(responseCode = "200", description = "Code list added successfully"),
             @ApiResponse(responseCode = "401", description = "Current user does not have rights for this model"),
             @ApiResponse(responseCode = "404", description = "Resource not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
     })

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassController.java
@@ -262,4 +262,31 @@ public class ClassController {
         return ResponseEntity.created(newURI).build();
     }
 
+    @Operation(summary = "Add code lists for library class' attribute")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Code list successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this model"),
+            @ApiResponse(responseCode = "404", description = "Resource not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
+    })
+    @PutMapping(value = "/library/{prefix}/{classIdentifier}/codeList", consumes = APPLICATION_JSON_VALUE)
+    public void addCodeList(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                            @PathVariable @Parameter(description = "Class whose attribute code list will be added") String classIdentifier,
+                            @RequestBody AddCodeListPayloadDTO payload) {
+        classService.addCodeList(prefix, classIdentifier, payload.getAttributeUri(), payload.getCodeLists());
+    }
+
+    @Operation(summary = "Remove code list from library class' attribute")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Code list removed successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this model"),
+            @ApiResponse(responseCode = "404", description = "Resource not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))})
+    })
+    @DeleteMapping(value = "/library/{prefix}/{classIdentifier}/codeList")
+    public void removeCodeList(@PathVariable @Parameter(description = "Data model prefix") String prefix,
+                               @PathVariable @Parameter(description = "Class whose attribute code list will be removed") String classIdentifier,
+                               @RequestParam @Parameter(description = "Attribute to which code list will be removed") String attributeUri,
+                               @RequestParam @Parameter(description = "Code list URI") String codeListUri) {
+        classService.removeCodeList(prefix, classIdentifier, attributeUri, codeListUri);
+    }
+
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ClassMapper.java
@@ -76,8 +76,8 @@ public class ClassMapper {
     }
 
     public static List<String> mapPlaceholderPropertyShapes(Model applicationProfileModel, String classURI,
-                                                            Model propertiesModel, YtiUser user,
-                                                            Predicate<String> checkFreeIdentifier) {
+                                                            Model propertiesModel, YtiUser user, Predicate<String> checkFreeIdentifier,
+                                                            List<SimpleResourceDTO> attributeRestrictions) {
         var iterator = propertiesModel.listSubjectsWithProperty(RDFS.isDefinedBy);
         var classResource = applicationProfileModel.getResource(classURI);
         var propertyResourceURIs = new ArrayList<String>();
@@ -121,6 +121,12 @@ public class ClassMapper {
                     .addProperty(RDF.type, targetResource.getProperty(RDF.type).getObject())
                     .addProperty(RDFS.isDefinedBy, classResource.getProperty(RDFS.isDefinedBy).getObject())
                     .addProperty(SuomiMeta.publicationStatus, ResourceFactory.createResource(MapperUtils.getStatusUri(Status.DRAFT)));
+
+            // add code list if added to library class' attribute restriction
+            var attributeRestriction = attributeRestrictions.stream().filter(r -> pathURI.equals(r.getUri())).findFirst();
+            attributeRestriction.ifPresent(
+                    a -> a.getCodeLists().forEach(c -> propertyShapeResource.addProperty(SuomiMeta.codeList, c))
+            );
 
             MapperUtils.addCreationMetadata(propertyShapeResource, user);
 

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/NodeShapeMapperTest.java
@@ -47,10 +47,16 @@ class NodeShapeMapperTest {
         dto.setTargetClass(ModelConstants.SUOMI_FI_NAMESPACE + "target/Class");
         dto.setApiPath("/api/path/");
 
+        var attributeRestriction = new SimpleResourceDTO();
+        attributeRestriction.setUri(DataModelURI
+                .createResourceURI("test_lib","attribute-1", "1.0.0")
+                .getResourceVersionURI());
+        attributeRestriction.setCodeLists(Set.of("http://uri.suomi.fi/codelist/test"));
+
         var uri = DataModelURI.createResourceURI("test", "TestClass");
         ClassMapper.createNodeShapeAndMapToModel(uri, model, dto, mockUser);
         ClassMapper.mapPlaceholderPropertyShapes(model, uri.getResourceURI(),
-                propertiesQueryResult, mockUser, freePrefixCheck);
+                propertiesQueryResult, mockUser, freePrefixCheck, List.of(attributeRestriction));
 
         Resource modelResource = model.getResource(uri.getModelURI());
         Resource classResource = model.getResource(uri.getResourceURI());
@@ -94,6 +100,7 @@ class NodeShapeMapperTest {
         assertEquals(Status.DRAFT, MapperUtils.getStatusFromUri(MapperUtils.propertyToString(propertyShapeAttribute, SuomiMeta.publicationStatus)));
         assertEquals("Attribute attribute-1", MapperUtils.localizedPropertyToMap(propertyShapeAttribute, RDFS.label).get("fi"));
         assertEquals("/api/path/", MapperUtils.propertyToString(classResource, HTTP.API_PATH));
+        assertEquals(Set.of("http://uri.suomi.fi/codelist/test"), MapperUtils.arrayPropertyToSet(propertyShapeAttribute, SuomiMeta.codeList));
     }
 
     @Test


### PR DESCRIPTION
- New endpoints for adding and removing code lists to/from library class' attributes
- If node shape is created based on library class (sh:targetClass), possible code lists will be added automatically to node shape's property shapes

Code list reference is saved to owl:Restriction resource, e.g.

```
test:class-1  rdf:type                owl:Class ;
        rdfs:isDefinedBy              test: ;
        rdfs:label                    "testiluokka"@fi ;
        dcterms:identifier            "class-1"^^xsd:NCName ;
        owl:equivalentClass           [ rdf:type            owl:Class ;
                                        owl:intersectionOf  ( 
                                                              [ rdf:type             owl:Restriction ;
                                                                owl:onProperty       test:attr-1 ;
                                                                owl:someValuesFrom   xsd:anyURI ;
                                                                suomi-meta:codeList  "http://uri.suomi.fi/codelist/sbr-fi-code-lists/AI"
                                                              ]
                                                            )
                                      ] ;
        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
```