### PR TITLE
YTI-4195 json schema improvements

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/MapperUtils.java
@@ -175,8 +175,14 @@ public class MapperUtils {
             return null;
         }
         var object = prop.getObject();
-        //null check for object
-        return object == null ? null : object.toString();
+
+        if (object == null) {
+            return null;
+        } else if (object.isLiteral()) {
+            return object.asLiteral().getString();
+        } else {
+            return object.toString();
+        }
     }
 
     public static <T> T getLiteral(Resource resource, Property property, Class<T> type) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ResourceMapper.java
@@ -437,16 +437,25 @@ public class ResourceMapper {
         }else{
             throw new MappingError("Unsupported rdf:type");
         }
-        dto.setAllowedValues(MapperUtils.arrayPropertyToList(resource, SH.in));
+
         dto.setClassType(MapperUtils.uriToURIDTO(
                 MapperUtils.propertyToString(resource, SH.class_), model)
         );
         dto.setDataType(MapperUtils.uriToURIDTO(MapperUtils.propertyToString(resource, SH.datatype), model));
-        dto.setDefaultValue(MapperUtils.propertyToString(resource, SH.defaultValue));
-        dto.setHasValue(MapperUtils.propertyToString(resource, SH.hasValue));
         dto.setPath(MapperUtils.uriToURIDTO(
                 MapperUtils.propertyToString(resource, SH.path), model)
         );
