### PR TITLE
YTI-4234 add graph to delete query

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
@@ -92,7 +92,7 @@ abstract class BaseResourceService {
             throw new MappingError("Cannot remove because other resources refer to it: " + refList);
         }
 
-        coreRepository.deleteResource(resourceUri);
+        coreRepository.deleteResource(uri);
         openSearchIndexer.deleteResourceFromIndex(resourceUri);
         auditService.log(AuditService.ActionType.DELETE, resourceUri, userProvider.getUser());
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ClassServiceTest.java
@@ -251,7 +251,7 @@ class ClassServiceTest {
 
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
-        verify(coreRepository).deleteResource(anyString());
+        verify(coreRepository).deleteResource(DataModelURI.createResourceURI("test", "Identifier"));
         verify(openSearchIndexer).deleteResourceFromIndex(anyString());
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/ResourceServiceTest.java
@@ -223,7 +223,7 @@ class ResourceServiceTest {
 
         verify(coreRepository).fetch(anyString());
         verify(authorizationManager).hasRightToModel(anyString(), any(Model.class));
-        verify(coreRepository).deleteResource(anyString());
+        verify(coreRepository).deleteResource(DataModelURI.createResourceURI("test", "identifier"));
         verify(openSearchIndexer).deleteResourceFromIndex(anyString());
     }
 


### PR DESCRIPTION
Add graph to delete query to prevent deleting resources from other graphs. Query looks like this:
```
DELETE {
  GRAPH <https://iri.suomi.fi/model/test/> {
    ?s ?p ?o .
  }
}
WHERE
  { GRAPH <https://iri.suomi.fi/model/test/>
      { ?s  ?p  ?o
        FILTER ( ( ?s = <https://iri.suomi.fi/model/test/class-1> ) || ( ?o = <https://iri.suomi.fi/model/test/class-1> ) )
      }
  }
```

Old query
```
DELETE {
  GRAPH ?g {
    ?s ?p ?o .
  }
}
...
```