### PR TITLE
YTI-4278 use and operator with separate words

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
@@ -10,7 +10,9 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.mapping.FieldType;
 import org.opensearch.client.opensearch._types.query_dsl.*;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class QueryFactoryUtils {
 
@@ -98,7 +100,9 @@ public class QueryFactoryUtils {
     public static Query labelQuery(String query) {
         var trimmed = query.trim();
         final var qs = trimmed.contains(" ")
-                ? String.format("*%s*", trimmed)
+                ? Arrays.stream(trimmed.split("\\s+"))
+                    .map(q -> String.format("*%s*", q))
+                    .collect(Collectors.joining(" "))
                 : String.format("%s~1 *%s*", trimmed, trimmed);
         return QueryStringQuery.of(q-> q
                 .query(qs)

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/QueryFactoryUtils.java
@@ -98,10 +98,13 @@ public class QueryFactoryUtils {
     public static Query labelQuery(String query) {
         var trimmed = query.trim();
         final var qs = trimmed.contains(" ")
-                ? String.format("\"%s\"", trimmed)
+                ? String.format("*%s*", trimmed)
                 : String.format("%s~1 *%s*", trimmed, trimmed);
         return QueryStringQuery.of(q-> q
                 .query(qs)
+                .defaultOperator(trimmed.contains(" ")
+                        ? Operator.And
+                        : Operator.Or)
                 .fields("label.*")
         )._toQuery();
     }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -10,7 +10,10 @@ import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Highlight;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static fi.vm.yti.datamodel.api.v2.opensearch.OpenSearchUtil.logPayload;
 
@@ -65,13 +68,17 @@ public class ResourceQueryFactory {
             indices.add(OpenSearchIndexer.OPEN_SEARCH_INDEX_EXTERNAL);
         }
 
-        SearchRequest sr = new SearchRequest.Builder()
+        var builder = new SearchRequest.Builder()
                 .from(QueryFactoryUtils.pageFrom(request))
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .index(indices)
-                .query(finalQuery)
-                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
-                .build();
+                .query(finalQuery);
+
+        if (request.getQuery() == null || request.getQuery().isBlank()) {
+            builder.sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()));
+        }
+        var sr = builder.build();
+
         logPayload(sr, String.join(", ", indices));
         return sr;
     }
@@ -115,14 +122,18 @@ public class ResourceQueryFactory {
                 .fields("label.*", f -> f)
                 .preTags("<b>")
                 .postTags("</b>");
-        SearchRequest sr = new SearchRequest.Builder()
+        var builder = new SearchRequest.Builder()
                 .from(QueryFactoryUtils.pageFrom(request))
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .index(indices)
                 .query(finalQuery)
-                .highlight(highlight.build())
-                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
-                .build();
+                .highlight(highlight.build());
+
+        if (request.getQuery() == null || request.getQuery().isBlank()) {
+            builder.sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()));
+        }
+
+        var sr = builder.build();
         logPayload(sr, String.join(", ", indices));
         return sr;
     }

--- a/src/test/resources/es/classRequest.json
+++ b/src/test/resources/es/classRequest.json
@@ -8,7 +8,8 @@
             "fields": [
               "label.*"
             ],
-            "query": "test~1 *test*"
+            "query": "test~1 *test*",
+            "default_operator": "or"
           }
         },
         {
@@ -78,13 +79,5 @@
       ]
     }
   },
-  "size": 100,
-  "sort": [
-    {
-      "label.en.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/es/modelrequest.json
+++ b/src/test/resources/es/modelrequest.json
@@ -77,19 +77,12 @@
             "fields": [
               "label.*"
             ],
-            "query": "\"test query\""
+            "query": "*test* *query*",
+            "default_operator": "and"
           }
         }
       ]
     }
   },
-  "size": 100,
-  "sort": [
-    {
-      "label.en.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }


### PR DESCRIPTION
- Use `and` operator with multiple words, e.g. query string "test search" -> `*test* AND *search*`.
- Removed sorting if query string is specified