### PR TITLE
YTI-4260 Terminology URIs

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/migration/task/V17_TerminologyIRIs.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/migration/task/V17_TerminologyIRIs.java
@@ -1,0 +1,67 @@
+package fi.vm.yti.datamodel.api.migration.task;
+
+import fi.vm.yti.datamodel.api.v2.repository.CoreRepository;
+import fi.vm.yti.migration.MigrationTask;
+import org.springframework.stereotype.Component;
+
+@Component
+@SuppressWarnings("java:S101")
+public class V17_TerminologyIRIs implements MigrationTask {
+
+    private final CoreRepository coreRepository;
+
+    public V17_TerminologyIRIs(CoreRepository coreRepository) {
+        this.coreRepository = coreRepository;
+    }
+
+    /**
+     * Change terminology and concept URIs to new format, e.g. https://iri.suomi.fi/terminology/test/concept-1
+     */
+    @Override
+    public void migrate() {
+
+        var queryTerminologies = """
+                PREFIX dcterms: <http://purl.org/dc/terms/>
+                DELETE { GRAPH ?g {
+                    ?s dcterms:requires ?terminology .
+                   }
+                }
+                INSERT { GRAPH ?g {
+                     ?s dcterms:requires ?newTerminologyURI
+                   }
+                }
+                WHERE { GRAPH ?g {
+                     ?s dcterms:requires ?terminology .
+                     filter (strstarts(str(?terminology), "http://uri.suomi.fi/terminology")) .
+                     bind (iri(
+                             replace(str(?terminology), "http://uri.suomi.fi/terminology", "https://iri.suomi.fi/terminology")
+                         ) as ?newTerminologyURI
+                     )
+                   }
+                }
+                """;
+
+        var queryConcepts = """
+                PREFIX dcterms: <http://purl.org/dc/terms/>
+                DELETE { GRAPH ?g {
+                    ?s dcterms:subject ?concept .
+                   }
+                }
+                INSERT { GRAPH ?g {
+                     ?s dcterms:subject ?newConceptURI
+                   }
+                }
+                WHERE { GRAPH ?g {
+                     ?s dcterms:subject ?concept .
+                     bind (iri(
+                             replace(str(?concept), "http://uri.suomi.fi/terminology", "https://iri.suomi.fi/terminology")
+                         ) as ?newConceptURI
+                     )
+                   }
+                }
+                """;
+
+        coreRepository.queryUpdate(queryConcepts);
+        coreRepository.queryUpdate(queryTerminologies);
+    }
+}

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/ModelConstants.java
@@ -11,7 +11,7 @@ public class ModelConstants {
 
     public static final String SUOMI_FI_NAMESPACE = "https://iri.suomi.fi/model/";
     public static final String CODELIST_NAMESPACE = "http://uri.suomi.fi/codelist/";
-    public static final String TERMINOLOGY_NAMESPACE = "http://uri.suomi.fi/terminology/";
+    public static final String TERMINOLOGY_NAMESPACE = "https://iri.suomi.fi/terminology/";
     public static final String MODEL_POSITIONS_NAMESPACE = "https://iri.suomi.fi/model-positions/";
     public static final String CORNER_PREFIX = "corner-";
     public static final String SUOMI_FI_DOMAIN = "uri.suomi.fi";

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/BaseValidator.java
@@ -67,7 +67,7 @@ public abstract class BaseValidator implements Annotation{
 
     public void checkSubject(ConstraintValidatorContext context, BaseDTO dto){
         var subject = dto.getSubject();
-        if (subject != null && !subject.matches("^https?://uri.suomi.fi/terminology/(.*)")) {
+        if (subject != null && !subject.matches("^https?://iri.suomi.fi/terminology/(.*)")) {
             addConstraintViolation(context, "invalid-terminology-uri", "subject");
         }
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/DataModelValidator.java
@@ -230,7 +230,7 @@ public class DataModelValidator extends BaseValidator implements
     }
 
     private void checkTerminologies(ConstraintValidatorContext context, DataModelDTO dataModel) {
-        if (!dataModel.getTerminologies().stream().allMatch(uri -> uri.matches("^https?://uri.suomi.fi/terminology/(.*)"))) {
+        if (!dataModel.getTerminologies().stream().allMatch(uri -> uri.matches("^https?://iri.suomi.fi/terminology/(.*)"))) {
             addConstraintViolation(context, "invalid-terminology-uri", "terminologies");
         }
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/ClassControllerTest.java
@@ -233,7 +233,7 @@ class ClassControllerTest {
         if(!update){
             dto.setIdentifier("Identifier");
         }
-        dto.setSubject("http://uri.suomi.fi/terminology/notrealurl");
+        dto.setSubject("https://iri.suomi.fi/terminology/notrealurl");
         dto.setLabel(Map.of("fi", "test label"));
         dto.setEquivalentClass(Set.of("http://uri.suomi.fi/datamodel/ns/notrealns/FakeClass"));
         dto.setSubClassOf(Set.of("http://uri.suomi.fi/datamodel/ns/notrealns/FakeClass"));
@@ -245,7 +245,7 @@ class ClassControllerTest {
         var dto = new NodeShapeDTO();
         dto.setLabel(Map.of("fi", "node label"));
         dto.setIdentifier("node-shape-1");
-        dto.setSubject("http://uri.suomi.fi/terminology/concept-123");
+        dto.setSubject("https://iri.suomi.fi/terminology/concept-123");
 
         return dto;
     }

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelControllerTest.java
@@ -189,7 +189,7 @@ class DataModelControllerTest {
         if(!updateModel){
             dataModelDTO.setPrefix("test");
         }
-        dataModelDTO.setTerminologies(Set.of("http://uri.suomi.fi/terminology/test"));
+        dataModelDTO.setTerminologies(Set.of("https://iri.suomi.fi/terminology/test/"));
         var linkDTO = new LinkDTO();
         linkDTO.setName(Map.of("fi", "test link"));
         linkDTO.setDescription(Map.of("fi", "link description"));


### PR DESCRIPTION
Use new iri.suomi.fi format in terminology and concept URIs. Craeted migration task and changed validation rules.