### PR TITLE
return "not found" during JSON schema export if user has no access

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/service/DataModelService.java
@@ -228,6 +228,9 @@ public class DataModelService {
 
         try {
             model = coreRepository.fetch(uri.getGraphURI());
+            if (version == null && !authorizationManager.hasRightToModel(prefix, model, true)) {
+                return ResponseEntity.notFound().build();
+            }
         } catch (ResourceNotFoundException e) {
             // cannot throw ResourceNotFoundException because accept header is not application/json
             return ResponseEntity.notFound().build();

--- a/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
+++ b/src/test/java/fi/vm/yti/datamodel/api/v2/service/DataModelServiceTest.java
@@ -291,7 +291,7 @@ class DataModelServiceTest {
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(true);
 
-        var response = dataModelService.export("test", null, "text/turtle", false, "fi");
+        var response = dataModelService.export("test", "1.0.0", "text/turtle", false, "fi");
         assertNotNull(response.getBody());
         assertTrue(response.getBody().contains("test:TestClass"));
         assertTrue(response.getBody().contains("test:TestAttribute"));
@@ -303,7 +303,7 @@ class DataModelServiceTest {
     void shouldGetModelWithAcceptHeader(String accept) {
         when(coreRepository.fetch(anyString())).thenReturn(ModelFactory.createDefaultModel());
 
-        var response = dataModelService.export("test", null, accept, false, "fi");
+        var response = dataModelService.export("test", "1.0.0", accept, false, "fi");
         assertTrue(response.getStatusCode().is2xxSuccessful());
         //TODO can this be fixed
     }
@@ -313,7 +313,7 @@ class DataModelServiceTest {
         var model = MapperTestUtils.getModelFromFile("/models/test_datamodel_library_with_resources.ttl");
         when(coreRepository.fetch(anyString())).thenReturn(model);
         when(authorizationManager.hasRightToModel(anyString(), any(Model.class))).thenReturn(false);
-        var response = dataModelService.export("test", null, "text/turtle", false, "fi");
+        var response = dataModelService.export("test", "1.0.0", "text/turtle", false, "fi");
         assertTrue(response.getStatusCode().is2xxSuccessful());
         assertNotNull(response.getBody());
         assertFalse(response.getBody().contains("skos:editorialNote"));


### PR DESCRIPTION
Previously we would be returning an incomplete JSON schema, if the user has no access to the model, which causes confusion.  Now we'll return a proper "not found" error instead.