### PR TITLE
YTI-4250 delete versioned datamodels

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -6,6 +6,7 @@ import fi.vm.yti.datamodel.api.v2.dto.*;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.ApiError;
 import fi.vm.yti.datamodel.api.v2.service.DataModelService;
 import fi.vm.yti.datamodel.api.v2.service.ReleaseValidationService;
+import fi.vm.yti.datamodel.api.v2.utils.DataModelURI;
 import fi.vm.yti.datamodel.api.v2.validator.ValidDatamodel;
 import fi.vm.yti.datamodel.api.v2.validator.ValidPrefix;
 import fi.vm.yti.datamodel.api.v2.validator.ValidSemanticVersion;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -193,5 +195,15 @@ public class DataModelController {
         return ResponseEntity
                 .created(URI.create(newURI))
                 .build();
+    }
+
+    @Operation(summary = "Get referrer models")
+    @GetMapping("/{prefix}/referrers")
+    public ResponseEntity<List<String>> getReferrerModels(
+            @PathVariable @Parameter(description = "Data model prefix") String prefix,
+            @RequestParam(required = false) @Parameter(description = "Version of the data model") @ValidSemanticVersion String version) {
+        return ResponseEntity.ok(dataModelService.getReferrerModels(DataModelURI
+                        .createModelURI(prefix, version)
+                        .getGraphURI()));
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/security/DataModelAuthorizationManager.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/security/DataModelAuthorizationManager.java
@@ -16,6 +16,11 @@ public class DataModelAuthorizationManager extends BaseAuthorizationManagerImpl 
         super(userProvider);
     }
 
+    public boolean hasAdminRightToModel(String prefix, Model model) {
+        var graphURI = DataModelURI.createModelURI(prefix).getGraphURI();
+        return super.hasRightToModel(graphURI, model);
+    }
+
     public boolean hasRightToModel(String prefix, Model model) {
         return hasRightToModel(prefix, model, false);
     }
@@ -24,8 +29,8 @@ public class DataModelAuthorizationManager extends BaseAuthorizationManagerImpl 
         var graphURI = DataModelURI.createModelURI(prefix).getGraphURI();
 
         return viewRights
-                ? hasRightToModel(graphURI, model, Role.DATA_MODEL_EDITOR, Role.MEMBER)
-                : hasRightToModel(graphURI, model, Role.DATA_MODEL_EDITOR);
+                ? super.hasRightToModel(graphURI, model, Role.DATA_MODEL_EDITOR, Role.MEMBER)
+                : super.hasRightToModel(graphURI, model, Role.DATA_MODEL_EDITOR);
     }
 
     public boolean hasRightToDoMigration() {

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/validator/ExceptionHandlerAdvice.java
@@ -1,6 +1,5 @@
 package fi.vm.yti.datamodel.api.v2.validator;
 
-import fi.vm.yti.common.exception.MappingError;
 import fi.vm.yti.common.exception.ResourceNotFoundException;
 import fi.vm.yti.datamodel.api.v2.endpoint.error.*;
 import fi.vm.yti.security.AuthorizationException;

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/EndpointUtils.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/endpoint/EndpointUtils.java
@@ -46,6 +46,18 @@ public class EndpointUtils {
             "",
             "");
 
+    public static final YtiUser mockAdminUser = new YtiUser("admin@localhost",
+            "super",
+            "user",
+            UUID.randomUUID(),
+            false,
+            false,
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            new HashMap<>(Map.of(UUID.randomUUID(), Set.of(Role.ADMIN))),
+            "",
+            "");
+
     public static Model getMockModel(Resource type) {
         var mockModel = ModelFactory.createDefaultModel();
         mockModel.createResource("https://iri.suomi.fi/model/test/")


### PR DESCRIPTION
Add new endpoint `GET /model/{prefix}/referrers` for checking if there are any referrer models.

Allow deleting data model for admin users if
- Status is DRAFT or SUGGESTION
- Status is RETIRED or SUPERSEDED and there are no referrer models to it
