### PR TITLE
YTI-4145 Resource identifier validation

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -138,10 +138,6 @@ public abstract class BaseValidator implements Annotation{
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, propertyName);
         } else if (value != null && !value.matches(regexp)) {
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, propertyName);
-        } else if (value != null && (
-                value.length() < ValidationConstants.PREFIX_MIN_LENGTH
-                        || value.length() > ValidationConstants.PREFIX_MAX_LENGTH)) {
-            addConstraintViolation(context, propertyName + "-character-count-mismatch", propertyName);
         }
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -44,7 +44,7 @@ public class ValidationConstants {
             Map.entry("oa", "http://www.w3.org/ns/oa#"),
             Map.entry("activitystreams", "https://www.w3.org/ns/activitystreams#"),
             Map.entry("csvw", "http://www.w3.org/ns/csvw#")
-    );
+        );
 
 
     public static final List<String> RESERVED_WORDS = List.of(

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ValidationConstants.java
@@ -12,7 +12,7 @@ public class ValidationConstants {
     public static final String MSG_VALUE_MISSING = "should-have-value";
     public static final String MSQ_NOT_ALLOWED = "should-not-have-value";
     public static final String MSG_VALUE_INVALID = "invalid-value";
-    public static final String MSG_NOT_ALLOWED_UPDATE =  "not-allowed-update";
+    public static final String MSG_NOT_ALLOWED_UPDATE = "not-allowed-update";
     public static final String MSG_OVER_CHARACTER_LIMIT = "value-over-character-limit.";
 
     public static final int TEXT_FIELD_MAX_LENGTH = 150;
@@ -20,11 +20,11 @@ public class ValidationConstants {
     public static final int TEXT_AREA_MAX_LENGTH = 5000;
     public static final int DOCUMENTATION_MAX_LENGTH = 50000;
 
-    public static final int PREFIX_MIN_LENGTH = 2;
-    public static final int PREFIX_MAX_LENGTH = 32;
-    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
+    // model prefix regex 2-32 character
+    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]{1,31}";
 
-    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]+";
+    // resource identifier regex 2-120 characters
+    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]{1,119}";
 
     public static final Map<String, String> RESERVED_NAMESPACES = Map.ofEntries(
             Map.entry("owl", "http://www.w3.org/2002/07/owl#"),
@@ -44,7 +44,7 @@ public class ValidationConstants {
             Map.entry("oa", "http://www.w3.org/ns/oa#"),
             Map.entry("activitystreams", "https://www.w3.org/ns/activitystreams#"),
             Map.entry("csvw", "http://www.w3.org/ns/csvw#")
-        );
+    );
 
 
     public static final List<String> RESERVED_WORDS = List.of(

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -215,7 +215,7 @@ class DataModelControllerTest {
 
         //Prefix over max length
         dataModelDTO = createDatamodelDTO(false);
-        dataModelDTO.setPrefix(RandomStringUtils.randomAlphanumeric( 121));
+        dataModelDTO.setPrefix(RandomStringUtils.randomAlphanumeric(121));
         args.add(dataModelDTO);
 
         dataModelDTO = createDatamodelDTO(false);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -215,7 +215,7 @@ class DataModelControllerTest {
 
         //Prefix over max length
         dataModelDTO = createDatamodelDTO(false);
-        dataModelDTO.setPrefix(RandomStringUtils.randomAlphanumeric(ValidationConstants.PREFIX_MAX_LENGTH + 1));
+        dataModelDTO.setPrefix(RandomStringUtils.randomAlphanumeric( 121));
         args.add(dataModelDTO);
 
         dataModelDTO = createDatamodelDTO(false);


### PR DESCRIPTION
Combine validations for identifier length and allowed characters. Allow max 120 characters as resource's (class, attribute, association), data model's prefix max length is 32 as before.