### PR TITLE
YTI-4111 Move pagination logic to backend

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ModelQueryFactory.java
@@ -37,7 +37,7 @@ public class ModelQueryFactory {
         var sr = new SearchRequest.Builder()
                 .index(OpenSearchIndexer.OPEN_SEARCH_INDEX_MODEL)
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
-                .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
+                .from(QueryFactoryUtils.pageFrom(request))
                 .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
                 .highlight(highlight.build())
                 .query(modelQuery)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -66,7 +66,7 @@ public class ResourceQueryFactory {
         }
 
         SearchRequest sr = new SearchRequest.Builder()
-                .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
+                .from(QueryFactoryUtils.pageFrom(request))
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .index(indices)
                 .query(finalQuery)
@@ -116,7 +116,7 @@ public class ResourceQueryFactory {
                 .preTags("<b>")
                 .postTags("</b>");
         SearchRequest sr = new SearchRequest.Builder()
-                .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
+                .from(QueryFactoryUtils.pageFrom(request))
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .index(indices)
                 .query(finalQuery)

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ModelQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/opensearch/ModelQueryFactoryTest.java
@@ -37,7 +37,7 @@ class ModelQueryFactoryTest {
         String expected = MapperTestUtils.getJsonString("/es/modelrequest.json");
         JSONAssert.assertEquals(expected, OpenSearchUtils.getPayload(modelQuery), JSONCompareMode.LENIENT);
 
-        assertEquals("Page from value not matching", 1, modelQuery.from());
+        assertEquals("Page from value not matching", 0, modelQuery.from());
         assertEquals("Page size value not matching", 100, modelQuery.size());
     }
 

--- a/src/test/resources/es/attributeListRequest.json
+++ b/src/test/resources/es/attributeListRequest.json
@@ -1,5 +1,5 @@
 {
-  "from": 1,
+  "from": 0,
   "query": {
     "bool": {
       "must": [

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -1,5 +1,5 @@
 {
-  "from": 1,
+  "from": 0,
   "query": {
     "bool": {
       "must": [

--- a/src/test/resources/es/classesByVersion.json
+++ b/src/test/resources/es/classesByVersion.json
@@ -1,5 +1,5 @@
 {
-  "from": 1,
+  "from": 0,
   "query": {
     "bool": {
       "must": [

--- a/src/test/resources/es/modelrequest.json
+++ b/src/test/resources/es/modelrequest.json
@@ -1,5 +1,5 @@
 {
-  "from": 1,
+  "from": 0,
   "highlight": {
     "fields": {
       "label.*": {}


### PR DESCRIPTION
Determine starting index (from) in the backend. Paging parameter from UI (pageFrom) represents the page number, so the starting index is calculated `(pageFrom - 1) * pageSize`