### PR TITLE
YTI-4241 fix validation for versioned model's documentation

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -1,8 +1,6 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
-import fi.vm.yti.datamodel.api.v2.dto.BaseDTO;
-import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
-import fi.vm.yti.datamodel.api.v2.dto.Status;
+import fi.vm.yti.datamodel.api.v2.dto.*;
 import jakarta.validation.ConstraintValidatorContext;
 
 import java.lang.annotation.Annotation;
@@ -129,6 +127,15 @@ public abstract class BaseValidator implements Annotation{
         } else {
             value.forEach((lang, v) -> checkCommonTextField(context, v, property));
         }
+    }
+
+    public void checkDocumentation(ConstraintValidatorContext context, ModelMetaData dataModel) {
+        dataModel.getDocumentation().forEach((lang, value) -> {
+            if (value != null && value.length() > ValidationConstants.DOCUMENTATION_MAX_LENGTH) {
+                addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT
+                                                + ValidationConstants.DOCUMENTATION_MAX_LENGTH, "documentation");
+            }
+        });
     }
 
     private void checkPrefixOrIdentifier(ConstraintValidatorContext context, String value, String propertyName, String regexp, boolean update) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -245,14 +245,6 @@ public class DataModelValidator extends BaseValidator implements
         }
     }
 
-    private void checkDocumentation(ConstraintValidatorContext context, DataModelDTO dataModel) {
-        dataModel.getDocumentation().forEach((lang, value) -> {
-            if (value != null && value.length() > ValidationConstants.DOCUMENTATION_MAX_LENGTH) {
-                addConstraintViolation(context, ValidationConstants.MSG_OVER_CHARACTER_LIMIT, "documentation");
-            }
-        });
-    }
-
     private void checkLinks(ConstraintValidatorContext context, DataModelDTO dataModel) {
         dataModel.getLinks().forEach(linkDTO -> {
             checkRequiredLocalizedValue(context, linkDTO.getName(), "links.name");

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/VersionedModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/VersionedModelValidator.java
@@ -6,8 +6,6 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class VersionedModelValidator extends BaseValidator implements ConstraintValidator<ValidVersionedDatamodel, VersionedModelDTO> {
 
-
-
     @Override
     public boolean isValid(VersionedModelDTO value, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
@@ -16,9 +14,5 @@ public class VersionedModelValidator extends BaseValidator implements Constraint
         checkDocumentation(context, value);
 
         return !isConstraintViolationAdded();
-    }
-
-    private void checkDocumentation(ConstraintValidatorContext context, VersionedModelDTO dataModel) {
-        dataModel.getDocumentation().forEach((lang, value) -> checkCommonTextArea(context, value, "documentation"));
     }
 }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -453,9 +453,9 @@ class DataModelControllerTest {
 
         //documentation over character limit
         dto = new VersionedModelDTO();
-        expected = new String[]{"updateVersionedModel.dto.documentation: value-over-character-limit.5000"};
+        expected = new String[]{"updateVersionedModel.dto.documentation: value-over-character-limit.50000"};
         dto.setDocumentation(Map.of("fi", RandomStringUtils.randomAlphanumeric(
-                ValidationConstants.TEXT_AREA_MAX_LENGTH + 1)));
+                ValidationConstants.DOCUMENTATION_MAX_LENGTH + 1)));
         dto.setStatus(Status.VALID);
         args.add(Pair.of(dto, expected));
 


### PR DESCRIPTION
Limit for documentation should be 50k characters. While saving versioned data model, the limit was only 5k characters.  Created common method for checking documentation to BaseValidator.