### PR TITLE
YTI-4257 skip initializing external resource index on startup

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/IndexService.java
@@ -82,8 +82,7 @@ public class IndexService extends OpenSearchInitializer {
 
         var indexConfig = Map.of(
                 OPEN_SEARCH_INDEX_MODEL, getModelMappings(),
-                OPEN_SEARCH_INDEX_RESOURCE, getResourceMappings(),
-                OPEN_SEARCH_INDEX_EXTERNAL, getExternalResourceMappings()
+                OPEN_SEARCH_INDEX_RESOURCE, getResourceMappings()
         );
         super.initIndexes(fn, indexConfig);
     }


### PR DESCRIPTION
Remove external resource index from index config map passed to the initilize method. If passed, it will be recreated and external resources are indexed on startup only if index is created for the [first time](https://github.com/VRK-YTI/yti-datamodel-api/blob/1e070466ac7a41c869d7281e9f612edd1d3a0fa1/src/main/java/fi/vm/yti/datamodel/api/v2/service/IndexService.java#L95)