### PR TITLE
YTI-4151 Redirect to latest version

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -103,8 +103,19 @@ public class DataModelController {
     })
     @GetMapping(value = "/{prefix}", produces = APPLICATION_JSON_VALUE)
     public DataModelInfoDTO getModel(@PathVariable @Parameter(description = "Data model prefix") String prefix,
-                                     @RequestParam(required = false) @Parameter(description = "Model version, if empty gets the draft version") @ValidSemanticVersion String version) {
+                                     @RequestParam(required = false) @Parameter(description = "Model version, if empty gets the latest version") @ValidSemanticVersion String version) {
         return dataModelService.get(prefix, version);
+    }
+
+    @ApiResponse(responseCode = "200", description = "Datamodel object for the found draft model")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Draft data model found"),
+            @ApiResponse(responseCode = "401", description = "User has no permissions to the model"),
+            @ApiResponse(responseCode = "404", description = "Data model was not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))}),
+    })
+    @GetMapping(value = "/{prefix}/draft", produces = APPLICATION_JSON_VALUE)
+    public DataModelInfoDTO getDraftModel(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
+        return dataModelService.getDraft(prefix);
     }
 
     @Operation(summary = "Check if prefix already exists")


### PR DESCRIPTION
- Create separate endpoint for getting draft (`GET /model/{prefix}/draft`) and published (`GET /model/{prefix}?version={version}`) data model. If not version parameter specified, return latest version.
- Redirect iri.suomi.fi addresses to latest published version if no version specified