+        dto.setCodeLists(MapperUtils.arrayPropertyToList(resource, SuomiMeta.codeList));
+        mapPropertyShapeRestrictions(dto, resource);
+        MapperUtils.mapCreationInfo(dto, resource, userMapper);
+
+        return dto;
+    }
+
+    public static void mapPropertyShapeRestrictions(PropertyShapeInfoDTO dto, Resource resource) {
+        dto.setAllowedValues(MapperUtils.arrayPropertyToList(resource, SH.in));
+        dto.setDefaultValue(MapperUtils.propertyToString(resource, SH.defaultValue));
+        dto.setHasValue(MapperUtils.propertyToString(resource, SH.hasValue));
         dto.setMaxCount(MapperUtils.getLiteral(resource, SH.maxCount, Integer.class));
         dto.setMinCount(MapperUtils.getLiteral(resource, SH.minCount, Integer.class));
         dto.setMaxLength(MapperUtils.getLiteral(resource, SH.maxLength, Integer.class));
@@ -457,10 +466,6 @@ public class ResourceMapper {
         dto.setMaxExclusive(MapperUtils.getLiteral(resource, SH.maxExclusive, Integer.class));
         dto.setPattern(MapperUtils.propertyToString(resource, SH.pattern));
         dto.setLanguageIn(MapperUtils.arrayPropertyToSet(resource, SH.languageIn));
-        dto.setCodeLists(MapperUtils.arrayPropertyToList(resource, SuomiMeta.codeList));
-        MapperUtils.mapCreationInfo(dto, resource, userMapper);
-
-        return dto;
     }
 
     public static ExternalResourceDTO mapToExternalResource(Resource resource) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
@@ -1,8 +1,11 @@
 package fi.vm.yti.datamodel.api.v2.service;
 
 import fi.vm.yti.datamodel.api.v2.dto.ModelConstants;
+import fi.vm.yti.datamodel.api.v2.dto.PropertyShapeInfoDTO;
 import fi.vm.yti.datamodel.api.v2.mapper.MapperUtils;
+import fi.vm.yti.datamodel.api.v2.mapper.ResourceMapper;
 import fi.vm.yti.datamodel.api.v2.properties.SuomiMeta;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -16,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.StringWriter;
-import java.util.Map;
+import java.util.*;
 
 public class JSONSchemaBuilder {
 
@@ -114,6 +117,12 @@ public class JSONSchemaBuilder {
                     ? handleAttribute(propertyResource, language)
                     : handleAssociation(model, propertyResource, language);
 
+            var minCount = MapperUtils.getLiteral(propertyResource, SH.minCount, Integer.class);
+
+            if (minCount != null && minCount > 0) {
+                schemaBuilder.addRequiredProperty(propertyResource.getLocalName());
+            }
+
             schemaBuilder.addPropertySchema(
                     propertyResource.getLocalName(),
                     propertySchema);
@@ -167,18 +176,27 @@ public class JSONSchemaBuilder {
         var title = getLocalizedValue(propertyResource, RDFS.label, language);
         var minCount = MapperUtils.getLiteral(propertyResource, SH.minCount, Integer.class);
         var maxCount = MapperUtils.getLiteral(propertyResource, SH.maxCount, Integer.class);
+        var allowed = MapperUtils.arrayPropertyToList(propertyResource, SH.in);
+        var requiredValue = MapperUtils.propertyToString(propertyResource, SH.hasValue);
+
         var type = getDatatype(MapperUtils.propertyToString(propertyResource, SH.datatype));
 
         Schema.Builder<? extends Schema> builder;
-        if (type == SchemaType.NUMBER || type == SchemaType.INTEGER){
+        if (requiredValue != null) {
+            builder = ConstSchema.builder().permittedValue(requiredValue);
+        } else if (!allowed.isEmpty()) {
+            builder = EnumSchema.builder().possibleValues(new ArrayList<>(allowed));
+        } else if (type == SchemaType.NUMBER || type == SchemaType.INTEGER) {
             builder = NumberSchema.builder();
         } else if (type == SchemaType.STRING) {
             builder = StringSchema.builder();
-        } else if (type == SchemaType.BOOLEAN)  {
+        } else if (type == SchemaType.BOOLEAN) {
             builder = BooleanSchema.builder();
         } else {
             builder = ObjectSchema.builder();
         }
+
+        addRestrictions(builder, propertyResource);
 
         // handle property as an array if either minCount or maxCount > 1
         if ((minCount != null && minCount > 1) || (maxCount != null && maxCount > 1)) {
@@ -198,6 +216,57 @@ public class JSONSchemaBuilder {
                 .description(description)
                 .title(title);
         return builder.build();
+    }
+
+    private static void addRestrictions(Schema.Builder<? extends Schema> builder, Resource propertyResource) {
+        var dto = new PropertyShapeInfoDTO();
+        ResourceMapper.mapPropertyShapeRestrictions(dto, propertyResource);
+
+        if (builder instanceof StringSchema.Builder stringBuilder) {
+            if (dto.getPattern() != null) {
+                stringBuilder.pattern(dto.getPattern());
+            }
+            if (dto.getMinLength() != null) {
+                stringBuilder.minLength(dto.getMinLength());
+            }
+            if (dto.getMaxLength() != null) {
+                stringBuilder.maxLength(dto.getMaxLength());
+            }
+            if (dto.getDefaultValue() != null) {
+                stringBuilder.defaultValue(MapperUtils.propertyToString(propertyResource, SH.defaultValue));
+            }
+        } else if (builder instanceof NumberSchema.Builder numberSchema) {
+            // x >= minInclusive
+            if (dto.getMinInclusive() != null) {
+                numberSchema.minimum(dto.getMinInclusive());
+                numberSchema.exclusiveMinimum(false);
+            }
+            // x <= maxInclusive
+            if (dto.getMaxInclusive() != null) {
+                numberSchema.maximum(dto.getMaxInclusive());
+                numberSchema.exclusiveMaximum(false);
+            }
+            // x > minExclusive
+            if (dto.getMinExclusive() != null) {
+                numberSchema.minimum(dto.getMinExclusive());
+                numberSchema.exclusiveMinimum(true);
+            }
+            // x < maxExclusive
+            if (dto.getMaxExclusive() != null) {
+                numberSchema.maximum(dto.getMaxExclusive());
+                numberSchema.exclusiveMaximum(true);
+            }
+
+            if (dto.getDefaultValue() != null) {
+                try {
+                    numberSchema.defaultValue(NumberUtils.createNumber(dto.getDefaultValue()));
+                } catch (NumberFormatException nfe) {
+                    logger.warn("Invalid number as a default value: {}, uri: {}", dto.getDefaultValue(), propertyResource.getURI());
+                }
+            }
+        } else if (dto.getDefaultValue() != null) {
+            builder.defaultValue(dto.getDefaultValue());
+        }
     }
 
     private static String getLocalizedValue(Resource resource, Property property, String language) {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
@@ -10,6 +10,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.OWL2;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.everit.json.schema.*;
@@ -72,6 +73,10 @@ public class JSONSchemaBuilder {
                 : language;
 
         var schemaBuilder = ObjectSchema.builder();
+
+        schemaBuilder.id(modelResource.hasProperty(OWL2.versionIRI)
+                ? MapperUtils.propertyToString(modelResource, OWL2.versionIRI)
+                : modelResource.getURI());
         schemaBuilder.description(getLocalizedValue(modelResource, RDFS.comment, language));
         schemaBuilder.title(getLocalizedValue(modelResource, RDFS.label, language));
 

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaBuilder.java
@@ -158,9 +158,17 @@ public class JSONSchemaBuilder {
                 .build();
         subject.setReferredSchema(EmptySchema.builder().build());
 
-        if ((maxCount != null && maxCount > 1) || (minCount != null && minCount > 1)) {
-            return ArraySchema.builder()
-                    .addItemSchema(subject)
+        if (isArraySchema(minCount, maxCount)) {
+            var arraySchemaBuilder = ArraySchema.builder()
+                    .addItemSchema(subject);
+
+            if (minCount != null) {
+                arraySchemaBuilder.minItems(minCount);
+            }
+            if (maxCount != null) {
+                arraySchemaBuilder.maxItems(maxCount);
+            }
+            return arraySchemaBuilder
                     .description(description)
                     .title(title)
                     .build();
@@ -198,8 +206,7 @@ public class JSONSchemaBuilder {
 
         addRestrictions(builder, propertyResource);
 
-        // handle property as an array if either minCount or maxCount > 1
-        if ((minCount != null && minCount > 1) || (maxCount != null && maxCount > 1)) {
+        if (isArraySchema(minCount, maxCount)) {
             var arraySchemaBuilder = ArraySchema.builder()
                     .allItemSchema(builder.build());
 
@@ -267,6 +274,18 @@ public class JSONSchemaBuilder {
         } else if (dto.getDefaultValue() != null) {
             builder.defaultValue(dto.getDefaultValue());
         }
+    }
+
+    /**
+     * Handle property as an array if
+     * - maxCount is empty or > 1
+     * - minCount > 1
+     *
+     * @param minCount sh:minCount
+     * @param maxCount sh:maxCount
+     */
+    private static boolean isArraySchema(Integer minCount, Integer maxCount) {
+        return (maxCount == null || maxCount > 1) || (minCount != null && minCount > 1);
     }
 
     private static String getLocalizedValue(Resource resource, Property property, String language) {

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
@@ -22,6 +22,7 @@ class JSONSchemaTest {
         var writer = new StringWriter();
         JSONSchemaBuilder.export(writer, model, "en");
 
+        System.out.println(writer);
         var expected = MapperTestUtils.getJsonString("/json-schema-expected.json");
 
         JSONAssert.assertEquals(expected, writer.toString(), JSONCompareMode.LENIENT);

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/JSONSchemaTest.java
@@ -22,7 +22,6 @@ class JSONSchemaTest {
         var writer = new StringWriter();
         JSONSchemaBuilder.export(writer, model, "en");
 
-        System.out.println(writer);
         var expected = MapperTestUtils.getJsonString("/json-schema-expected.json");
 
         JSONAssert.assertEquals(expected, writer.toString(), JSONCompareMode.LENIENT);

--- a/src/test/resources/json-schema-data.ttl
+++ b/src/test/resources/json-schema-data.ttl
@@ -10,11 +10,24 @@
 @prefix http:       <http://www.w3.org/2011/http#> .
 
 test:property-1  rdf:type   owl:DatatypeProperty ;
-        rdfs:label          "Property label"@en ;
+        rdfs:label          "String property"@en ;
         dcterms:identifier  "property-1" ;
         sh:datatype         "http://www.w3.org/2001/XMLSchema#string" ;
-        sh:in               "02" , "01" ;
+        sh:pattern          "[a-zA-Z]" ;
+        sh:minLength        1 ;
+        sh:maxLength        100 ;
+        sh:defaultValue     "default value" ;
         sh:minCount         "1"^^xsd:long .
+
+test:property-5 rdf:type  owl:DatatypeProperty ;
+        rdfs:label          "Property with enum"@en ;
+        dcterms:identifier  "property-5" ;
+        sh:in               "Value1" , "Value2" .
+
+test:property-6 rdf:type  owl:DatatypeProperty ;
+        rdfs:label          "Property with required value"@en ;
+        dcterms:identifier  "property-6" ;
+        sh:hasValue         "required value" .
 
 test:class-2  rdf:type      sh:NodeShape ;
         rdfs:label          "Target node"@en ;
@@ -26,17 +39,22 @@ test:property-4  rdf:type   owl:ObjectProperty ;
         sh:deactivated      true .
 
 test:property-2  rdf:type   owl:DatatypeProperty ;
-        rdfs:label          "Property label 2"@en ;
+        rdfs:label          "Numeric property"@en ;
         dcterms:identifier  "property-2" ;
         sh:datatype         "http://www.w3.org/2001/XMLSchema#integer" ;
-        sh:maxCount         "5"^^xsd:long .
+        sh:maxCount         "5"^^xsd:long ;
+        sh:defaultValue     1 ;
+        sh:minInclusive     1 ;
+        sh:minExclusive     0 ;
+        sh:maxInclusive     5 ;
+        sh:maxExclusive     6 .
 
 test:class-1  rdf:type      sh:NodeShape ;
         rdfs:comment        "Property shape info"@en ;
         rdfs:label          "Node shape label"@en ;
         dcterms:identifier  "class-1" ;
         http:absolutePath   "/path/{var1}/{var2}?q=123" ;
-        sh:property         test:property-4 , test:property-3 , test:property-2 , test:property-1 .
+        sh:property         test:property-6 , test:property-5 , test:property-4 , test:property-3 , test:property-2 , test:property-1 .
 
 test:   rdf:type         suomi-meta:ApplicationProfile ;
         rdfs:comment     "Model info"@en ;

--- a/src/test/resources/json-schema-data.ttl
+++ b/src/test/resources/json-schema-data.ttl
@@ -17,17 +17,20 @@ test:property-1  rdf:type   owl:DatatypeProperty ;
         sh:minLength        1 ;
         sh:maxLength        100 ;
         sh:defaultValue     "default value" ;
-        sh:minCount         "1"^^xsd:long .
+        sh:minCount         "1"^^xsd:long ;
+        sh:maxCount         "1"^^xsd:long .
 
 test:property-5 rdf:type  owl:DatatypeProperty ;
         rdfs:label          "Property with enum"@en ;
         dcterms:identifier  "property-5" ;
-        sh:in               "Value1" , "Value2" .
+        sh:in               "Value1" , "Value2" ;
+        sh:maxCount         "1"^^xsd:long .
 
 test:property-6 rdf:type  owl:DatatypeProperty ;
         rdfs:label          "Property with required value"@en ;
         dcterms:identifier  "property-6" ;
-        sh:hasValue         "required value" .
+        sh:hasValue         "required value" ;
+        sh:maxCount         "1"^^xsd:long .
 
 test:class-2  rdf:type      sh:NodeShape ;
         rdfs:label          "Target node"@en ;

--- a/src/test/resources/json-schema-expected.json
+++ b/src/test/resources/json-schema-expected.json
@@ -12,22 +12,53 @@
       "description": "Property shape info",
       "type": "object",
       "title": "Node shape label",
+      "required": ["property-1"],
       "properties": {
+        "property-5": {
+          "description": "",
+          "title": "Property with enum",
+          "enum": [
+            "Value1",
+            "Value2"
+          ]
+        },
+        "property-6": {
+          "const": "required value",
+          "description": "",
+          "title": "Property with required value"
+        },
         "property-1": {
+          "default": "default value",
+          "minLength": 1,
+          "pattern": "[a-zA-Z]",
           "description": "",
           "type": "string",
-          "title": "Property label"
+          "title": "String property",
+          "maxLength": 100
         },
         "property-3": {
           "description": "",
           "type": "array",
           "title": "Property label 3",
-          "items": [{"$ref": "#/properties/class-2"}]
+          "items": [{
+            "description": "",
+            "title": "Property label 3",
+            "$ref": "#/properties/class-2"
+          }]
         },
         "property-2": {
+          "maxItems": 5,
           "description": "",
           "type": "array",
-          "title": "Property label 2"
+          "title": "Numeric property",
+          "items": {
+            "exclusiveMaximum": true,
+            "default": 1,
+            "maximum": 6,
+            "type": "number",
+            "exclusiveMinimum": true,
+            "minimum": 0
+          }
         }
       }
     }


### PR DESCRIPTION
Add more restrictions to JSON schema
- min-/maxLength (string)
- pattern (string)
- min-/maxInclusive (number)
- min-/maxExclusive (number)
- const, if hasValue is provided
- enum, if allowedValues is provided
- defaultValue (all)

ArraySchema: Property is handled as an array if minCount > 1 or maxCount is empty or > 1.

MapperUtils fix: check if property value is literal, `toString` method returns value with type e.g. `"1"^^xsd:long`