### PR TITLE
YTI-4233 Fetch target class properties from OpenSearch

### DIFF
--- a/src/test/resources/test_datamodel_profile.ttl
+++ b/src/test/resources/test_datamodel_profile.ttl
@@ -15,7 +15,7 @@
         dcterms:created                 "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;
         dcterms:identifier              "d2edb497-ba0b-49c9-aeb7-49749d836434" ;
         dcterms:isPartOf                <http://urn.fi/URN:NBN:fi:au:ptvl:v1105> ;
-        dcterms:language                "fi" ;
+        dcterms:language                "fi" , "en";
         owl:imports                     <https://iri.suomi.fi/model/int> ;
         dcterms:requires                <https://www.example.com/ns/ext>, <http://uri.suomi.fi/codelist/test/testcodelist> , <https://iri.suomi.fi/model/test_lib/1.0.0> ;
         dcterms:modified                "2023-01-03T12:44:45.799Z"^^xsd:dateTime ;


### PR DESCRIPTION
When selecting properties from node shape's target class, fetch them from OpenSearch rather than Fuseki. Sparql query used for fetching resources is quite heavy especially if several properties are selected.

Fixed also checking existing sh:path references. In the scenario where we have a property shape with a path reference 
```
<https://iri.suomi.fi/model/test-profile/attribute-1>
   a                   sh:PropertyShape ;
   sh:path            <https://iri.suomi.fi/model/test-library/attribute-1> .
```

Next we create a new node shape and select resource `https://iri.suomi.fi/model/test-library/attribute-1` as a path reference in the dialog after selecting target class. After the node shape is created, an existing property shape (`https://iri.suomi.fi/model/test-profile/attribute-1`) is added to the node shape's properties. So no new property shape with identifier `attribute-1-1` is created