### PR TITLE
Allow removing class with references to itself

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/BaseResourceService.java
@@ -84,6 +84,13 @@ abstract class BaseResourceService {
         check(authorizationManager.hasRightToModel(prefix, model));
 
         var references = getResourceReferences(resourceUri, true);
+
+        // If the references include the resource being deleted, remove it so it won't prevent deletion
+        references.forEach((type, refs) -> {
+            refs.removeIf(r -> r.getResourceURI().getUri().equals(resourceUri));
+        });
+        references.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+
         if (!references.isEmpty()) {
             var refList = references.keySet().stream()
                     .flatMap(r -> references.get(r).stream())


### PR DESCRIPTION
Class may have a reference to itself in one of the resources. Allow removing the class, since that reference is going away anyway.