### PR TITLE
YTI-4341 check that draft data model is included to restricted models

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/opensearch/queries/ResourceQueryFactory.java
@@ -166,7 +166,12 @@ public class ResourceQueryFactory {
         }
 
         if (request.getIncludeDraftFrom() != null && !request.getIncludeDraftFrom().isEmpty()) {
-            builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", request.getIncludeDraftFrom()));
+            var allowedDraftModels = request.getIncludeDraftFrom().stream()
+                    .filter(restrictedDataModels::contains)
+                    .toList();
+            if (!allowedDraftModels.isEmpty()) {
+                builder.should(QueryFactoryUtils.termsQuery("isDefinedBy", allowedDraftModels));
+            }
         }
 
         builder.should(QueryFactoryUtils.termsQuery("namespace", externalNamespaces))


### PR DESCRIPTION
When user selects "all data models" from resource selection modal, search results may contain resources where original search conditions are not met. 
For example in application profile, we want to add class reference (sh:class), which should be a class from library (owl:class). When selecting "all data models" in search dialog, also draft resources from current model (application profile) are included to the results. If application profile class is chosen, the error is thrown because the resource has a wrong type.