### PR TITLE
YTI-4359 add workaround importing for untp-core namespace

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/NamespaceResolver.java
@@ -66,7 +66,7 @@ public class NamespaceResolver {
             var accept = String.join(", ", ACCEPT_TYPES);
 
             // Uncefact works only with one accept header
-            if (namespace.equals("https://vocabulary.uncefact.org/")) {
+            if (namespace.equals("https://vocabulary.uncefact.org/") || namespace.startsWith("https://test.uncefact.org/vocabulary/untp/core/0/")) {
                 accept = "application/ld+json";
             }
             RDFParser.create()


### PR DESCRIPTION
Workaround to allow adding external namespace from https://test.uncefact.org/vocabulary/untp/core/0/