### PR TITLE
YTI-4293 Add flag to mark if model uses domain/range associations

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/dto/DataModelInfoDTO.java
@@ -16,6 +16,7 @@ public class DataModelInfoDTO extends MetaDataInfoDTO {
     private Set<LinkDTO> links = Set.of();
     private String version;
     private String versionIri;
+    private Boolean hasAssociationsWithDomainOrRange;
 
     public Set<InternalNamespaceDTO> getInternalNamespaces() {
         return internalNamespaces;
@@ -79,5 +80,13 @@ public class DataModelInfoDTO extends MetaDataInfoDTO {
 
     public void setVersionIri(String versionIri) {
         this.versionIri = versionIri;
+    }
+
+    public Boolean getHasAssociationsWithDomainOrRange() {
+        return hasAssociationsWithDomainOrRange;
+    }
+
+    public void setHasAssociationsWithDomainOrRange(Boolean hasAssociationsWithDomainOrRange) {
+        this.hasAssociationsWithDomainOrRange = hasAssociationsWithDomainOrRange;
     }
 }

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapper.java
@@ -256,6 +256,14 @@ public class ModelMapper {
         }).collect(Collectors.toSet());
         datamodelDTO.setLinks(links);
 
+        var hasAssociationsWithDomainOrRange = modelResource.listProperties(DCTerms.hasPart)
+                .toList()
+                .stream()
+                .map(stmt -> stmt.getObject().asResource())
+                .filter(res -> MapperUtils.hasType(res, OWL.ObjectProperty))
+                .anyMatch(res -> res.hasProperty(RDFS.domain) || res.hasProperty(RDFS.range));
+        datamodelDTO.setHasAssociationsWithDomainOrRange(hasAssociationsWithDomainOrRange);
+
         return datamodelDTO;
     }
 

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapperTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/mapper/ModelMapperTest.java
@@ -359,6 +359,39 @@ class ModelMapperTest {
         assertEquals("link title", linkDTO.getName().get("fi"));
         assertEquals("link description", linkDTO.getDescription().get("fi"));
         assertEquals("https://example.com", linkDTO.getUri());
+
+        assertFalse(result.getHasAssociationsWithDomainOrRange());
+    }
+
+    @Test
+    void testMapToDatamodelDTOHasAssociationsWithDomainOrRange() {
+        var modelUri = Constants.DATA_MODEL_NAMESPACE + "test/";
+        when(coreRepository.fetch(Constants.DATA_MODEL_NAMESPACE + "int/")).thenReturn(ModelFactory.createDefaultModel());
+
+        // domain only — flag should be true
+        var mDomainOnly = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        var associationDomainOnly = mDomainOnly.createResource(modelUri + "TestAssociation")
+                .addProperty(RDF.type, OWL.ObjectProperty)
+                .addProperty(RDFS.domain, mDomainOnly.createResource(modelUri + "SomeClass"));
+        mDomainOnly.getResource(modelUri).addProperty(DCTerms.hasPart, associationDomainOnly);
+        assertTrue(mapper.mapToDataModelDTO("test", mDomainOnly, null).getHasAssociationsWithDomainOrRange());
+
+        // range only — flag should be true
+        var mRangeOnly = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        var associationRangeOnly = mRangeOnly.createResource(modelUri + "TestAssociation")
+                .addProperty(RDF.type, OWL.ObjectProperty)
+                .addProperty(RDFS.range, mRangeOnly.createResource(modelUri + "OtherClass"));
+        mRangeOnly.getResource(modelUri).addProperty(DCTerms.hasPart, associationRangeOnly);
+        assertTrue(mapper.mapToDataModelDTO("test", mRangeOnly, null).getHasAssociationsWithDomainOrRange());
+
+        // both domain and range — flag should be true
+        var mBoth = MapperTestUtils.getModelFromFile("/test_datamodel_library.ttl");
+        var associationBoth = mBoth.createResource(modelUri + "TestAssociation")
+                .addProperty(RDF.type, OWL.ObjectProperty)
+                .addProperty(RDFS.domain, mBoth.createResource(modelUri + "SomeClass"))
+                .addProperty(RDFS.range, mBoth.createResource(modelUri + "OtherClass"));
+        mBoth.getResource(modelUri).addProperty(DCTerms.hasPart, associationBoth);
+        assertTrue(mapper.mapToDataModelDTO("test", mBoth, null).getHasAssociationsWithDomainOrRange());
     }
 
     @Test


### PR DESCRIPTION
This PR adds a check to find if the model uses domain/range associations, which in turn adds a corresponding flag to `DataModelInfoDTO`.

This flag is used on frontend to hide the domain/range options for models that don't already use them.