### PR TITLE
YTI-4251 create draft

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/DataModelController.java
@@ -197,6 +197,21 @@ public class DataModelController {
                 .build();
     }
 
+    @Operation(summary = "Creates a new draft from given version")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "New draft has been created"),
+    })
+    @PostMapping("/{prefix}/create-draft")
+    public ResponseEntity<Void> createDraft(
+            @PathVariable @Parameter(description = "Data model's prefix") String prefix,
+            @RequestParam @Parameter(description = "Version of the data model to be copied") @ValidSemanticVersion String version) {
+        dataModelService.createDraft(prefix, version);
+        var draftURI = DataModelURI.createModelURI(prefix).getGraphURI();
+        return ResponseEntity
+                .created(URI.create(draftURI))
+                .build();
+    }
+
     @Operation(summary = "Get referrer models")
     @GetMapping("/{prefix}/referrers")
     public ResponseEntity<List<String>> getReferrerModels(

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -298,6 +298,24 @@ public class ModelMapper {
         return indexModel;
     }
 
+    public Model mapNewDraft(Model model, DataModelURI versionURI) {
+
+        var newDraft = ModelFactory.createDefaultModel().add(model);
+        var modelResource = newDraft.getResource(versionURI.getModelURI());
+
+        // new prior version is the version from which the new draft is created
+        MapperUtils.updateUriProperty(modelResource, OWL.priorVersion, versionURI.getGraphURI());
+        modelResource.removeAll(OWL.versionInfo);
+        modelResource.removeAll(OWL2.versionIRI);
+
+        // change all statuses to DRAFT
+        newDraft.listSubjectsWithProperty(SuomiMeta.publicationStatus)
+                .forEach(resource -> MapperUtils.updateUriProperty(
+                        resource, SuomiMeta.publicationStatus, MapperUtils.getStatusUri(Status.DRAFT))
+                );
+        return newDraft;
+    }
+
     /**
      * Add organizations to a model
      * @param organizations Organizations

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -612,25 +612,38 @@ class DataModelServiceTest {
 
         when(userProvider.getUser()).thenReturn(EndpointUtils.mockAdminUser);
         when(coreRepository.fetch(graphURI.getGraphURI())).thenReturn(version);
-        when(coreRepository.fetch(graphURI.getDraftGraphURI())).thenReturn(draft);
-        when(coreRepository.graphExists(graphURI.getDraftGraphURI())).thenReturn(true);
-        when(coreRepository.queryConstruct(any(Query.class))).thenReturn(ModelFactory.createDefaultModel());
+        when(coreRepository.graphExists(graphURI.getDraftGraphURI())).thenReturn(false);
         when(authorizationManager.hasAdminRightToModel(eq(graphURI.getModelId()), any(Model.class))).thenReturn(true);
         when(modelMapper.mapToIndexModel(anyString(), any(Model.class))).thenReturn(new IndexModel());
         when(modelMapper.mapNewDraft(any(Model.class), any(DataModelURI.class))).thenReturn(ModelFactory.createDefaultModel());
 
         dataModelService.createDraft(graphURI.getModelId(), graphURI.getVersion());
 
-        // old draft should be deleted
-        verify(coreRepository).delete(graphURI.getDraftGraphURI());
         // new draft should be saved
         verify(coreRepository).put(eq(graphURI.getDraftGraphURI()), any(Model.class));
-        // remove old draft from index
-        verify(indexService).deleteModelFromIndex(graphURI.getDraftGraphURI());
-        verify(indexService).removeResourceIndexesByDataModel(graphURI.getDraftGraphURI(), null);
         // add new draft to index
         verify(indexService).createModelToIndex(any(IndexModel.class));
         verify(indexService).indexGraphResource(any(Model.class));
+    }
+
+    @Test
+    void testCreateNewDraftExisting() {
+        var graphURI = DataModelURI.createModelURI("test", "1.0.0");
+
+        when(coreRepository.graphExists(graphURI.getDraftGraphURI())).thenReturn(true);
+
+        var error = assertThrows(MappingError.class,
+                () -> dataModelService.createDraft("test", "1.0.0"));
+
+        assertTrue(error.getMessage().contains("Draft graph exists"),
+                "Unexpected error creating new draft with existing one.");
+
+        // new draft should be saved
+        verify(coreRepository, never()).put(anyString(), any(Model.class));
+        // add new draft to index
+        verify(indexService, never()).createModelToIndex(any(IndexModel.class));
+        verify(indexService, never()).indexGraphResource(any(Model.class));
+
     }
 
     private Predicate<RDFNode> containsReferences(String ns) {


### PR DESCRIPTION
- Create draft version from some published version
- Allowed for admin users
- Not allowed if there is an existing draft version. It should be removed first (see https://github.com/VRK-YTI/yti-datamodel-api/pull/335).