### PR TITLE
YTI-4218 Data model copy

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Map;
@@ -174,5 +175,20 @@ public class DataModelController {
     @GetMapping("/{prefix}/validate")
     public ResponseEntity<Map<String, Set<ResourceReferenceDTO>>> validateRelease(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
         return ResponseEntity.ok(releaseValidationService.validateRelease(prefix));
+    }
+
+    @Operation(summary = "Copies the datamodel to a new prefix")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Copy of the data model has been created with a new prefix"),
+    })
+    @PostMapping("/{prefix}/copy")
+    public ResponseEntity<Void> copyDataModel(
+            @PathVariable @Parameter(description = "Data model's current prefix") String prefix,
+            @RequestParam(required = false) @Parameter(description = "Version of the data model to be copied") @ValidSemanticVersion String version,
+            @RequestParam @Parameter(description = "New prefix") String newPrefix) {
+        var newURI = dataModelService.copyDataModel(prefix, version, newPrefix);
+        return ResponseEntity
+                .created(URI.create(newURI))
+                .build();
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -535,7 +535,7 @@ public class MapperUtils {
     }
 
     /**
-     * Create a copy of given model and renames all resource URIs to given new prefix.
+     * Creates a copy of given model and renames all resource URIs to given new prefix.
      * All version related information and creating / modifying metadata will be reset.
      * @param model model to be copied
      * @param user copier user

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/properties/SuomiMeta.java
@@ -28,4 +28,6 @@ public class SuomiMeta {
     public static final Property referenceTarget = ResourceFactory.createProperty(URI, "referenceTarget");
     public static final Property target = ResourceFactory.createProperty(URI, "target");
     public static final Property origin = ResourceFactory.createProperty(URI, "origin");
+
+    public static final Property copiedFrom = ResourceFactory.createProperty(URI, "copiedFrom");
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -426,15 +426,16 @@ public class DataModelService {
 
         var model = coreRepository.fetch(oldURI.getGraphURI());
 
-        var user = userProvider.getUser();
-        check(authorizationManager.hasRightToModel(oldPrefix, model));
-
+        // check that old graph exists and new prefix is not in use
         if (!coreRepository.graphExists(oldURI.getGraphURI())) {
             throw new ResourceNotFoundException(oldURI.getGraphURI());
         }
         if (coreRepository.graphExists(newURI.getGraphURI())) {
             throw new MappingError("Prefix in use");
         }
+
+        var user = userProvider.getUser();
+        check(authorizationManager.hasRightToModel(oldPrefix, model));
 
         var copy = MapperUtils.mapCopyModel(model, user, oldURI, newURI);
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -418,6 +418,36 @@ public class DataModelService {
         coreRepository.queryUpdate(builder.buildRequest());
     }
 
+    public String copyDataModel(String oldPrefix, String version, String newPrefix) {
+        var oldURI = DataModelURI.createModelURI(oldPrefix, version);
+        var newURI = DataModelURI.createModelURI(newPrefix);
+
+        logger.info("Copying graph {}, new prefix {}", oldURI.getGraphURI(), newPrefix);
+
+        var model = coreRepository.fetch(oldURI.getGraphURI());
+
+        var user = userProvider.getUser();
+        check(authorizationManager.hasRightToModel(oldPrefix, model));
+
+        if (!coreRepository.graphExists(oldURI.getGraphURI())) {
+            throw new ResourceNotFoundException(oldURI.getGraphURI());
+        }
+        if (coreRepository.graphExists(newURI.getGraphURI())) {
+            throw new MappingError("Prefix in use");
+        }
+
+        var copy = MapperUtils.mapCopyModel(model, user, oldURI, newURI);
+
+        coreRepository.put(newURI.getGraphURI(), copy);
+        visualisationService.copyVisualization(oldPrefix, version, newPrefix);
+
+        openSearchIndexer.createModelToIndex(mapper.mapToIndexModel(newURI.getModelURI(), copy));
+        openSearchIndexer.indexGraphResource(copy);
+
+        auditService.log(AuditService.ActionType.CREATE, newURI.getGraphURI(), userProvider.getUser());
+
+        return newURI.getGraphURI();
+    }
 
     private void updatePriorVersions(String graphUri, String priorVersion) {
         var update = new UpdateBuilder();

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/VisualizationService.java
@@ -13,6 +13,7 @@ import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelUtils;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import org.apache.jena.rdf.model.*;
+import org.apache.jena.util.ResourceUtils;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
@@ -188,6 +189,21 @@ public class VisualizationService {
         }catch (ResourceNotFoundException e){
             //if no positions found, do nothing
         }
+    }
+
+    public void copyVisualization(String oldPrefix, String version, String newPrefix) {
+        var positions = getPositions(oldPrefix, version);
+        var positionsCopy = ModelFactory.createDefaultModel().add(positions);
+        var positionGraphURI = getPositionGraphURI(newPrefix, null);
+
+        positionsCopy.listSubjects()
+                .filterDrop(RDFNode::isAnon)
+                .forEach(subject -> {
+                    var newSubject = positionGraphURI + MapperUtils.propertyToString(subject, DCTerms.identifier);
+                    ResourceUtils.renameResource(subject, newSubject);
+                });
+
+        coreRepository.put(positionGraphURI, positionsCopy);
     }
 
     private static void addExternalClasses(VisualizationClassDTO classDTO, Set<String> languages, HashSet<VisualizationNodeDTO> result) {

--- a/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/mapper/ClassMapperTest.java
@@ -110,7 +110,8 @@ class ClassMapperTest {
         assertEquals(1, dto.getEquivalentClass().size());
         assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/EqClass"), dto.getEquivalentClass().stream().findFirst().orElse(null));
         assertEquals(1, dto.getSubClassOf().size());
-        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/SubClass"), dto.getSubClassOf().stream().findFirst().orElse(null));
+        assertEquals(new UriDTO(ModelConstants.SUOMI_FI_NAMESPACE + "test/1.0.1/SubClass", "test:SubClass"),
+                dto.getSubClassOf().stream().findFirst().orElse(null));
         assertEquals(1, dto.getLabel().size());
         assertEquals("test label", dto.getLabel().get("fi"));
         assertEquals("http://uri.suomi.fi/terminology/test/test1", dto.getSubject().getConceptURI());

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtilsTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtilsTest.java
@@ -2,11 +2,21 @@ package fi.vm.yti.datamodel.api.v2.mapper;
 
 import fi.vm.yti.datamodel.api.mapper.MapperTestUtils;
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.Status;
+import fi.vm.yti.datamodel.api.v2.endpoint.EndpointUtils;
+import fi.vm.yti.datamodel.api.v2.properties.DCAP;
+import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
 import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
-import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.vocabulary.*;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class MapperUtilsTest {
 
@@ -24,5 +34,66 @@ class MapperUtilsTest {
 
         assertEquals(ModelConstants.SUOMI_FI_NAMESPACE + "test/NewClass", resource.getURI());
         assertEquals("NewClass", MapperUtils.getLiteral(resource, DCTerms.identifier, String.class));
+    }
+
+    @Test
+    void copyModel() {
+        var oldGraphURI = DataModelURI.createModelURI("test", "1.0.0");
+        var newGraphURI = DataModelURI.createModelURI("new_prefix");
+        var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
+        var mockUser = EndpointUtils.mockUser;
+
+        var copy = MapperUtils.mapCopyModel(model, mockUser, oldGraphURI, newGraphURI);
+
+        var resources = copy.listSubjectsWithProperty(RDF.type, OWL.Class)
+                .andThen(copy.listSubjectsWithProperty(RDF.type, OWL.DatatypeProperty))
+                .andThen(copy.listSubjectsWithProperty(RDF.type, OWL.ObjectProperty))
+                .filterDrop(RDFNode::isAnon)
+                .toList();
+
+        var modelResource = copy.getResource(newGraphURI.getModelURI());
+
+        var classResource = copy.getResource(DataModelURI
+                .createResourceURI("new_prefix", "TestClass")
+                .getResourceURI());
+
+        var today = DateTimeFormatter
+                .ofPattern("yyyy-MM-dd")
+                .format(LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC));
+
+        assertEquals(model.listSubjects().toList().size(), copy.listSubjects().toList().size());
+
+        // All version related triples should be removed
+        assertFalse(modelResource.hasProperty(OWL.versionInfo));
+        assertFalse(modelResource.hasProperty(OWL2.versionIRI));
+
+        // Datamodel name should have suffix (Copy) in each language
+        assertTrue(
+                MapperUtils.localizedPropertyToMap(modelResource, RDFS.label)
+                        .values().stream()
+                        .allMatch(label -> label.endsWith((" (Copy)"))));
+
+        // New namespace and prefix
+        assertEquals("https://iri.suomi.fi/model/new_prefix/",
+                MapperUtils.propertyToString(modelResource, DCAP.preferredXMLNamespace));
+        assertEquals("new_prefix", MapperUtils.propertyToString(modelResource, DCAP.preferredXMLNamespacePrefix));
+
+        // Objects (e.g. rdfs:subClassOf) should point to URIs with new prefix
+        assertEquals("https://iri.suomi.fi/model/new_prefix/SubClass", MapperUtils.propertyToString(classResource, RDFS.subClassOf));
+
+        // Update metadata
+        assertTrue(resources.stream().allMatch(r -> {
+            var validURI = r.getURI().startsWith(newGraphURI.getGraphURI());
+            var validStatus = MapperUtils.getStatusUri(Status.DRAFT).equals(MapperUtils.propertyToString(r, SuomiMeta.publicationStatus));
+            var validCreator = mockUser.getId().toString().equals(MapperUtils.propertyToString(r, DCTerms.creator));
+            var validModifier = mockUser.getId().toString().equals(MapperUtils.propertyToString(r, SuomiMeta.modifier));
+
+            var created = MapperUtils.propertyToString(r, DCTerms.created);
+            var modified = MapperUtils.propertyToString(r, DCTerms.modified);
+            var validCreated = created != null && created.startsWith(today);
+            var validModified = modified != null && modified.startsWith(today);
+
+            return validURI && validStatus && validCreator && validModifier && validCreated && validModified;
+        }));
     }
 }

--- a/src/test/resources/models/test_datamodel_library_with_resources.ttl
+++ b/src/test/resources/models/test_datamodel_library_with_resources.ttl
@@ -21,7 +21,7 @@ dcterms:language                "fi" ;
 owl:imports                     <https://iri.suomi.fi/model/int/> ;
 dcterms:requires                <https://www.example.com/ns/ext/> ;
 dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
-dcap:preferredXMLNamespaceName  "https://iri.suomi.fi/model/test" ;
+dcap:preferredXMLNamespace      "https://iri.suomi.fi/model/test" ;
 dcap:preferredXMLNamespacePrefix
 "test" ;
 suomi-meta:contentModified             "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
@@ -94,7 +94,8 @@ test:TestAssociation  rdf:type     owl:ObjectProperty, owl:FunctionalProperty ;
 
 test:DomainClass    rdf:type    owl:Class .
 
-test:RangeClass    rdf:type    owl:Class ;
+test:RangeClass    rdf:type    owl:Class .
 
+test:SubClass      rdf:type    owl:Class ;
 
 


### PR DESCRIPTION
- Created new endpoint for copying data model `POST /model/{prefix}/copy?newPrefix={new_prefix}&version={version}`. If version is not specified, draft version will be copied.
- All version related information (e.g. OWL:versionInfo) will be remove from the copy. Also all created and updated will be reset